### PR TITLE
fix: 自动更新 + 字体缩放设置 + 排队消息 UI 优化

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -66,7 +66,7 @@ Download the latest build from [GitHub Releases](https://github.com/slicenferqin
 > **macOS note**: The current build is unsigned. On first launch macOS will show an "unidentified developer" warning.
 > Run this in Terminal, then reopen the app:
 > ```bash
-> /usr/bin/xattr -cr /Applications/Xuanpu.app
+> /usr/bin/xattr -cr "/Applications/玄圃.app"
 > ```
 > Or: System Settings → Privacy & Security → click "Open Anyway".
 >
@@ -83,6 +83,25 @@ pnpm dev
 - `macOS`: primary platform, full feature set including Ghostty terminal
 - `Windows`: supported — all core features work; Ghostty terminal is macOS-only
 - `Linux`: planned target, still evolving
+
+## Download Trends
+
+> Data from GitHub Releases, updated manually with each release.
+
+```mermaid
+xychart-beta
+    title "Downloads per Release"
+    x-axis ["v1.1.5", "v1.2.1", "v1.2.2", "v1.2.3", "v1.2.4", "v1.2.5"]
+    y-axis "Downloads" 0 --> 100
+    bar [9, 8, 12, 14, 21, 79]
+```
+
+<p>
+  <a href="https://github.com/slicenferqin/xuanpu/releases"><img src="https://img.shields.io/github/downloads/slicenferqin/xuanpu/total?style=flat-square&label=total%20downloads&color=blue" alt="Total Downloads" /></a>
+  <a href="https://github.com/slicenferqin/xuanpu/releases/latest"><img src="https://img.shields.io/github/downloads/slicenferqin/xuanpu/latest/total?style=flat-square&label=latest%20release&color=brightgreen" alt="Latest Release Downloads" /></a>
+</p>
+
+📊 [View full download analytics →](https://greedeks.github.io/Pulse/?username=slicenferqin&repo=xuanpu)
 
 ## Repo Status
 Current stack:

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@
 > **macOS 安装提示**：当前版本未经 Apple 签名，首次打开时会提示"无法验证开发者"。
 > 请在终端执行以下命令后重新打开：
 > ```bash
-> /usr/bin/xattr -cr /Applications/Xuanpu.app
+> /usr/bin/xattr -cr "/Applications/玄圃.app"
 > ```
 > 或者：系统设置 → 隐私与安全性 → 点击「仍要打开」。
 >
@@ -100,6 +100,25 @@ pnpm dev
 5. 必要时通过 connections 把相关 worktree / 仓库连接进来
 
 如果你习惯用键盘操作，命令面板、会话切换、侧栏切换、终端与文件区协同会比较顺手。
+
+## 下载趋势
+
+> 数据来自 GitHub Releases，每次发版时手动更新。
+
+```mermaid
+xychart-beta
+    title "各版本下载量"
+    x-axis ["v1.1.5", "v1.2.1", "v1.2.2", "v1.2.3", "v1.2.4", "v1.2.5"]
+    y-axis "Downloads" 0 --> 100
+    bar [9, 8, 12, 14, 21, 79]
+```
+
+<p>
+  <a href="https://github.com/slicenferqin/xuanpu/releases"><img src="https://img.shields.io/github/downloads/slicenferqin/xuanpu/total?style=flat-square&label=total%20downloads&color=blue" alt="Total Downloads" /></a>
+  <a href="https://github.com/slicenferqin/xuanpu/releases/latest"><img src="https://img.shields.io/github/downloads/slicenferqin/xuanpu/latest/total?style=flat-square&label=latest%20release&color=brightgreen" alt="Latest Release Downloads" /></a>
+</p>
+
+📊 [查看完整下载统计 →](https://greedeks.github.io/Pulse/?username=slicenferqin&repo=xuanpu)
 
 ## 仓库现状
 当前仓库是桌面端主仓，核心栈如下：

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -223,6 +223,7 @@ function createWindow(): void {
       const wc = mainWindow!.webContents
       const current = wc.getZoomLevel()
       wc.setZoomLevel(Math.min(current + 0.5, 5))
+      mainWindow!.webContents.send('zoom:changed', wc.getZoomLevel())
     }
 
     // Zoom Out (Cmd+-)
@@ -237,6 +238,7 @@ function createWindow(): void {
       const wc = mainWindow!.webContents
       const current = wc.getZoomLevel()
       wc.setZoomLevel(Math.max(current - 0.5, -5))
+      mainWindow!.webContents.send('zoom:changed', wc.getZoomLevel())
     }
 
     // Reset Zoom (Cmd+0)
@@ -249,6 +251,7 @@ function createWindow(): void {
     ) {
       event.preventDefault()
       mainWindow!.webContents.setZoomLevel(0)
+      mainWindow!.webContents.send('zoom:changed', 0)
     }
   })
 
@@ -409,6 +412,24 @@ function registerSystemHandlers(): void {
   // Get the current platform (darwin, win32, linux)
   ipcMain.handle('system:getPlatform', () => {
     return process.platform
+  })
+
+  // Set the UI zoom level (clamped to Electron's -5..5 range)
+  ipcMain.handle('system:setZoomLevel', (_event, level: number) => {
+    if (mainWindow && !mainWindow.isDestroyed()) {
+      const clamped = Math.max(-5, Math.min(5, level))
+      mainWindow.webContents.setZoomLevel(clamped)
+      return { success: true, level: clamped }
+    }
+    return { success: false }
+  })
+
+  // Get the current UI zoom level
+  ipcMain.handle('system:getZoomLevel', () => {
+    if (mainWindow && !mainWindow.isDestroyed()) {
+      return mainWindow.webContents.getZoomLevel()
+    }
+    return 0
   })
 
   // Install xuanpu-server shell wrapper to PATH

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -221,6 +221,7 @@ export function buildMenu(mainWindow: BrowserWindow, isDev: boolean): Menu {
             if (_mainWindow && !_mainWindow.isDestroyed()) {
               const current = _mainWindow.webContents.getZoomLevel()
               _mainWindow.webContents.setZoomLevel(Math.min(current + 0.5, 5))
+              _mainWindow.webContents.send('zoom:changed', _mainWindow.webContents.getZoomLevel())
             }
           }
         },
@@ -231,6 +232,7 @@ export function buildMenu(mainWindow: BrowserWindow, isDev: boolean): Menu {
             if (_mainWindow && !_mainWindow.isDestroyed()) {
               const current = _mainWindow.webContents.getZoomLevel()
               _mainWindow.webContents.setZoomLevel(Math.max(current - 0.5, -5))
+              _mainWindow.webContents.send('zoom:changed', _mainWindow.webContents.getZoomLevel())
             }
           }
         },
@@ -240,6 +242,7 @@ export function buildMenu(mainWindow: BrowserWindow, isDev: boolean): Menu {
           click: () => {
             if (_mainWindow && !_mainWindow.isDestroyed()) {
               _mainWindow.webContents.setZoomLevel(0)
+              _mainWindow.webContents.send('zoom:changed', 0)
             }
           }
         },

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -520,6 +520,9 @@ declare global {
       installServerToPath: () => Promise<{ success: boolean; path?: string; error?: string }>
       uninstallServerFromPath: () => Promise<{ success: boolean; error?: string }>
       getPlatform: () => Promise<string>
+      setZoomLevel: (level: number) => Promise<{ success: boolean; level?: number }>
+      getZoomLevel: () => Promise<number>
+      onZoomChanged: (callback: (level: number) => void) => () => void
     }
     loggingOps: {
       createResponseLog: (sessionId: string) => Promise<string>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1,10 +1,20 @@
 import { contextBridge, ipcRenderer, webUtils, webFrame } from 'electron'
 
-// Force 100% zoom — Ghostty's native NSView overlay requires 1:1 CSS-to-AppKit
-// point mapping. Any zoom level breaks coordinate sync and causes misaligned
-// rendering. This also resets zoom for users who accidentally changed it.
-webFrame.setZoomFactor(1)
-webFrame.setVisualZoomLevelLimits(1, 1)
+// Apply persisted UI zoom level from localStorage before first paint to avoid flash.
+// Ghostty's getContainerRect() has visualViewport.scale compensation for non-100% zoom.
+try {
+  const stored = localStorage.getItem('hive-settings')
+  if (stored) {
+    const parsed = JSON.parse(stored)
+    const zoom = parsed?.state?.uiZoomLevel
+    if (typeof zoom === 'number' && zoom !== 0) {
+      const factor = Math.pow(1.2, zoom)
+      webFrame.setZoomFactor(factor)
+    }
+  }
+} catch {
+  // Ignore — keep default 100% zoom
+}
 
 // Typed database API for renderer
 const db = {
@@ -536,7 +546,25 @@ const systemOps = {
     ipcRenderer.invoke('system:uninstallServerFromPath'),
 
   // Get the current platform (darwin, win32, linux)
-  getPlatform: (): Promise<string> => ipcRenderer.invoke('system:getPlatform')
+  getPlatform: (): Promise<string> => ipcRenderer.invoke('system:getPlatform'),
+
+  // Set the UI zoom level (Electron webContents zoom)
+  setZoomLevel: (level: number): Promise<{ success: boolean; level?: number }> =>
+    ipcRenderer.invoke('system:setZoomLevel', level),
+
+  // Get the current UI zoom level
+  getZoomLevel: (): Promise<number> => ipcRenderer.invoke('system:getZoomLevel'),
+
+  // Subscribe to zoom level changes (from keyboard shortcuts or menu)
+  onZoomChanged: (callback: (level: number) => void): (() => void) => {
+    const handler = (_e: Electron.IpcRendererEvent, level: number): void => {
+      callback(level)
+    }
+    ipcRenderer.on('zoom:changed', handler)
+    return () => {
+      ipcRenderer.removeListener('zoom:changed', handler)
+    }
+  }
 }
 
 // Response logging operations API (only functional when --log is active)

--- a/src/renderer/src/components/sessions/QueuedMessagesBar.tsx
+++ b/src/renderer/src/components/sessions/QueuedMessagesBar.tsx
@@ -1,0 +1,96 @@
+import { X, ListOrdered } from 'lucide-react'
+import { useI18n } from '@/i18n/useI18n'
+import { cn } from '@/lib/utils'
+
+export interface QueuedMsg {
+  id: string
+  content: string
+  timestamp: number
+}
+
+interface QueuedMessagesBarProps {
+  messages: QueuedMsg[]
+  onCancel: (id: string) => void
+  onClearAll: () => void
+}
+
+/**
+ * Compact chip bar rendered directly above the input box to show messages the
+ * user queued while the assistant is streaming. Replaces the old in-list
+ * QueuedMessageBubble so the message area stays clean and pending sends stay
+ * visually attached to the composer.
+ */
+export function QueuedMessagesBar({
+  messages,
+  onCancel,
+  onClearAll
+}: QueuedMessagesBarProps): React.JSX.Element | null {
+  const { t } = useI18n()
+  if (messages.length === 0) return null
+
+  return (
+    <div
+      className={cn(
+        'mb-2 rounded-xl border border-border/60 bg-muted/40 px-3 py-2',
+        'animate-in fade-in slide-in-from-bottom-1 duration-200',
+        'motion-reduce:animate-none'
+      )}
+      data-testid="queued-messages-bar"
+      role="status"
+      aria-live="polite"
+    >
+      {/* Header row */}
+      <div className="flex items-center justify-between mb-1.5">
+        <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+          <ListOrdered className="h-3 w-3" />
+          <span>{t('sessionView.queuedBar.heading', { count: messages.length })}</span>
+        </div>
+        {messages.length > 1 && (
+          <button
+            type="button"
+            onClick={onClearAll}
+            className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+            data-testid="queued-messages-clear-all"
+          >
+            {t('sessionView.queuedBar.clearAll')}
+          </button>
+        )}
+      </div>
+
+      {/* Chip list — scrollable when too many */}
+      <div className="flex flex-wrap gap-1.5 max-h-24 overflow-y-auto">
+        {messages.map((msg, idx) => {
+          const preview = msg.content.replace(/\s+/g, ' ').trim()
+          return (
+            <div
+              key={msg.id}
+              className={cn(
+                'group inline-flex items-center gap-1.5 max-w-[280px]',
+                'rounded-md border border-border/60 bg-background/80 px-2 py-1',
+                'text-xs text-foreground',
+                'animate-in fade-in zoom-in-95 duration-150',
+                'motion-reduce:animate-none'
+              )}
+              title={msg.content}
+              data-testid={`queued-chip-${msg.id}`}
+            >
+              <span className="shrink-0 text-[10px] font-mono text-muted-foreground tabular-nums">
+                {idx + 1}
+              </span>
+              <span className="truncate">{preview}</span>
+              <button
+                type="button"
+                onClick={() => onCancel(msg.id)}
+                className="shrink-0 opacity-0 group-hover:opacity-100 focus:opacity-100 text-muted-foreground hover:text-foreground transition-opacity"
+                aria-label={t('sessionView.queuedBar.cancelAriaLabel')}
+                data-testid={`queued-chip-cancel-${msg.id}`}
+              >
+                <X className="h-3 w-3" />
+              </button>
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/sessions/SessionView.tsx
+++ b/src/renderer/src/components/sessions/SessionView.tsx
@@ -80,6 +80,7 @@ import { CommandApprovalPrompt } from './CommandApprovalPrompt'
 import type { ToolStatus, ToolUseInfo } from './ToolCard'
 import { PLAN_MODE_PREFIX, ASK_MODE_PREFIX, stripPlanModePrefix } from '@/lib/constants'
 import { SessionCostPill } from './SessionCostPill'
+import { QueuedMessagesBar, type QueuedMsg } from './QueuedMessagesBar'
 import type { UsageAnalyticsSessionSummary } from '@shared/types/usage-analytics'
 import type { SessionActivity } from '@shared/types/session'
 
@@ -572,13 +573,7 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
   const [editingMessageId, setEditingMessageId] = useState<string | null>(null)
   const [editingContent, setEditingContent] = useState<string>('')
   const [_editingAttachments, _setEditingAttachments] = useState<MessagePart[]>([])
-  const [queuedMessages, setQueuedMessages] = useState<
-    Array<{
-      id: string
-      content: string
-      timestamp: number
-    }>
-  >([])
+  const [queuedMessages, setQueuedMessages] = useState<QueuedMsg[]>([])
   const [attachments, setAttachments] = useState<Attachment[]>(
     () => useDraftAttachmentStore.getState().restore(sessionId)
   )
@@ -3504,6 +3499,35 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
     ]
   )
 
+  // Handle cancelling a single queued message
+  const handleCancelQueuedMessage = useCallback(
+    (id: string) => {
+      let removedContent: string | undefined
+      setQueuedMessages((prev) => {
+        const target = prev.find((m) => m.id === id)
+        removedContent = target?.content
+        return prev.filter((m) => m.id !== id)
+      })
+      // Sync store (keyed by content string, first-match FIFO)
+      if (removedContent !== undefined) {
+        const existing =
+          useSessionStore.getState().pendingFollowUpMessages.get(sessionId) ?? []
+        const idx = existing.indexOf(removedContent)
+        if (idx >= 0) {
+          const next = [...existing.slice(0, idx), ...existing.slice(idx + 1)]
+          useSessionStore.getState().setPendingFollowUpMessages(sessionId, next)
+        }
+      }
+    },
+    [sessionId]
+  )
+
+  // Handle clearing all queued messages
+  const handleClearAllQueuedMessages = useCallback(() => {
+    setQueuedMessages([])
+    useSessionStore.getState().setPendingFollowUpMessages(sessionId, [])
+  }, [sessionId])
+
   // Handle send message
   const handleSend = useCallback(
     async (overrideValue?: string) => {
@@ -5051,7 +5075,6 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
               isSending={isSending}
               hasVisibleWritingCursor={hasVisibleWritingCursor}
               isCompacting={isCompacting}
-              queuedMessages={queuedMessages}
             />
           )}
         </div>
@@ -5146,6 +5169,12 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
           />
           {/* PR review comment attachments — above the input container */}
           <PrCommentAttachments />
+          {/* Queued follow-up messages — attached above the input box */}
+          <QueuedMessagesBar
+            messages={queuedMessages}
+            onCancel={handleCancelQueuedMessage}
+            onClearAll={handleClearAllQueuedMessages}
+          />
           <div
             className={cn(
               'overflow-hidden rounded-2xl border border-border/80 bg-card/88 shadow-[0_4px_14px_rgba(15,23,42,0.035)] transition-colors duration-200',

--- a/src/renderer/src/components/sessions/VirtualizedMessageList.tsx
+++ b/src/renderer/src/components/sessions/VirtualizedMessageList.tsx
@@ -1,7 +1,6 @@
 import { forwardRef, useImperativeHandle, useMemo, useCallback } from 'react'
 import { useVirtualizer } from '@tanstack/react-virtual'
 import { MessageRenderer } from './MessageRenderer'
-import { QueuedMessageBubble } from './QueuedMessageBubble'
 import type { OpenCodeMessage, StreamingPart } from './SessionView'
 import { AlertCircle, RefreshCw, Minimize2 } from 'lucide-react'
 import { useI18n } from '@/i18n/useI18n'
@@ -19,12 +18,6 @@ interface SessionRetryState {
   next?: number
 }
 
-interface QueuedMsg {
-  id: string
-  content: string
-  timestamp: number
-}
-
 type VirtualListItem =
   | { type: 'message'; message: OpenCodeMessage; key: string }
   | { type: 'revert-banner'; key: string }
@@ -32,7 +25,6 @@ type VirtualListItem =
   | { type: 'retry-banner'; key: string }
   | { type: 'streaming'; key: string }
   | { type: 'typing'; key: string }
-  | { type: 'queued'; msg: QueuedMsg; key: string }
 
 export interface VirtualizedMessageListHandle {
   scrollToEnd: (behavior?: ScrollBehavior) => void
@@ -75,8 +67,6 @@ export interface VirtualizedMessageListProps {
   isSending: boolean
   hasVisibleWritingCursor: boolean
   isCompacting: boolean
-  // Queued messages
-  queuedMessages: QueuedMsg[]
 }
 
 // ── Component ──────────────────────────────────────────────────
@@ -116,8 +106,7 @@ export const VirtualizedMessageList = forwardRef<
     isStreaming,
     isSending,
     hasVisibleWritingCursor,
-    isCompacting,
-    queuedMessages
+    isCompacting
   } = props
 
   // Build the flat list of virtual items
@@ -154,11 +143,6 @@ export const VirtualizedMessageList = forwardRef<
       result.push({ type: 'typing', key: 'typing-indicator' })
     }
 
-    // 7. Queued messages
-    for (const msg of queuedMessages) {
-      result.push({ type: 'queued', msg, key: `queued-${msg.id}` })
-    }
-
     return result
   }, [
     visibleMessages,
@@ -168,8 +152,7 @@ export const VirtualizedMessageList = forwardRef<
     sessionRetry,
     hasStreamingContent,
     isSending,
-    hasVisibleWritingCursor,
-    queuedMessages
+    hasVisibleWritingCursor
   ])
 
   const virtualizer = useVirtualizer({
@@ -342,9 +325,6 @@ export const VirtualizedMessageList = forwardRef<
               )}
             </div>
           )
-
-        case 'queued':
-          return <QueuedMessageBubble content={item.msg.content} />
 
         default:
           return null

--- a/src/renderer/src/components/settings/SettingsAppearance.tsx
+++ b/src/renderer/src/components/settings/SettingsAppearance.tsx
@@ -1,8 +1,39 @@
 import { Check } from 'lucide-react'
 import { THEME_PRESETS, type ThemePreset } from '@/lib/themes'
 import { useThemeStore } from '@/stores/useThemeStore'
+import { useSettingsStore, applyFontScale } from '@/stores/useSettingsStore'
 import { cn } from '@/lib/utils'
 import { useI18n } from '@/i18n/useI18n'
+
+const FONT_SCALE_PRESETS = [
+  { labelKey: 'small', scale: 0.9 },
+  { labelKey: 'default', scale: 1.0 },
+  { labelKey: 'medium', scale: 1.1 },
+  { labelKey: 'large', scale: 1.2 },
+  { labelKey: 'xlarge', scale: 1.35 }
+] as const
+
+const ZOOM_PRESETS = [
+  { label: '80%', level: -1.22 },
+  { label: '90%', level: -0.58 },
+  { label: '100%', level: 0 },
+  { label: '110%', level: 0.53 },
+  { label: '120%', level: 1.0 },
+  { label: '130%', level: 1.44 },
+  { label: '150%', level: 2.22 }
+] as const
+
+function findClosestPreset<T extends { scale?: number; level?: number }>(
+  presets: readonly T[],
+  value: number,
+  key: 'scale' | 'level'
+): T {
+  return presets.reduce((closest, preset) => {
+    const currentDiff = Math.abs((preset[key] as number) - value)
+    const closestDiff = Math.abs((closest[key] as number) - value)
+    return currentDiff < closestDiff ? preset : closest
+  })
+}
 
 function ThemeCard({
   preset,
@@ -65,10 +96,28 @@ function ThemeCard({
 
 export function SettingsAppearance(): React.JSX.Element {
   const themeId = useThemeStore((s) => s.themeId)
+  const uiFontScale = useSettingsStore((s) => s.uiFontScale)
+  const uiZoomLevel = useSettingsStore((s) => s.uiZoomLevel)
+  const updateSetting = useSettingsStore((s) => s.updateSetting)
   const { t } = useI18n()
 
   const darkThemes = THEME_PRESETS.filter((p) => p.type === 'dark')
   const lightThemes = THEME_PRESETS.filter((p) => p.type === 'light')
+
+  const activeFontPreset = findClosestPreset(FONT_SCALE_PRESETS, uiFontScale, 'scale')
+  const activeZoomPreset = findClosestPreset(ZOOM_PRESETS, uiZoomLevel, 'level')
+
+  const handleFontScaleChange = (scale: number): void => {
+    applyFontScale(scale)
+    updateSetting('uiFontScale', scale)
+  }
+
+  const handleZoomChange = (level: number): void => {
+    if (window.systemOps?.setZoomLevel) {
+      window.systemOps.setZoomLevel(level)
+    }
+    updateSetting('uiZoomLevel', level)
+  }
 
   return (
     <div className="space-y-6" data-testid="settings-appearance">
@@ -104,6 +153,66 @@ export function SettingsAppearance(): React.JSX.Element {
           {lightThemes.map((preset) => (
             <ThemeCard key={preset.id} preset={preset} isActive={themeId === preset.id} />
           ))}
+        </div>
+      </div>
+
+      {/* Font Size */}
+      <div>
+        <h3 className="text-sm font-medium text-foreground mb-1">
+          {t('settings.appearance.fontSize.title')}
+        </h3>
+        <p className="text-xs text-muted-foreground mb-3">
+          {t('settings.appearance.fontSize.description')}
+        </p>
+        <div className="flex flex-wrap gap-2" data-testid="font-scale-presets">
+          {FONT_SCALE_PRESETS.map((preset) => {
+            const isActive = activeFontPreset.scale === preset.scale
+            return (
+              <button
+                key={preset.labelKey}
+                onClick={() => handleFontScaleChange(preset.scale)}
+                className={cn(
+                  'rounded-md border px-3 py-1.5 text-xs font-medium transition-colors',
+                  isActive
+                    ? 'border-primary bg-primary text-primary-foreground'
+                    : 'border-border bg-background text-foreground hover:bg-muted'
+                )}
+                data-testid={`font-scale-${preset.labelKey}`}
+              >
+                {t(`settings.appearance.fontSize.presets.${preset.labelKey}`)}
+              </button>
+            )
+          })}
+        </div>
+      </div>
+
+      {/* UI Scale (Electron zoom) */}
+      <div>
+        <h3 className="text-sm font-medium text-foreground mb-1">
+          {t('settings.appearance.uiScale.title')}
+        </h3>
+        <p className="text-xs text-muted-foreground mb-3">
+          {t('settings.appearance.uiScale.description')}
+        </p>
+        <div className="flex flex-wrap gap-2" data-testid="ui-zoom-presets">
+          {ZOOM_PRESETS.map((preset) => {
+            const isActive = activeZoomPreset.level === preset.level
+            return (
+              <button
+                key={preset.label}
+                onClick={() => handleZoomChange(preset.level)}
+                className={cn(
+                  'rounded-md border px-3 py-1.5 text-xs font-medium transition-colors',
+                  isActive
+                    ? 'border-primary bg-primary text-primary-foreground'
+                    : 'border-border bg-background text-foreground hover:bg-muted'
+                )}
+                data-testid={`ui-zoom-${preset.label}`}
+              >
+                {preset.label}
+              </button>
+            )
+          })}
         </div>
       </div>
     </div>

--- a/src/renderer/src/components/toasts/UpdateAvailableToast.tsx
+++ b/src/renderer/src/components/toasts/UpdateAvailableToast.tsx
@@ -1,4 +1,4 @@
-import { Download } from 'lucide-react'
+import { ExternalLink } from 'lucide-react'
 import { useI18n } from '@/i18n/useI18n'
 
 interface UpdateAvailableToastProps {
@@ -19,7 +19,7 @@ export function UpdateAvailableToast({
   return (
     <div className="flex w-[360px] flex-col gap-3 rounded-xl border border-border bg-background p-4 shadow-xl">
       <div className="flex items-center gap-2">
-        <Download className="h-4 w-4 text-blue-500" />
+        <ExternalLink className="h-4 w-4 text-blue-500" />
         <span className="text-sm font-medium text-foreground">
           {t('updateToast.available.title', { version })}
         </span>

--- a/src/renderer/src/hooks/useAutoUpdate.ts
+++ b/src/renderer/src/hooks/useAutoUpdate.ts
@@ -45,15 +45,8 @@ export function useAutoUpdate(): void {
                   sonnerToast.dismiss(promptToastId.current)
                   promptToastId.current = null
                 }
-                window.updaterOps.downloadUpdate().catch(() => {})
-                progressToastId.current = sonnerToast.custom(
-                  () =>
-                    createElement(UpdateProgressToast, {
-                      version: data.version,
-                      percent: 0
-                    }),
-                  { duration: Infinity }
-                )
+                const releaseUrl = `https://github.com/slicenferqin/xuanpu/releases/tag/v${data.version}`
+                window.systemOps.openInChrome(releaseUrl)
               },
               onLater: () => {
                 dismissedForSessionRef.current = data.version

--- a/src/renderer/src/i18n/messages.ts
+++ b/src/renderer/src/i18n/messages.ts
@@ -989,6 +989,11 @@ export const messages: Record<AppLocale, MessageTree> = {
         queueMessage: 'Queue message',
         sendMessage: 'Send message'
       },
+      queuedBar: {
+        heading: '{count} queued',
+        clearAll: 'Clear all',
+        cancelAriaLabel: 'Remove from queue'
+      },
       costPill: {
         title: 'Session Cost',
         totalCost: 'Total Cost',
@@ -3044,6 +3049,11 @@ export const messages: Record<AppLocale, MessageTree> = {
         sendFeedbackTitle: '发送反馈以修改计划',
         queueMessage: '加入队列',
         sendMessage: '发送消息'
+      },
+      queuedBar: {
+        heading: '已排队 {count}',
+        clearAll: '全部取消',
+        cancelAriaLabel: '从队列移除'
       },
       costPill: {
         title: '会话计费',

--- a/src/renderer/src/i18n/messages.ts
+++ b/src/renderer/src/i18n/messages.ts
@@ -564,7 +564,7 @@ export const messages: Record<AppLocale, MessageTree> = {
         title: 'Update v{version} available',
         later: 'Later',
         skip: 'Skip this version',
-        download: 'Download'
+        download: 'View Release'
       },
       progress: {
         title: 'Downloading v{version}...'
@@ -2610,7 +2610,7 @@ export const messages: Record<AppLocale, MessageTree> = {
         title: '发现 v{version} 更新',
         later: '稍后',
         skip: '跳过此版本',
-        download: '下载'
+        download: '前往下载'
       },
       progress: {
         title: '正在下载 v{version}...'

--- a/src/renderer/src/i18n/messages.ts
+++ b/src/renderer/src/i18n/messages.ts
@@ -28,7 +28,23 @@ export const messages: Record<AppLocale, MessageTree> = {
         title: 'Appearance',
         description: 'Choose a theme for the application.',
         darkThemes: 'Dark Themes',
-        lightThemes: 'Light Themes'
+        lightThemes: 'Light Themes',
+        fontSize: {
+          title: 'Font Size',
+          description: 'Adjust text size without changing layout or icons.',
+          presets: {
+            small: 'Small',
+            default: 'Default',
+            medium: 'Medium',
+            large: 'Large',
+            xlarge: 'X-Large'
+          }
+        },
+        uiScale: {
+          title: 'UI Scale',
+          description:
+            'Scale the entire interface, including icons and spacing. You can also use Cmd+/Cmd- shortcuts.'
+        }
       },
       general: {
         title: 'General',
@@ -2088,7 +2104,22 @@ export const messages: Record<AppLocale, MessageTree> = {
         title: '外观',
         description: '为应用选择主题。',
         darkThemes: '深色主题',
-        lightThemes: '浅色主题'
+        lightThemes: '浅色主题',
+        fontSize: {
+          title: '字体大小',
+          description: '仅调整文字大小，不影响图标和布局。',
+          presets: {
+            small: '较小',
+            default: '默认',
+            medium: '稍大',
+            large: '较大',
+            xlarge: '最大'
+          }
+        },
+        uiScale: {
+          title: '界面缩放',
+          description: '等比缩放整体界面，包括图标和间距。也可使用 Cmd+/Cmd- 快捷键。'
+        }
       },
       general: {
         title: '通用',

--- a/src/renderer/src/lib/font-size.ts
+++ b/src/renderer/src/lib/font-size.ts
@@ -1,0 +1,36 @@
+/**
+ * Font size scaling via Tailwind v4 CSS custom properties.
+ *
+ * Tailwind v4 compiles `text-sm` → `font-size: var(--text-sm)`, so
+ * overriding `--text-sm` on `:root` changes all `text-sm` elements
+ * without affecting spacing, icons, or layout.
+ */
+
+/** Tailwind v4 default text sizes in rem */
+const BASE_TEXT_SIZES: Record<string, number> = {
+  '--text-xs': 0.75,
+  '--text-sm': 0.875,
+  '--text-base': 1,
+  '--text-lg': 1.125,
+  '--text-xl': 1.25,
+  '--text-2xl': 1.5
+}
+
+const ALL_FONT_VARS = Object.keys(BASE_TEXT_SIZES)
+
+/**
+ * Apply a font scale multiplier by overriding Tailwind's --text-* CSS variables.
+ * scale = 1 removes all overrides (restores Tailwind defaults).
+ */
+export function applyFontScale(scale: number): void {
+  const root = document.documentElement
+  if (scale === 1) {
+    for (const key of ALL_FONT_VARS) {
+      root.style.removeProperty(key)
+    }
+    return
+  }
+  for (const [key, base] of Object.entries(BASE_TEXT_SIZES)) {
+    root.style.setProperty(key, `${(base * scale).toFixed(4)}rem`)
+  }
+}

--- a/src/renderer/src/main.tsx
+++ b/src/renderer/src/main.tsx
@@ -2,6 +2,22 @@ import './styles/globals.css'
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App'
+import { applyFontScale } from '@/lib/font-size'
+
+// Apply persisted font scale from localStorage before first paint to avoid flash.
+// (Zoom is already applied in preload via webFrame.setZoomFactor.)
+try {
+  const stored = localStorage.getItem('hive-settings')
+  if (stored) {
+    const parsed = JSON.parse(stored)
+    const scale = parsed?.state?.uiFontScale
+    if (typeof scale === 'number' && scale !== 1) {
+      applyFontScale(scale)
+    }
+  }
+} catch {
+  // Ignore — default font sizes will be used
+}
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>

--- a/src/renderer/src/stores/useSettingsStore.ts
+++ b/src/renderer/src/stores/useSettingsStore.ts
@@ -2,6 +2,7 @@ import { create } from 'zustand'
 import { persist, createJSONStorage } from 'zustand/middleware'
 import { APP_SETTINGS_DB_KEY } from '@shared/types/settings'
 import { DEFAULT_LOCALE, type AppLocale } from '@/i18n/messages'
+import { applyFontScale } from '@/lib/font-size'
 
 // ==========================================
 // Migration helpers
@@ -21,6 +22,9 @@ export function migrateSettingsShape(raw: Record<string, any>): Record<string, a
   delete result.defaultAgentSdk
   return result
 }
+
+// Re-export for convenience
+export { applyFontScale } from '@/lib/font-size'
 
 // ==========================================
 // Types
@@ -128,6 +132,10 @@ export interface AppSettings {
 
   // Git
   autoPullBeforeWorktree: boolean
+
+  // Appearance
+  uiZoomLevel: number
+  uiFontScale: number
 }
 
 const DEFAULT_SETTINGS: AppSettings = {
@@ -177,7 +185,9 @@ const DEFAULT_SETTINGS: AppSettings = {
     enabled: false
   },
   telemetryEnabled: true,
-  autoPullBeforeWorktree: true
+  autoPullBeforeWorktree: true,
+  uiZoomLevel: 0,
+  uiFontScale: 1
 }
 
 interface SettingsState extends AppSettings {
@@ -281,7 +291,10 @@ function extractSettings(state: SettingsState): AppSettings {
     skippedUpdateVersion: state.skippedUpdateVersion,
     initialSetupComplete: state.initialSetupComplete,
     commandFilter: state.commandFilter,
-    telemetryEnabled: state.telemetryEnabled
+    telemetryEnabled: state.telemetryEnabled,
+    autoPullBeforeWorktree: state.autoPullBeforeWorktree,
+    uiZoomLevel: state.uiZoomLevel,
+    uiFontScale: state.uiFontScale
   }
 }
 
@@ -494,7 +507,9 @@ export const useSettingsStore = create<SettingsState>()(
         skippedUpdateVersion: state.skippedUpdateVersion,
         initialSetupComplete: state.initialSetupComplete,
         commandFilter: state.commandFilter,
-        telemetryEnabled: state.telemetryEnabled
+        telemetryEnabled: state.telemetryEnabled,
+        uiZoomLevel: state.uiZoomLevel,
+        uiFontScale: state.uiFontScale
       })
     }
   )
@@ -508,8 +523,27 @@ if (typeof window !== 'undefined') {
       .loadFromDatabase()
       .then(() => {
         useSettingsStore.getState().detectAvailableAgentSdks()
+
+        // Apply saved zoom level (Electron webContents zoom)
+        const zoomLevel = useSettingsStore.getState().uiZoomLevel
+        if (zoomLevel !== 0 && window.systemOps?.setZoomLevel) {
+          window.systemOps.setZoomLevel(zoomLevel)
+        }
+
+        // Apply saved font scale (Tailwind CSS variable override)
+        const fontScale = useSettingsStore.getState().uiFontScale
+        if (fontScale !== 1) {
+          applyFontScale(fontScale)
+        }
       })
   }, 200)
+
+  // Sync zoom changes from keyboard shortcuts / menu back into settings
+  if (window.systemOps?.onZoomChanged) {
+    window.systemOps.onZoomChanged((level: number) => {
+      useSettingsStore.getState().updateSetting('uiZoomLevel', level)
+    })
+  }
 
   // Listen for settings updates from main process (e.g., when "Allow always" adds to allowlist)
   window.settingsOps?.onSettingsUpdated((data) => {


### PR DESCRIPTION
## Summary

Closes #14

- **fix auto-update**: open GitHub Releases instead of direct download (self-signed can't pass Gatekeeper)
- **docs**: fix macOS app name to 玄圃.app, add download trends
- **feat font size + UI scale**: two independent controls in Settings > Appearance — CSS variable font scaling + Electron zoom, with anti-flash bootstrap and Cmd+/- sync
- **feat queued messages bar**: move queued follow-ups from message list to compact chip bar above input box, with cancel support

## Test plan

- [ ] `pnpm dev` → Settings > Appearance shows Font Size and UI Scale controls
- [ ] Font size presets change text only; UI scale presets scale everything
- [ ] Cmd+/Cmd-/Cmd+0 sync with UI Scale preset highlight
- [ ] Settings persist across restart (no flash)
- [ ] Queue messages while streaming → chips appear above input, not in message list
- [ ] Cancel individual / clear all queued messages works
- [ ] Auto-send on stream end removes chips progressively
- [ ] Update notification opens GitHub Releases (not direct download)
- [ ] `pnpm lint` / `pnpm build` / `pnpm test` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)