### PR TITLE
fix: add window zoom support (Cmd+=/-, Cmd+0)

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -209,7 +209,44 @@ function createWindow(): void {
       mainWindow!.webContents.send('shortcut:close-session')
     }
 
-    // Allow standard zoom shortcuts (Cmd+=/-, Cmd+0) to pass through to Chromium.
+    // Zoom In (Cmd+= / Cmd+Shift+=)
+    if (
+      (input.key === '=' || input.key === '+') &&
+      (input.meta || input.control) &&
+      !input.alt &&
+      input.type === 'keyDown'
+    ) {
+      event.preventDefault()
+      const wc = mainWindow!.webContents
+      const current = wc.getZoomLevel()
+      wc.setZoomLevel(Math.min(current + 0.5, 5))
+    }
+
+    // Zoom Out (Cmd+-)
+    if (
+      input.key === '-' &&
+      (input.meta || input.control) &&
+      !input.alt &&
+      !input.shift &&
+      input.type === 'keyDown'
+    ) {
+      event.preventDefault()
+      const wc = mainWindow!.webContents
+      const current = wc.getZoomLevel()
+      wc.setZoomLevel(Math.max(current - 0.5, -5))
+    }
+
+    // Reset Zoom (Cmd+0)
+    if (
+      input.key === '0' &&
+      (input.meta || input.control) &&
+      !input.alt &&
+      !input.shift &&
+      input.type === 'keyDown'
+    ) {
+      event.preventDefault()
+      mainWindow!.webContents.setZoomLevel(0)
+    }
   })
 
   mainWindow.webContents.setWindowOpenHandler((details) => {

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -214,6 +214,36 @@ export function buildMenu(mainWindow: BrowserWindow, isDev: boolean): Menu {
           click: () => send('menu:focus-main-pane')
         },
         { type: 'separator' },
+        {
+          label: 'Zoom In',
+          accelerator: 'CmdOrCtrl+=',
+          click: () => {
+            if (_mainWindow && !_mainWindow.isDestroyed()) {
+              const current = _mainWindow.webContents.getZoomLevel()
+              _mainWindow.webContents.setZoomLevel(Math.min(current + 0.5, 5))
+            }
+          }
+        },
+        {
+          label: 'Zoom Out',
+          accelerator: 'CmdOrCtrl+-',
+          click: () => {
+            if (_mainWindow && !_mainWindow.isDestroyed()) {
+              const current = _mainWindow.webContents.getZoomLevel()
+              _mainWindow.webContents.setZoomLevel(Math.max(current - 0.5, -5))
+            }
+          }
+        },
+        {
+          label: 'Reset Zoom',
+          accelerator: 'CmdOrCtrl+0',
+          click: () => {
+            if (_mainWindow && !_mainWindow.isDestroyed()) {
+              _mainWindow.webContents.setZoomLevel(0)
+            }
+          }
+        },
+        { type: 'separator' },
         { role: 'togglefullscreen' },
         ...(isDev ? [{ role: 'toggleDevTools' as const }] : [])
       ]


### PR DESCRIPTION
## Summary
- Add explicit zoom handlers (`Cmd+=` / `Cmd+-` / `Cmd+0`) in the `before-input-event` listener in `src/main/index.ts`, using `webContents.setZoomLevel()` / `getZoomLevel()` with 0.5 increments (clamped to [-5, 5])
- Add Zoom In, Zoom Out, and Reset Zoom menu items to the View menu in `src/main/menu.ts`
- The previous approach of just "allowing shortcuts to pass through to Chromium" did not work because Electron's sandboxed webContents does not reliably handle built-in Chromium zoom shortcuts

Closes #1

## Test plan
- [ ] Launch the app and press `Cmd+=` repeatedly -- UI should zoom in incrementally
- [ ] Press `Cmd+-` repeatedly -- UI should zoom out incrementally
- [ ] Press `Cmd+0` -- zoom should reset to default
- [ ] Open View menu and verify Zoom In / Zoom Out / Reset Zoom items appear with correct accelerators
- [ ] Click each View menu zoom item and verify it works
- [ ] Verify zoom level persists across keyboard and menu interactions (e.g., zoom in with keyboard, then zoom out via menu)

🤖 Generated with [Claude Code](https://claude.com/claude-code)