### PR TITLE
fix(codex): 防止无 params 通知导致日志崩溃与问答事件丢失

### DIFF
--- a/src/main/services/codex-app-server-manager.ts
+++ b/src/main/services/codex-app-server-manager.ts
@@ -4,7 +4,7 @@ import { EventEmitter } from 'node:events'
 import readline from 'node:readline'
 
 import { createLogger } from './logger'
-import { asObject, asString } from './codex-utils'
+import { asObject, asString, toDebugSnapshot } from './codex-utils'
 import { CODEX_DEFAULT_MODEL } from './codex-models'
 
 const log = createLogger({ component: 'CodexAppServerManager' })
@@ -918,7 +918,7 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
         paramsKeys: notification.params
           ? Object.keys(notification.params as Record<string, unknown>)
           : [],
-        paramsSnapshot: JSON.stringify(notification.params).slice(0, 500)
+        paramsSnapshot: toDebugSnapshot(notification.params, 500)
       })
     }
 

--- a/src/main/services/codex-implementer.ts
+++ b/src/main/services/codex-implementer.ts
@@ -13,7 +13,7 @@ import { createLogger } from './logger'
 import { CodexAppServerManager, type CodexManagerEvent } from './codex-app-server-manager'
 import { mapCodexManagerEventToActivity } from './codex-activity-mapper'
 import { mapCodexEventToStreamEvents, contentStreamKindFromMethod } from './codex-event-mapper'
-import { asNumber, asObject, asString } from './codex-utils'
+import { asNumber, asObject, asString, toDebugSnapshot } from './codex-utils'
 import { generateCodexSessionTitle } from './codex-session-title'
 import type { DatabaseService } from '../db/database'
 import { autoRenameWorktreeBranch } from './git-service'
@@ -158,7 +158,7 @@ export class CodexImplementer implements AgentSdkImplementer, AgentRuntimeAdapte
         method: event.method,
         threadId: event.threadId,
         payloadKeys: event.payload ? Object.keys(event.payload as Record<string, unknown>) : [],
-        payloadSnapshot: JSON.stringify(event.payload).slice(0, 500)
+        payloadSnapshot: toDebugSnapshot(event.payload, 500)
       })
     }
 
@@ -298,7 +298,7 @@ export class CodexImplementer implements AgentSdkImplementer, AgentRuntimeAdapte
     const payload = asObject(event.payload)
     log.info('DEBUG handleProviderTitleUpdate: raw payload', {
       payloadKeys: payload ? Object.keys(payload) : [],
-      fullPayload: JSON.stringify(event.payload).slice(0, 1000)
+      fullPayload: toDebugSnapshot(event.payload, 1000)
     })
     const title = asString(payload?.threadName)
     if (!title) {

--- a/src/main/services/codex-utils.ts
+++ b/src/main/services/codex-utils.ts
@@ -14,3 +14,15 @@ export function asString(value: unknown): string | undefined {
 export function asNumber(value: unknown): number | undefined {
   return typeof value === 'number' ? value : undefined
 }
+
+export function toDebugSnapshot(value: unknown, maxLength = 500): string {
+  if (value === undefined) return 'undefined'
+
+  try {
+    const serialized = JSON.stringify(value)
+    if (serialized === undefined) return 'undefined'
+    return serialized.length > maxLength ? serialized.slice(0, maxLength) : serialized
+  } catch {
+    return '[unserializable]'
+  }
+}

--- a/test/phase-22/session-4/codex-app-server-manager.test.ts
+++ b/test/phase-22/session-4/codex-app-server-manager.test.ts
@@ -401,6 +401,21 @@ describe('CodexAppServerManager', () => {
       expect(events[0].method).toBe('item/agentMessage/delta')
     })
 
+    it('emits event for notifications without params', () => {
+      const { context } = createTestContext()
+      const events: any[] = []
+      manager.on('event', (event) => events.push(event))
+
+      expect(() =>
+        manager.handleStdoutLine(context, JSON.stringify({ method: 'thread/name/updated' }))
+      ).not.toThrow()
+
+      expect(events).toHaveLength(1)
+      expect(events[0].kind).toBe('notification')
+      expect(events[0].method).toBe('thread/name/updated')
+      expect(events[0].payload).toBeUndefined()
+    })
+
     it('emits event for server requests', () => {
       const { context } = createTestContext()
       const events: any[] = []

--- a/test/phase-22/session-6/codex-question-prompts.test.ts
+++ b/test/phase-22/session-6/codex-question-prompts.test.ts
@@ -565,6 +565,68 @@ describe('Codex Question Prompts', () => {
       expect(impl.getPendingApprovalSessions().has('req-a-1')).toBe(true)
     })
 
+    it('does not crash on payload-less notifications and still handles later requests', async () => {
+      const { CodexImplementer } = await import('../../../src/main/services/codex-implementer')
+      const impl = new CodexImplementer()
+      const internalManager = impl.getManager() as any
+      const mockWindow = {
+        isDestroyed: () => false,
+        webContents: { send: vi.fn() }
+      }
+      impl.setMainWindow(mockWindow as any)
+
+      impl.getSessions().set('/test::thread-q-1', {
+        threadId: 'thread-q-1',
+        hiveSessionId: 'hive-q-1',
+        worktreePath: '/test',
+        status: 'ready',
+        messages: [],
+        revertMessageID: null,
+        revertDiff: null
+      })
+
+      let managerListener: any
+      internalManager.on = vi.fn().mockImplementation((_: string, handler: any) => {
+        managerListener = handler
+      })
+      ;(impl as any).attachManagerListener()
+
+      expect(() =>
+        managerListener({
+          id: 'evt-empty',
+          kind: 'notification',
+          provider: 'codex',
+          threadId: 'thread-q-1',
+          createdAt: new Date().toISOString(),
+          method: 'thread/name/updated'
+        })
+      ).not.toThrow()
+
+      managerListener({
+        id: 'evt-followup',
+        kind: 'request',
+        provider: 'codex',
+        threadId: 'thread-q-1',
+        createdAt: new Date().toISOString(),
+        method: 'item/tool/requestUserInput',
+        requestId: 'req-q-2',
+        payload: {
+          questions: [{ id: 'q2', question: 'Still working?' }]
+        }
+      })
+
+      const sendCalls = mockWindow.webContents.send.mock.calls
+      const streamCalls = sendCalls
+        .filter((c: any[]) => c[0] === 'opencode:stream')
+        .map((c: any[]) => c[1])
+
+      const questionEvent = streamCalls.find((e: any) => e.type === 'question.asked')
+      expect(questionEvent).toBeDefined()
+      expect(questionEvent.sessionId).toBe('hive-q-1')
+      expect(questionEvent.data.requestId).toBe('req-q-2')
+      expect(questionEvent.data.questions).toHaveLength(1)
+    })
+
     it('ignores events for unknown threads', async () => {
       const { CodexImplementer } = await import('../../../src/main/services/codex-implementer')
       const impl = new CodexImplementer()


### PR DESCRIPTION
## Summary

- Codex app-server 偶发发送无 `params` 的 JSON-RPC 通知（如 `thread/name/updated`），旧日志路径 `JSON.stringify(undefined).slice(...)` 抛 `TypeError`，破坏当前事件处理，甚至吞掉后续的 `item/tool/requestUserInput`，导致 UI 问答卡片不出现。
- 新增 `toDebugSnapshot()`，安全处理 `undefined`、不可序列化值与长度裁剪，替换 3 处不安全调用点。
- 增加两条回归测试：无 payload 通知不抛错；紧随其后的问答请求仍能产出 `question.asked` 流事件。

## Test plan

- [ ] `pnpm vitest run test/phase-22/session-4/codex-app-server-manager.test.ts`
- [ ] `pnpm vitest run test/phase-22/session-6/codex-question-prompts.test.ts`
- [ ] 手动：触发一次 Codex 会话改名（`thread/name/updated`），随后让模型发起 `requestUserInput`，确认 UI 问答卡片正常显示

🤖 Generated with [Claude Code](https://claude.com/claude-code)