### PR TITLE
fix: slash命令弹窗/Plan卡片重复渲染/Compaction UI支持

### DIFF
--- a/src/main/services/claude-code-implementer.ts
+++ b/src/main/services/claude-code-implementer.ts
@@ -646,6 +646,22 @@ export class ClaudeCodeImplementer implements AgentSdkImplementer {
         // Log init messages (includes MCP server connection status) and cache slash commands
         // SDK sends init as { type: 'system', subtype: 'init' }
         const msgSubtype = (sdkMessage as Record<string, unknown>).subtype as string | undefined
+
+        // Detect compaction start via system status message.
+        // Fires BEFORE compact_boundary, so the renderer can show a loading
+        // indicator ("正在压缩上下文窗口...") immediately.
+        if (msgType === 'system' && msgSubtype === 'status') {
+          const status = (sdkMessage as Record<string, unknown>).status as string | undefined
+          if (status === 'compacting') {
+            log.info('Compaction started detected via system status message')
+            this.sendToRenderer('opencode:stream', {
+              type: 'session.compaction_started',
+              sessionId: session.hiveSessionId,
+              data: {}
+            })
+          }
+        }
+
         if (msgType === 'system' && msgSubtype === 'init') {
           const initMsg = sdkMessage as Record<string, unknown>
           log.info('Prompt: init message received', {
@@ -963,6 +979,36 @@ export class ClaudeCodeImplementer implements AgentSdkImplementer {
                 session.messages.push(translated)
               }
             }
+          }
+        }
+
+        // Persist compaction boundary as a synthetic assistant message so it
+        // survives the getMessages() → finalizeResponse() reload cycle.
+        // Without this, the CompactionPill would disappear when the renderer
+        // refreshes messages from the in-memory cache on stream completion.
+        if (msgType === 'system') {
+          const subtype = (sdkMessage as Record<string, unknown>).subtype as string | undefined
+          if (subtype === 'compact_boundary') {
+            const meta = (sdkMessage as Record<string, unknown>).compact_metadata as
+              | Record<string, unknown>
+              | undefined
+            session.messages.push({
+              id: `compaction-${randomUUID()}`,
+              role: 'assistant',
+              timestamp: new Date().toISOString(),
+              content: '',
+              parts: [
+                {
+                  type: 'compaction',
+                  auto: meta?.trigger === 'auto'
+                }
+              ]
+            })
+            log.info('Compaction boundary persisted to session.messages', {
+              hiveSessionId: session.hiveSessionId,
+              trigger: meta?.trigger,
+              totalMessages: session.messages.length
+            })
           }
         }
 

--- a/src/renderer/src/components/sessions/SessionView.tsx
+++ b/src/renderer/src/components/sessions/SessionView.tsx
@@ -1229,7 +1229,7 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
           ? { ...p, toolUse: { ...p.toolUse!, status, ...(error ? { error } : {}) } }
           : p
 
-      // Update streaming parts (may still be rendering from here)
+      // Update streaming parts — transition status first for immediate visual feedback
       updateStreamingPartsRef((parts) => parts.map(mapper))
       immediateFlush()
 
@@ -1246,6 +1246,14 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
           return changed ? { ...msg, parts: updatedParts } : msg
         })
       )
+
+      // Remove from streaming parts to avoid double-rendering:
+      // the tool card is now in committed messages, so the streaming
+      // overlay no longer needs it.
+      updateStreamingPartsRef((parts) =>
+        parts.filter((p) => !(p.type === 'tool_use' && p.toolUse?.id === toolUseID))
+      )
+      immediateFlush()
     },
     [updateStreamingPartsRef, immediateFlush]
   )
@@ -3666,6 +3674,8 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
       }
       setInputValue('')
       inputValueRef.current = ''
+      setShowSlashCommands(false)
+      showSlashCommandsRef.current = false
       fileMentions.clearMentions()
       if (draftTimerRef.current) clearTimeout(draftTimerRef.current)
       window.db.session.updateDraft(sessionId, null)

--- a/src/renderer/src/components/sessions/SessionView.tsx
+++ b/src/renderer/src/components/sessions/SessionView.tsx
@@ -2040,6 +2040,14 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
             return
           }
 
+          // Claude Code compaction started — the SDK sends
+          // system { subtype: 'status', status: 'compacting' } BEFORE
+          // compact_boundary, so we can show a loading indicator immediately.
+          if (event.type === 'session.compaction_started') {
+            setIsCompacting(true)
+            return
+          }
+
           if (event.type === 'message.part.updated') {
             // Skip user-message echoes; user messages are already rendered locally.
             if (eventRole === 'user') return

--- a/src/renderer/src/lib/opencode-transcript.ts
+++ b/src/renderer/src/lib/opencode-transcript.ts
@@ -322,6 +322,19 @@ export function mapOpencodeMessagesToSessionViewMessages(messages: unknown[]): O
   const seen = new Set<string>()
   return sorted.filter((msg) => {
     if (msg.role !== 'user') return true
+
+    // Filter out compaction summary — a synthetic user message injected by the
+    // Claude CLI after context compaction.  The backend already filters this in
+    // the main loop (isCompactSummary + text match), but messages loaded via
+    // getMessages() may bypass that filter.
+    if (
+      msg.content
+        .trimStart()
+        .startsWith('This session is being continued from a previous conversation')
+    ) {
+      return false
+    }
+
     const key = msg.content.trim()
     if (seen.has(key)) return false
     seen.add(key)


### PR DESCRIPTION
## Summary

Closes #10

修复 3 类 UI/流式渲染问题，并补全上下文压缩(Compaction)的完整 UI 支持。

## 变更详情

### 1. Slash命令弹窗发送后不关闭
- 在 `handleSend()` 中重置 `setShowSlashCommands(false)` 和 `showSlashCommandsRef.current = false`
- 确保无论消息是否以 `/` 开头，发送后弹窗都会正确关闭

### 2. Plan卡片重复渲染
- `transitionToolStatus()` 回调中，在将 tool card 提交到 committed messages **之后**，从 `streamingParts` 中 `filter` 移除对应的 tool_use part
- 调用 `immediateFlush()` 确保 UI 立即反映变化，消除双重渲染

### 3. 上下文压缩(Compaction)完整 UI 支持（3 个文件）

| 文件 | 变更 |
|------|------|
| `claude-code-implementer.ts` | 监听 SDK `system/status/compacting` → 发送 `session.compaction_started` 事件；监听 `compact_boundary` → 持久化为合成 assistant 消息（含 `compaction` part） |
| `SessionView.tsx` | 处理 `session.compaction_started` 事件 → `setIsCompacting(true)` 显示加载指示器 |
| `opencode-transcript.ts` | 过滤压缩后注入的合成 user 消息（"This session is being continued from..."），防止内部消息泄露给用户 |

## 影响范围
- `src/main/services/claude-code-implementer.ts` — 后端事件检测 & 消息持久化
- `src/renderer/src/components/sessions/SessionView.tsx` — 前端事件处理 & 渲染逻辑
- `src/renderer/src/lib/opencode-transcript.ts` — 消息过滤

## Test plan
- [ ] 输入 `/` 选择 slash command 后发送，弹窗应自动关闭
- [ ] 触发 tool_use 状态转换，确认 Plan 卡片不再重复渲染
- [ ] 触发上下文压缩，确认出现"正在压缩"加载指示器
- [ ] 压缩完成后刷新/切换会话，确认 CompactionPill 仍然可见
- [ ] 压缩后的合成 user 消息不应出现在聊天记录中

🤖 Generated with [Claude Code](https://claude.com/claude-code)