### PR TITLE
feat: harden runtime startup, HITL handling, and branch compare

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -44,6 +44,7 @@ import { CodexImplementer } from './services/codex-implementer'
 import { openCodeService } from './services/opencode-service'
 import { AgentRuntimeManager } from './services/agent-runtime-manager'
 import { resolveClaudeBinaryPath } from './services/claude-binary-resolver'
+import { powerSaveBlockerService } from './services/power-save-blocker'
 import { telemetryService } from './services/telemetry-service'
 import { ensureForkDataDir } from './services/fork-data-migration'
 import { APP_BUNDLE_ID, APP_CLI_NAME, APP_PRODUCT_NAME } from '@shared/app-identity'
@@ -162,8 +163,42 @@ function createWindow(): void {
     mainWindow.maximize()
   }
 
+  let readyToShowFired = false
   mainWindow.on('ready-to-show', () => {
+    readyToShowFired = true
     mainWindow.show()
+  })
+
+  if (process.platform === 'win32') {
+    setTimeout(() => {
+      if (!mainWindow || mainWindow.isDestroyed() || readyToShowFired) return
+      log.warn('ready-to-show did not fire in time, force-showing window', {
+        timeoutMs: 3000
+      })
+      mainWindow.show()
+    }, 3000)
+  }
+
+  mainWindow.webContents.on(
+    'did-fail-load',
+    (_event, errorCode, errorDescription, validatedURL, isMainFrame) => {
+      log.error('Renderer failed to load', new Error(errorDescription), {
+        errorCode,
+        validatedURL,
+        isMainFrame
+      })
+    }
+  )
+
+  mainWindow.webContents.on('render-process-gone', (_event, details) => {
+    log.error('Renderer process gone', new Error(details.reason), {
+      reason: details.reason,
+      exitCode: details.exitCode
+    })
+  })
+
+  mainWindow.on('unresponsive', () => {
+    log.warn('Main window became unresponsive')
   })
 
   // Emit focus event to renderer for git refresh on window focus
@@ -373,7 +408,7 @@ function registerSystemHandlers(): void {
   })
 
   // Detect which agent SDKs are installed on the system (first-launch setup)
-  ipcMain.handle('system:detectAgentRuntimes', () => {
+  ipcMain.handle('system:detectAgentRuntimes', async () => {
     return detectAgentSdks()
   })
 
@@ -413,6 +448,15 @@ function registerSystemHandlers(): void {
   // Get the current platform (darwin, win32, linux)
   ipcMain.handle('system:getPlatform', () => {
     return process.platform
+  })
+
+  ipcMain.handle('system:setKeepAwakeEnabled', (_event, enabled: boolean) => {
+    if (enabled) {
+      powerSaveBlockerService.enable()
+    } else {
+      powerSaveBlockerService.disable()
+    }
+    return { success: true }
   })
 
   // Set the UI zoom level (clamped to Electron's -5..5 range)
@@ -708,6 +752,9 @@ app.whenReady().then(async () => {
     // dock icon is clicked and there are no other windows open.
     if (BrowserWindow.getAllWindows().length === 0) createWindow()
   })
+}).catch((error) => {
+  log.error('Fatal app startup error', error instanceof Error ? error : new Error(String(error)))
+  app.quit()
 })
 
 // Quit when all windows are closed, except on macOS. There, it's common

--- a/src/main/ipc/git-file-handlers.ts
+++ b/src/main/ipc/git-file-handlers.ts
@@ -852,6 +852,62 @@ export function registerGitFileHandlers(window: BrowserWindow): void {
     }
   )
 
+  ipcMain.handle(
+    'git:branchBaseContent',
+    async (
+      _event,
+      worktreePath: string,
+      branch: string,
+      filePath: string
+    ): Promise<{ success: boolean; content?: string | null; error?: string }> => {
+      try {
+        const gitService = createGitService(worktreePath)
+        const result = await gitService.getBranchBaseContent(branch, filePath)
+        return {
+          success: result.success,
+          content: result.content ?? null,
+          error: result.error
+        }
+      } catch (error) {
+        const message = error instanceof Error ? error.message : 'Unknown error'
+        log.error(
+          'Failed to get branch base content',
+          error instanceof Error ? error : new Error(message),
+          { worktreePath, branch, filePath }
+        )
+        return { success: false, error: message }
+      }
+    }
+  )
+
+  ipcMain.handle(
+    'git:branchBaseContentBase64',
+    async (
+      _event,
+      worktreePath: string,
+      branch: string,
+      filePath: string
+    ): Promise<{ success: boolean; content?: string | null; error?: string }> => {
+      try {
+        const gitService = createGitService(worktreePath)
+        const result = await gitService.getBranchBaseContentBase64(branch, filePath)
+        return {
+          success: result.success,
+          content: result.data ?? null,
+          error: result.error
+        }
+      } catch (error) {
+        const message = error instanceof Error ? error.message : 'Unknown error'
+        log.error(
+          'Failed to get branch base content as base64',
+          error instanceof Error ? error : new Error(message),
+          { worktreePath, branch, filePath }
+        )
+        return { success: false, error: message }
+      }
+    }
+  )
+
   // List open pull requests via gh CLI
   ipcMain.handle(
     'git:listPRs',

--- a/src/main/services/claude-code-implementer.ts
+++ b/src/main/services/claude-code-implementer.ts
@@ -2391,6 +2391,7 @@ export class ClaudeCodeImplementer implements AgentSdkImplementer, AgentRuntimeA
             sessionId: session.hiveSessionId,
             data: questionRequest
           })
+          this.maybeNotifyPendingUserFeedback(session.hiveSessionId, 'question')
 
           log.info('canUseTool: emitted question.asked, waiting for response', {
             requestId,
@@ -2571,6 +2572,7 @@ export class ClaudeCodeImplementer implements AgentSdkImplementer, AgentRuntimeA
       sessionId: session.hiveSessionId,
       data: approvalRequest
     })
+    this.maybeNotifyPendingUserFeedback(session.hiveSessionId, 'approval')
 
     // Log timestamp for debugging approval dialog issues
     log.info('APPROVAL FLOW: Waiting for user response', {
@@ -2887,6 +2889,42 @@ export class ClaudeCodeImplementer implements AgentSdkImplementer, AgentRuntimeA
       })
     } catch (error) {
       log.warn('Failed to show session completion notification', { hiveSessionId, error })
+    }
+  }
+
+  private maybeNotifyPendingUserFeedback(
+    hiveSessionId: string,
+    kind: 'question' | 'approval'
+  ): void {
+    try {
+      if (!this.mainWindow || this.mainWindow.isDestroyed() || this.mainWindow.isFocused()) {
+        return
+      }
+
+      if (!this.dbService) return
+
+      const session = this.dbService.getSession(hiveSessionId)
+      if (!session) return
+
+      const project = this.dbService.getProject(session.project_id)
+      if (!project) return
+
+      notificationService.showPendingUserFeedback(
+        {
+          projectName: project.name,
+          sessionName: session.name || 'Untitled',
+          projectId: session.project_id,
+          worktreeId: session.worktree_id || '',
+          sessionId: hiveSessionId
+        },
+        kind
+      )
+    } catch (error) {
+      log.warn('Failed to show pending user feedback notification', {
+        hiveSessionId,
+        kind,
+        error
+      })
     }
   }
 

--- a/src/main/services/codex-app-server-manager.ts
+++ b/src/main/services/codex-app-server-manager.ts
@@ -1,4 +1,4 @@
-import { type ChildProcess, spawn, spawnSync } from 'node:child_process'
+import { type ChildProcess, spawnSync } from 'node:child_process'
 import { randomUUID } from 'node:crypto'
 import { EventEmitter } from 'node:events'
 import readline from 'node:readline'
@@ -6,6 +6,8 @@ import readline from 'node:readline'
 import { createLogger } from './logger'
 import { asObject, asString } from './codex-utils'
 import { CODEX_DEFAULT_MODEL } from './codex-models'
+import { type CodexLaunchSpec } from './codex-binary-resolver'
+import { spawnLaunchSpec } from './command-launch-utils'
 
 const log = createLogger({ component: 'CodexAppServerManager' })
 
@@ -97,6 +99,7 @@ export interface CodexStartSessionOptions {
   resumeCursor?: string
   codexBinaryPath?: string
   codexHomePath?: string
+  codexLaunchSpec?: CodexLaunchSpec
 }
 
 // ── Turn input ────────────────────────────────────────────────────
@@ -346,15 +349,19 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
         updatedAt: now
       }
 
-      const codexBinaryPath = options.codexBinaryPath ?? 'codex'
-      const child = spawn(codexBinaryPath, ['app-server'], {
+      const launchSpec =
+        options.codexLaunchSpec ??
+        (options.codexBinaryPath
+          ? { command: options.codexBinaryPath, shell: process.platform === 'win32' }
+          : { command: 'codex', shell: process.platform === 'win32' })
+      const child = spawnLaunchSpec(launchSpec, ['app-server'], {
         cwd: resolvedCwd,
         env: {
           ...process.env,
           ...(options.codexHomePath ? { CODEX_HOME: options.codexHomePath } : {})
         },
         stdio: ['pipe', 'pipe', 'pipe'],
-        shell: process.platform === 'win32'
+        windowsHide: true
       })
       const output = readline.createInterface({ input: child.stdout! })
 

--- a/src/main/services/codex-binary-resolver.ts
+++ b/src/main/services/codex-binary-resolver.ts
@@ -1,0 +1,106 @@
+import { createLogger } from './logger'
+import {
+  executeLaunchSpec,
+  resolveCommandLaunchSpec,
+  type CommandLaunchSpec
+} from './command-launch-utils'
+
+const log = createLogger({ component: 'CodexBinaryResolver' })
+
+export type CodexLaunchSpec = CommandLaunchSpec
+
+export interface CodexLaunchInfo {
+  spec: CodexLaunchSpec | null
+  version: string | null
+  supportsAppServer: boolean
+}
+
+function parseVersionOutput(output: string): string | null {
+  const trimmed = output.trim()
+  if (!trimmed) return null
+
+  const prefixed = trimmed.match(/codex[\s/]+(\S+)/i)
+  if (prefixed) return prefixed[1]
+
+  const firstLine = trimmed.split(/\r?\n/)[0]?.trim() ?? ''
+  const versionMatch = firstLine.match(/(\d+\.\d+\.\d+[\w.-]*)/)
+  return versionMatch ? versionMatch[1] : firstLine || null
+}
+
+export async function resolveCodexLaunchSpec(): Promise<CodexLaunchSpec | null> {
+  const spec = await resolveCommandLaunchSpec('codex')
+  if (!spec) {
+    log.warn('Could not resolve Codex binary')
+    return null
+  }
+
+  log.info('Resolved Codex binary', { command: spec.command, shell: spec.shell })
+  return spec
+}
+
+export async function getCodexVersion(spec?: CodexLaunchSpec | null): Promise<string | null> {
+  const resolved = spec ?? (await resolveCodexLaunchSpec())
+  if (!resolved) return null
+
+  try {
+    const { stdout, stderr } = await executeLaunchSpec(resolved, ['--version'])
+    return parseVersionOutput(`${stdout}\n${stderr}`)
+  } catch (error) {
+    log.debug('Codex version check failed', {
+      command: resolved.command,
+      error: error instanceof Error ? error.message : String(error)
+    })
+    return null
+  }
+}
+
+export async function probeCodexAppServerSupport(
+  spec?: CodexLaunchSpec | null
+): Promise<boolean> {
+  const resolved = spec ?? (await resolveCodexLaunchSpec())
+  if (!resolved) return false
+
+  try {
+    const { stdout, stderr } = await executeLaunchSpec(resolved, ['app-server', '--help'], {
+      timeoutMs: 8000
+    })
+    const output = `${stdout}\n${stderr}`.toLowerCase()
+    return output.includes('app-server') || output.includes('json-rpc') || output.includes('usage')
+  } catch (error) {
+    log.warn('Codex app-server capability probe failed', {
+      command: resolved.command,
+      error: error instanceof Error ? error.message : String(error)
+    })
+    return false
+  }
+}
+
+export async function getCodexLaunchInfo(): Promise<CodexLaunchInfo> {
+  const spec = await resolveCodexLaunchSpec()
+  if (!spec) {
+    return { spec: null, version: null, supportsAppServer: false }
+  }
+
+  const [version, supportsAppServer] = await Promise.all([
+    getCodexVersion(spec),
+    probeCodexAppServerSupport(spec)
+  ])
+
+  return { spec, version, supportsAppServer }
+}
+
+export async function ensureCodexAppServerLaunchSpec(): Promise<CodexLaunchSpec> {
+  const info = await getCodexLaunchInfo()
+  if (!info.spec) {
+    throw new Error('Codex CLI not found on PATH')
+  }
+
+  if (!info.supportsAppServer) {
+    const versionLabel = info.version ? ` (${info.version})` : ''
+    throw new Error(
+      `Codex CLI${versionLabel} does not support \`codex app-server\`. Upgrade @openai/codex and try again.`
+    )
+  }
+
+  return info.spec
+}

--- a/src/main/services/codex-health.ts
+++ b/src/main/services/codex-health.ts
@@ -1,6 +1,11 @@
-import { execFile } from 'node:child_process'
-
 import { createLogger } from './logger'
+import {
+  ensureCodexAppServerLaunchSpec,
+  getCodexLaunchInfo,
+  getCodexVersion as getResolvedCodexVersion,
+  type CodexLaunchSpec
+} from './codex-binary-resolver'
+import { executeLaunchSpec } from './command-launch-utils'
 
 const log = createLogger({ component: 'CodexHealth' })
 
@@ -11,31 +16,13 @@ export interface CodexHealthStatus {
   message?: string
 }
 
-const EXEC_TIMEOUT_MS = 5000
-
-/**
- * Run a command and return stdout, or throw on error/timeout.
- */
-function execCommand(cmd: string, args: string[], timeoutMs = EXEC_TIMEOUT_MS): Promise<string> {
-  return new Promise((resolve, reject) => {
-    execFile(cmd, args, { timeout: timeoutMs, encoding: 'utf-8' }, (error, stdout) => {
-      if (error) {
-        reject(error)
-      } else {
-        resolve(stdout)
-      }
-    })
-  })
-}
-
 /**
  * Run `codex --version` and return the parsed version string.
  * Returns null if codex is not installed or the command fails.
  */
-export async function getCodexVersion(): Promise<string | null> {
+export async function getCodexVersion(spec?: CodexLaunchSpec | null): Promise<string | null> {
   try {
-    const output = await execCommand('codex', ['--version'])
-    return parseVersionOutput(output)
+    return await getResolvedCodexVersion(spec)
   } catch (error) {
     log.debug('codex --version failed', { error })
     return null
@@ -104,10 +91,13 @@ export function parseAuthOutput(output: string): 'authenticated' | 'unauthentica
  * Check `codex login status` to determine authentication state.
  * Returns 'unknown' if the command is not available or fails.
  */
-export async function checkCodexAuth(): Promise<'authenticated' | 'unauthenticated' | 'unknown'> {
+export async function checkCodexAuth(
+  spec?: CodexLaunchSpec | null
+): Promise<'authenticated' | 'unauthenticated' | 'unknown'> {
   try {
-    const output = await execCommand('codex', ['login', 'status'])
-    return parseAuthOutput(output)
+    const resolved = spec ?? (await ensureCodexAppServerLaunchSpec())
+    const { stdout, stderr } = await executeLaunchSpec(resolved, ['login', 'status'])
+    return parseAuthOutput(`${stdout}\n${stderr}`)
   } catch (error) {
     log.debug('codex login status failed', { error })
     return 'unknown'
@@ -123,9 +113,8 @@ export async function checkCodexHealth(
 ): Promise<CodexHealthStatus> {
   const { checkAuth = true } = options
 
-  // Step 1: Check if codex is installed
-  const version = await getCodexVersion()
-  if (!version) {
+  const info = await getCodexLaunchInfo()
+  if (!info.spec) {
     return {
       available: false,
       authStatus: 'unknown',
@@ -133,15 +122,24 @@ export async function checkCodexHealth(
     }
   }
 
+  if (!info.supportsAppServer) {
+    return {
+      available: false,
+      version: info.version ?? undefined,
+      authStatus: 'unknown',
+      message: `Codex CLI${info.version ? ` ${info.version}` : ''} does not support codex app-server. Upgrade @openai/codex.`
+    }
+  }
+
   // Step 2: Optionally check auth
   let authStatus: CodexHealthStatus['authStatus'] = 'unknown'
   if (checkAuth) {
-    authStatus = await checkCodexAuth()
+    authStatus = await checkCodexAuth(info.spec)
   }
 
   const result: CodexHealthStatus = {
     available: true,
-    version,
+    version: info.version ?? undefined,
     authStatus
   }
 

--- a/src/main/services/codex-implementer.ts
+++ b/src/main/services/codex-implementer.ts
@@ -13,11 +13,13 @@ import { createLogger } from './logger'
 import { CodexAppServerManager, type CodexManagerEvent } from './codex-app-server-manager'
 import { mapCodexManagerEventToActivity } from './codex-activity-mapper'
 import { mapCodexEventToStreamEvents, contentStreamKindFromMethod } from './codex-event-mapper'
+import { ensureCodexAppServerLaunchSpec } from './codex-binary-resolver'
 import { asNumber, asObject, asString } from './codex-utils'
 import { generateCodexSessionTitle } from './codex-session-title'
 import type { DatabaseService } from '../db/database'
 import { autoRenameWorktreeBranch } from './git-service'
 import { emitAgentEvent } from '@shared/lib/normalize-agent-event'
+import { notificationService } from './notification-service'
 
 const log = createLogger({ component: 'CodexImplementer' })
 
@@ -136,6 +138,46 @@ export class CodexImplementer implements AgentSdkImplementer, AgentRuntimeAdapte
 
   setDatabaseService(db: DatabaseService): void {
     this.dbService = db
+  }
+
+  private async resolveLaunchSpec() {
+    return ensureCodexAppServerLaunchSpec()
+  }
+
+  private maybeNotifyPendingUserFeedback(
+    hiveSessionId: string,
+    kind: 'question' | 'approval'
+  ): void {
+    try {
+      if (!this.mainWindow || this.mainWindow.isDestroyed() || this.mainWindow.isFocused()) {
+        return
+      }
+
+      if (!this.dbService) return
+
+      const session = this.dbService.getSession(hiveSessionId)
+      if (!session) return
+
+      const project = this.dbService.getProject(session.project_id)
+      if (!project) return
+
+      notificationService.showPendingUserFeedback(
+        {
+          projectName: project.name,
+          sessionName: session.name || 'Untitled',
+          projectId: session.project_id,
+          worktreeId: session.worktree_id || '',
+          sessionId: hiveSessionId
+        },
+        kind
+      )
+    } catch (error) {
+      log.warn('Failed to show pending user feedback notification', {
+        hiveSessionId,
+        kind,
+        error
+      })
+    }
   }
 
   // ── Manager event listener (handles approval/question routing) ──
@@ -267,6 +309,7 @@ export class CodexImplementer implements AgentSdkImplementer, AgentRuntimeAdapte
           event.itemId
         )
       })
+      this.maybeNotifyPendingUserFeedback(targetSession.hiveSessionId, 'approval')
       return
     }
 
@@ -291,6 +334,7 @@ export class CodexImplementer implements AgentSdkImplementer, AgentRuntimeAdapte
           questions
         }
       })
+      this.maybeNotifyPendingUserFeedback(targetSession.hiveSessionId, 'question')
     }
   }
 
@@ -332,7 +376,8 @@ export class CodexImplementer implements AgentSdkImplementer, AgentRuntimeAdapte
 
     const providerSession = await this.manager.startSession({
       cwd: worktreePath,
-      model: resolvedModel
+      model: resolvedModel,
+      codexLaunchSpec: await this.resolveLaunchSpec()
     })
 
     const threadId = providerSession.threadId
@@ -401,7 +446,8 @@ export class CodexImplementer implements AgentSdkImplementer, AgentRuntimeAdapte
       const providerSession = await this.manager.startSession({
         cwd: worktreePath,
         model: resolvedModel,
-        resumeThreadId: agentSessionId
+        resumeThreadId: agentSessionId,
+        codexLaunchSpec: await this.resolveLaunchSpec()
       })
 
       const threadId = providerSession.threadId
@@ -1696,10 +1742,43 @@ export class CodexImplementer implements AgentSdkImplementer, AgentRuntimeAdapte
     if (isComplete()) return Promise.resolve()
 
     return new Promise<void>((resolve, reject) => {
-      const timer = setTimeout(() => {
-        cleanup()
-        reject(new Error('Turn timed out'))
-      }, timeoutMs)
+      let remainingMs = timeoutMs
+      let timerStartedAt = Date.now()
+      let timer: ReturnType<typeof setTimeout> | null = null
+
+      const hasPendingHitlForThread = (): boolean => {
+        for (const entry of this.pendingQuestions.values()) {
+          if (entry.threadId === session.threadId) return true
+        }
+        for (const entry of this.pendingApprovalSessions.values()) {
+          if (entry.threadId === session.threadId) return true
+        }
+        return false
+      }
+
+      const clearTimer = () => {
+        if (timer) {
+          clearTimeout(timer)
+          timer = null
+        }
+      }
+
+      const startTimer = () => {
+        clearTimer()
+        timerStartedAt = Date.now()
+        timer = setTimeout(() => {
+          cleanup()
+          reject(new Error('Turn timed out'))
+        }, remainingMs)
+      }
+
+      const pauseTimer = () => {
+        if (!timer) return
+        clearTimeout(timer)
+        timer = null
+        const elapsed = Date.now() - timerStartedAt
+        remainingMs = Math.max(0, remainingMs - elapsed)
+      }
 
       const checkEvent = (event: CodexManagerEvent) => {
         if (event.threadId !== session.threadId) return
@@ -1739,14 +1818,33 @@ export class CodexImplementer implements AgentSdkImplementer, AgentRuntimeAdapte
           cleanup()
           reject(new Error(reason))
         }
+
+        if (event.kind === 'request') {
+          pauseTimer()
+          return
+        }
+
+        const hitlStateChanged =
+          event.method === 'item/tool/requestUserInput/answered' ||
+          event.method === 'approval/responded' ||
+          event.method === 'userInput/rejected' ||
+          event.method === 'session/closed' ||
+          event.method === 'session/exited'
+
+        if (hitlStateChanged && !hasPendingHitlForThread() && remainingMs > 0) {
+          startTimer()
+        }
       }
 
       const cleanup = () => {
-        clearTimeout(timer)
+        clearTimer()
         this.manager.removeListener('event', checkEvent)
       }
 
       this.manager.on('event', checkEvent)
+      if (!hasPendingHitlForThread()) {
+        startTimer()
+      }
 
       // Check again in case it completed between the start and listener setup
       if (isComplete()) {
@@ -1835,7 +1933,8 @@ export class CodexImplementer implements AgentSdkImplementer, AgentRuntimeAdapte
       const providerSession = await this.manager.startSession({
         cwd: worktreePath,
         model: resolveCodexModelSlug(persistedSession.model_id ?? this.selectedModel),
-        resumeThreadId: agentSessionId
+        resumeThreadId: agentSessionId,
+        codexLaunchSpec: await this.resolveLaunchSpec()
       })
 
       const threadId = providerSession.threadId

--- a/src/main/services/codex-session-title.ts
+++ b/src/main/services/codex-session-title.ts
@@ -1,6 +1,7 @@
 import { homedir } from 'node:os'
 
 import { CodexAppServerManager, type CodexManagerEvent } from './codex-app-server-manager'
+import { ensureCodexAppServerLaunchSpec } from './codex-binary-resolver'
 import { createLogger } from './logger'
 
 const log = createLogger({ component: 'CodexSessionTitle' })
@@ -169,7 +170,8 @@ export async function generateCodexSessionTitle(
     try {
       const session = await manager.startSession({
         cwd: worktreePath || homedir(),
-        model: TITLE_MODEL
+        model: TITLE_MODEL,
+        codexLaunchSpec: await ensureCodexAppServerLaunchSpec()
       })
 
       threadId = session.threadId

--- a/src/main/services/command-launch-utils.ts
+++ b/src/main/services/command-launch-utils.ts
@@ -1,0 +1,139 @@
+import { execFile, spawn, type ChildProcess, type ExecFileOptions, type SpawnOptions } from 'node:child_process'
+import { existsSync } from 'node:fs'
+import { extname, isAbsolute } from 'node:path'
+
+export interface CommandLaunchSpec {
+  command: string
+  shell: boolean
+}
+
+export interface CommandExecutionResult {
+  stdout: string
+  stderr: string
+}
+
+const RESOLVE_TIMEOUT_MS = 5000
+
+function normalizeOutputLines(output: string): string[] {
+  return output
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+}
+
+function looksLikePath(command: string): boolean {
+  return isAbsolute(command) || command.includes('/') || command.includes('\\')
+}
+
+export function shouldUseShellForCommand(command: string): boolean {
+  if (process.platform !== 'win32') return false
+  return ['.cmd', '.bat', '.com'].includes(extname(command).toLowerCase())
+}
+
+export function buildLaunchSpec(command: string): CommandLaunchSpec {
+  return {
+    command,
+    shell: shouldUseShellForCommand(command)
+  }
+}
+
+async function execFileCapture(
+  command: string,
+  args: string[],
+  options: ExecFileOptions
+): Promise<CommandExecutionResult> {
+  return new Promise((resolve, reject) => {
+    execFile(command, args, options, (error, stdout, stderr) => {
+      if (error) {
+        reject(error)
+        return
+      }
+      resolve({
+        stdout: stdout ?? '',
+        stderr: stderr ?? ''
+      })
+    })
+  })
+}
+
+export async function executeLaunchSpec(
+  spec: CommandLaunchSpec,
+  args: string[],
+  options: { timeoutMs?: number; cwd?: string; env?: NodeJS.ProcessEnv } = {}
+): Promise<CommandExecutionResult> {
+  return execFileCapture(spec.command, args, {
+    encoding: 'utf-8',
+    timeout: options.timeoutMs ?? RESOLVE_TIMEOUT_MS,
+    cwd: options.cwd,
+    env: options.env ?? process.env,
+    shell: spec.shell,
+    windowsHide: true
+  })
+}
+
+export function spawnLaunchSpec(
+  spec: CommandLaunchSpec,
+  args: string[],
+  options: SpawnOptions = {}
+): ChildProcess {
+  return spawn(spec.command, args, {
+    ...options,
+    shell: spec.shell
+  })
+}
+
+async function resolveCommandCandidates(binary: string): Promise<string[]> {
+  const resolver = process.platform === 'win32' ? 'where' : 'which'
+  try {
+    const { stdout, stderr } = await execFileCapture(resolver, [binary], {
+      encoding: 'utf-8',
+      timeout: RESOLVE_TIMEOUT_MS,
+      env: process.env,
+      windowsHide: true
+    })
+    return Array.from(new Set(normalizeOutputLines(`${stdout}\n${stderr}`)))
+  } catch {
+    return []
+  }
+}
+
+function scoreWindowsCandidate(candidate: string): number {
+  const lower = candidate.toLowerCase()
+  let score = 0
+
+  if (lower.includes('\\windowsapps\\')) {
+    score -= 100
+  }
+
+  const extension = extname(lower)
+  if (extension === '.exe') score += 40
+  if (extension === '.cmd') score += 30
+  if (extension === '.bat') score += 20
+  if (extension === '.com') score += 10
+
+  if (lower.includes('\\appdata\\roaming\\npm\\')) score += 8
+  if (lower.includes('\\nvm\\')) score += 4
+
+  return score
+}
+
+function selectResolvedCommand(candidates: string[]): string | null {
+  const existing = candidates.filter((candidate) => existsSync(candidate))
+  if (existing.length === 0) return null
+
+  if (process.platform !== 'win32') {
+    return existing[0]
+  }
+
+  return [...existing].sort((left, right) => scoreWindowsCandidate(right) - scoreWindowsCandidate(left))[0]
+}
+
+export async function resolveCommandLaunchSpec(command: string): Promise<CommandLaunchSpec | null> {
+  if (looksLikePath(command)) {
+    return existsSync(command) ? buildLaunchSpec(command) : null
+  }
+
+  const candidates = await resolveCommandCandidates(command)
+  const selected = selectResolvedCommand(candidates)
+  return selected ? buildLaunchSpec(selected) : null
+}

--- a/src/main/services/file-ops.ts
+++ b/src/main/services/file-ops.ts
@@ -1,5 +1,5 @@
 import { readFileSync, writeFileSync, existsSync, statSync } from 'fs'
-import { join } from 'path'
+import { dirname, join } from 'path'
 import { app } from 'electron'
 import { getImageMimeType } from '@shared/types/file-utils'
 
@@ -94,13 +94,23 @@ export function writeFile(filePath: string, content: string): { success: boolean
     if (typeof content !== 'string') {
       return { success: false, error: 'Invalid content' }
     }
-    if (!existsSync(filePath)) {
-      return { success: false, error: 'File does not exist' }
+    if (existsSync(filePath)) {
+      const stat = statSync(filePath)
+      if (stat.isDirectory()) {
+        return { success: false, error: 'Path is a directory' }
+      }
+    } else {
+      const parentDir = dirname(filePath)
+      if (!existsSync(parentDir)) {
+        return { success: false, error: 'Parent directory does not exist' }
+      }
+
+      const parentStat = statSync(parentDir)
+      if (!parentStat.isDirectory()) {
+        return { success: false, error: 'Parent path is not a directory' }
+      }
     }
-    const stat = statSync(filePath)
-    if (stat.isDirectory()) {
-      return { success: false, error: 'Path is a directory' }
-    }
+
     writeFileSync(filePath, content, 'utf-8')
     return { success: true }
   } catch (error) {

--- a/src/main/services/git-service.ts
+++ b/src/main/services/git-service.ts
@@ -1064,6 +1064,36 @@ export class GitService {
     }
   }
 
+  private async resolveBranchDiffBase(branch: string): Promise<string> {
+    try {
+      const mergeBase = (await this.git.raw(['merge-base', 'HEAD', branch])).trim()
+      if (mergeBase) return mergeBase
+    } catch (error) {
+      log.warn('Falling back to branch tip for diff base', {
+        branch,
+        repoPath: this.repoPath,
+        error: error instanceof Error ? error.message : String(error)
+      })
+    }
+    return branch
+  }
+
+  async getBranchBaseContent(
+    branch: string,
+    filePath: string
+  ): Promise<{ success: boolean; content?: string; error?: string }> {
+    const baseRef = await this.resolveBranchDiffBase(branch)
+    return this.getRefContent(baseRef, filePath)
+  }
+
+  async getBranchBaseContentBase64(
+    branch: string,
+    filePath: string
+  ): Promise<{ success: boolean; data?: string; mimeType?: string; error?: string }> {
+    const baseRef = await this.resolveBranchDiffBase(branch)
+    return this.getRefContentBase64(baseRef, filePath)
+  }
+
   /**
    * Write patch content to a temp file, run git apply, then clean up.
    * simple-git's applyPatch() treats the first arg as a file path,
@@ -1615,7 +1645,8 @@ export class GitService {
       return { success: false, error: 'Invalid branch name' }
     }
     try {
-      const result = await this.git.raw(['diff', '--name-status', '--no-renames', branch])
+      const baseRef = await this.resolveBranchDiffBase(branch)
+      const result = await this.git.raw(['diff', '--name-status', '--no-renames', baseRef])
       const files: { relativePath: string; status: string }[] = []
       for (const line of result.trim().split('\n')) {
         if (!line) continue
@@ -1648,7 +1679,8 @@ export class GitService {
       return { success: false, error: 'Invalid branch name' }
     }
     try {
-      const result = await this.git.raw(['diff', branch, '--', filePath])
+      const baseRef = await this.resolveBranchDiffBase(branch)
+      const result = await this.git.raw(['diff', baseRef, '--', filePath])
       return { success: true, diff: result || '' }
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)

--- a/src/main/services/notification-service.ts
+++ b/src/main/services/notification-service.ts
@@ -11,6 +11,8 @@ interface SessionNotificationData {
   sessionId: string
 }
 
+type PendingUserFeedbackKind = 'question' | 'approval'
+
 class NotificationService {
   private mainWindow: BrowserWindow | null = null
   private unreadCount = 0
@@ -25,19 +27,37 @@ class NotificationService {
   }
 
   showSessionComplete(data: SessionNotificationData): void {
+    this.showNotification({
+      data,
+      body: `"${data.sessionName}" completed`
+    })
+  }
+
+  showPendingUserFeedback(data: SessionNotificationData, kind: PendingUserFeedbackKind): void {
+    this.showNotification({
+      data,
+      body:
+        kind === 'question'
+          ? `"${data.sessionName}" needs your answer`
+          : `"${data.sessionName}" needs your permission`
+    })
+  }
+
+  private showNotification({ data, body }: { data: SessionNotificationData; body: string }): void {
     if (!Notification.isSupported()) {
       log.warn('Notifications not supported on this platform')
       return
     }
 
-    log.info('Showing session complete notification', {
+    log.info('Showing session notification', {
       projectName: data.projectName,
-      sessionName: data.sessionName
+      sessionName: data.sessionName,
+      body
     })
 
     const notification = new Notification({
       title: data.projectName,
-      body: `"${data.sessionName}" completed`,
+      body,
       silent: false
     })
 
@@ -55,7 +75,6 @@ class NotificationService {
 
     notification.show()
 
-    // Increment dock badge
     this.unreadCount++
     app.dock?.setBadge(String(this.unreadCount))
   }

--- a/src/main/services/onboarding-doctor.ts
+++ b/src/main/services/onboarding-doctor.ts
@@ -2,6 +2,7 @@ import { execFile, spawn } from 'node:child_process'
 
 import { checkCodexHealth } from './codex-health'
 import { createLogger } from './logger'
+import { getOpenCodeVersion, resolveOpenCodeLaunchSpec } from './opencode-binary-resolver'
 import { checkClaudeAuth } from './usage-service'
 
 const log = createLogger({ component: 'OnboardingDoctor' })
@@ -250,9 +251,10 @@ async function checkCodex(): Promise<OnboardingAgentStatus> {
 }
 
 async function checkOpencode(): Promise<OnboardingAgentStatus> {
-  const version = await getBinaryVersion('opencode')
+  const spec = await resolveOpenCodeLaunchSpec()
+  const version = await getOpenCodeVersion(spec)
 
-  if (!version) {
+  if (!spec || !version) {
     return {
       id: 'opencode',
       status: 'missing',

--- a/src/main/services/opencode-binary-resolver.ts
+++ b/src/main/services/opencode-binary-resolver.ts
@@ -1,0 +1,54 @@
+import { createLogger } from './logger'
+import {
+  executeLaunchSpec,
+  resolveCommandLaunchSpec,
+  type CommandLaunchSpec
+} from './command-launch-utils'
+
+const log = createLogger({ component: 'OpenCodeBinaryResolver' })
+
+export type OpenCodeLaunchSpec = CommandLaunchSpec
+
+function parseVersionOutput(output: string): string | null {
+  const trimmed = output.trim()
+  if (!trimmed) return null
+
+  const firstLine = trimmed.split(/\r?\n/)[0]?.trim() ?? ''
+  const match = firstLine.match(/v?\d+\.\d+\.\d+(?:[-+.\w]*)?/)
+  return match ? match[0] : firstLine || null
+}
+
+export async function resolveOpenCodeLaunchSpec(): Promise<OpenCodeLaunchSpec | null> {
+  const spec = await resolveCommandLaunchSpec('opencode')
+  if (!spec) {
+    log.warn('Could not resolve OpenCode binary')
+    return null
+  }
+
+  log.info('Resolved OpenCode binary', { command: spec.command, shell: spec.shell })
+  return spec
+}
+
+export async function getOpenCodeVersion(
+  spec?: OpenCodeLaunchSpec | null
+): Promise<string | null> {
+  const resolved = spec ?? (await resolveOpenCodeLaunchSpec())
+  if (!resolved) return null
+
+  try {
+    const { stdout, stderr } = await executeLaunchSpec(resolved, ['--version'])
+    return parseVersionOutput(`${stdout}\n${stderr}`)
+  } catch (error) {
+    log.debug('OpenCode version check failed', {
+      command: resolved.command,
+      error: error instanceof Error ? error.message : String(error)
+    })
+    return null
+  }
+}
+
+export async function canLaunchOpenCode(): Promise<boolean> {
+  const spec = await resolveOpenCodeLaunchSpec()
+  if (!spec) return false
+  return (await getOpenCodeVersion(spec)) !== null
+}

--- a/src/main/services/opencode-service.ts
+++ b/src/main/services/opencode-service.ts
@@ -1,5 +1,5 @@
 import type { BrowserWindow } from 'electron'
-import { spawn, type ChildProcess } from 'node:child_process'
+import type { ChildProcess } from 'node:child_process'
 import { createLogger } from './logger'
 import { notificationService } from './notification-service'
 import { getDatabase } from '../db'
@@ -8,6 +8,11 @@ import { getEventBus } from '../../server/event-bus'
 import type { AgentSdkImplementer } from './agent-runtime-types'
 import type { AgentRuntimeAdapter } from './agent-runtime-types'
 import { emitAgentEvent } from '@shared/lib/normalize-agent-event'
+import {
+  resolveOpenCodeLaunchSpec,
+  type OpenCodeLaunchSpec
+} from './opencode-binary-resolver'
+import { spawnLaunchSpec } from './command-launch-utils'
 
 const log = createLogger({ component: 'OpenCodeService' })
 
@@ -112,73 +117,97 @@ async function loadOpenCodeSDK(): Promise<{ createOpencode: any; createOpencodeC
  * Parses the listening URL from stdout.
  */
 function spawnOpenCodeServer(
-  options: { hostname?: string; timeout?: number; signal?: AbortSignal } = {}
+  options: {
+    hostname?: string
+    timeout?: number
+    signal?: AbortSignal
+    launchSpec?: OpenCodeLaunchSpec
+  } = {}
 ): Promise<{ url: string; close(): void }> {
   const hostname = options.hostname ?? '127.0.0.1'
   const timeout = options.timeout ?? 10000
 
-  const args = ['serve', `--hostname=${hostname}`]
-  const proc: ChildProcess = spawn('opencode', args, {
-    signal: options.signal,
-    env: { ...process.env }
-  })
+  return (async () => {
+    const launchSpec = options.launchSpec ?? (await resolveOpenCodeLaunchSpec())
+    if (!launchSpec) {
+      throw new Error('OpenCode CLI not found on PATH')
+    }
 
-  const url = new Promise<string>((resolve, reject) => {
-    const id = setTimeout(() => {
-      reject(new Error(`Timeout waiting for opencode server to start after ${timeout}ms`))
-    }, timeout)
+    const args = ['serve', `--hostname=${hostname}`]
+    const proc: ChildProcess = spawnLaunchSpec(launchSpec, args, {
+      signal: options.signal,
+      env: { ...process.env }
+    })
 
-    let output = ''
-    proc.stdout?.on('data', (chunk: Buffer) => {
-      output += chunk.toString()
-      const lines = output.split('\n')
-      for (const line of lines) {
-        if (line.startsWith('opencode server listening')) {
-          const match = line.match(/on\s+(https?:\/\/[^\s]+)/)
+    const url = new Promise<string>((resolve, reject) => {
+      const id = setTimeout(() => {
+        reject(new Error(`Timeout waiting for opencode server to start after ${timeout}ms`))
+      }, timeout)
+
+      let output = ''
+      proc.stdout?.on('data', (chunk: Buffer) => {
+        output += chunk.toString()
+        const lines = output.split(/\r?\n/)
+        for (const line of lines) {
+          const trimmed = line.trim()
+          if (!trimmed.startsWith('opencode server listening')) continue
+          const match = trimmed.match(/on\s+(https?:\/\/[^\s]+)/)
           if (!match) {
             clearTimeout(id)
-            reject(new Error(`Failed to parse server url from output: ${line}`))
+            reject(new Error(`Failed to parse server url from output: ${trimmed}`))
             return
           }
           clearTimeout(id)
           resolve(match[1])
           return
         }
-      }
-    })
-
-    proc.stderr?.on('data', (chunk: Buffer) => {
-      output += chunk.toString()
-    })
-
-    proc.on('exit', (code) => {
-      clearTimeout(id)
-      let msg = `opencode server exited with code ${code}`
-      if (output.trim()) {
-        msg += `\nServer output: ${output}`
-      }
-      reject(new Error(msg))
-    })
-
-    proc.on('error', (error) => {
-      clearTimeout(id)
-      reject(error)
-    })
-
-    if (options.signal) {
-      options.signal.addEventListener('abort', () => {
-        clearTimeout(id)
-        reject(new Error('Aborted'))
       })
-    }
-  })
 
-  return url.then((resolvedUrl) => ({
-    url: resolvedUrl,
-    close() {
-      proc.kill()
-    }
-  }))
+      proc.stderr?.on('data', (chunk: Buffer) => {
+        output += chunk.toString()
+      })
+
+      proc.on('exit', (code) => {
+        clearTimeout(id)
+        let msg = `opencode server exited with code ${code}`
+        if (output.trim()) {
+          msg += `\nServer output: ${output}`
+        }
+        reject(new Error(msg))
+      })
+
+      proc.on('error', (error) => {
+        clearTimeout(id)
+        reject(error)
+      })
+
+      if (options.signal) {
+        options.signal.addEventListener('abort', () => {
+          clearTimeout(id)
+          reject(new Error('Aborted'))
+        })
+      }
+    })
+
+    return url.then((resolvedUrl) => ({
+      url: resolvedUrl,
+      close() {
+        if (process.platform === 'win32' && proc.pid && launchSpec.shell) {
+          try {
+            const killer = spawnLaunchSpec({ command: 'taskkill', shell: false }, ['/pid', String(proc.pid), '/t', '/f'])
+            killer.once('error', () => {
+              proc.kill()
+            })
+            return
+          } catch {
+            proc.kill()
+            return
+          }
+        }
+        proc.kill()
+      }
+    }))
+  })()
 }
 
 class OpenCodeService implements AgentSdkImplementer, AgentRuntimeAdapter {
@@ -1111,6 +1140,17 @@ class OpenCodeService implements AgentSdkImplementer, AgentRuntimeAdapter {
       }
     }
 
+    if (
+      eventType === 'question.asked' ||
+      eventType === 'permission.asked' ||
+      eventType === 'command.approval_needed'
+    ) {
+      this.maybeNotifyPendingUserFeedback(
+        hiveSessionId,
+        eventType === 'question.asked' ? 'question' : 'approval'
+      )
+    }
+
     // Handle session.updated events — persist title to DB before forwarding to renderer
     // The SDK event structure is: { properties: { info: Session } } where Session has { id, title, ... }
     if (eventType === 'session.updated') {
@@ -1335,6 +1375,51 @@ class OpenCodeService implements AgentSdkImplementer, AgentRuntimeAdapter {
       })
     } catch (error) {
       log.warn('Failed to show session completion notification', { hiveSessionId, error })
+    }
+  }
+
+  private maybeNotifyPendingUserFeedback(
+    hiveSessionId: string,
+    kind: 'question' | 'approval'
+  ): void {
+    try {
+      if (!this.mainWindow || this.mainWindow.isDestroyed() || this.mainWindow.isFocused()) {
+        return
+      }
+
+      const db = getDatabase()
+      const session = db.getSession(hiveSessionId)
+      if (!session) {
+        log.warn('Cannot notify pending feedback: session not found', { hiveSessionId, kind })
+        return
+      }
+
+      const project = db.getProject(session.project_id)
+      if (!project) {
+        log.warn('Cannot notify pending feedback: project not found', {
+          hiveSessionId,
+          projectId: session.project_id,
+          kind
+        })
+        return
+      }
+
+      notificationService.showPendingUserFeedback(
+        {
+          projectName: project.name,
+          sessionName: session.name || 'Untitled',
+          projectId: session.project_id,
+          worktreeId: session.worktree_id || '',
+          sessionId: hiveSessionId
+        },
+        kind
+      )
+    } catch (error) {
+      log.warn('Failed to show pending user feedback notification', {
+        hiveSessionId,
+        kind,
+        error
+      })
     }
   }
 

--- a/src/main/services/power-save-blocker.ts
+++ b/src/main/services/power-save-blocker.ts
@@ -1,0 +1,37 @@
+import { powerSaveBlocker, app } from 'electron'
+
+import { createLogger } from './logger'
+
+const log = createLogger({ component: 'PowerSaveBlockerService' })
+
+class PowerSaveBlockerService {
+  private blockerId: number | null = null
+
+  enable(): void {
+    if (this.blockerId !== null && powerSaveBlocker.isStarted(this.blockerId)) {
+      return
+    }
+
+    this.blockerId = powerSaveBlocker.start('prevent-display-sleep')
+    log.info('Enabled keep-awake blocker', { blockerId: this.blockerId })
+  }
+
+  disable(): void {
+    if (this.blockerId === null) return
+    if (powerSaveBlocker.isStarted(this.blockerId)) {
+      powerSaveBlocker.stop(this.blockerId)
+      log.info('Disabled keep-awake blocker', { blockerId: this.blockerId })
+    }
+    this.blockerId = null
+  }
+
+  isEnabled(): boolean {
+    return this.blockerId !== null && powerSaveBlocker.isStarted(this.blockerId)
+  }
+}
+
+export const powerSaveBlockerService = new PowerSaveBlockerService()
+
+app.on('will-quit', () => {
+  powerSaveBlockerService.disable()
+})

--- a/src/main/services/system-info.ts
+++ b/src/main/services/system-info.ts
@@ -1,7 +1,8 @@
 import { app } from 'electron'
-import { execFileSync } from 'child_process'
-import { existsSync } from 'fs'
 import { getLogDir } from './logger'
+import { resolveClaudeBinaryPath } from './claude-binary-resolver'
+import { getCodexLaunchInfo } from './codex-binary-resolver'
+import { canLaunchOpenCode } from './opencode-binary-resolver'
 
 export interface AgentSdkDetection {
   opencode: boolean
@@ -15,22 +16,13 @@ export interface AppPaths {
   logs: string
 }
 
-export function detectAgentSdks(): AgentSdkDetection {
-  const whichCmd = process.platform === 'win32' ? 'where' : 'which'
-  const check = (binary: string): boolean => {
-    try {
-      const result = execFileSync(whichCmd, [binary], {
-        encoding: 'utf-8',
-        timeout: 5000,
-        env: process.env
-      }).trim()
-      const resolved = result.split('\n')[0].trim()
-      return !!resolved && existsSync(resolved)
-    } catch {
-      return false
-    }
+export async function detectAgentSdks(): Promise<AgentSdkDetection> {
+  const [opencode, codex] = await Promise.all([canLaunchOpenCode(), getCodexLaunchInfo()])
+  return {
+    opencode,
+    claude: !!resolveClaudeBinaryPath(),
+    codex: !!codex.spec && codex.supportsAppServer
   }
-  return { opencode: check('opencode'), claude: check('claude'), codex: check('codex') }
 }
 
 export function getAppPaths(): AppPaths {

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -494,6 +494,7 @@ declare global {
       }>
       isLogMode: () => Promise<boolean>
       detectAgentRuntimes: () => Promise<{ opencode: boolean; claude: boolean; codex: boolean }>
+      setKeepAwakeEnabled: (enabled: boolean) => Promise<{ success: boolean }>
       runOnboardingDoctor: () => Promise<OnboardingDoctorResult>
       openCommandInTerminal: (
         command: string,
@@ -1202,6 +1203,24 @@ declare global {
       ) => Promise<{
         success: boolean
         diff?: string
+        error?: string
+      }>
+      getBranchBaseContent: (
+        worktreePath: string,
+        branch: string,
+        filePath: string
+      ) => Promise<{
+        success: boolean
+        content?: string | null
+        error?: string
+      }>
+      getBranchBaseContentBase64: (
+        worktreePath: string,
+        branch: string,
+        filePath: string
+      ) => Promise<{
+        success: boolean
+        content?: string | null
         error?: string
       }>
     }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -436,6 +436,9 @@ const systemOps = {
   detectAgentRuntimes: (): Promise<{ opencode: boolean; claude: boolean; codex: boolean }> =>
     ipcRenderer.invoke('system:detectAgentRuntimes'),
 
+  setKeepAwakeEnabled: (enabled: boolean): Promise<{ success: boolean }> =>
+    ipcRenderer.invoke('system:setKeepAwakeEnabled', enabled),
+
   // Run the first-launch onboarding doctor
   runOnboardingDoctor: (): Promise<OnboardingDoctorResult> =>
     ipcRenderer.invoke('system:runOnboardingDoctor'),
@@ -1106,7 +1109,21 @@ const gitOps = {
     success: boolean
     diff?: string
     error?: string
-  }> => ipcRenderer.invoke('git:branchFileDiff', worktreePath, branch, filePath)
+  }> => ipcRenderer.invoke('git:branchFileDiff', worktreePath, branch, filePath),
+
+  getBranchBaseContent: (
+    worktreePath: string,
+    branch: string,
+    filePath: string
+  ): Promise<{ success: boolean; content?: string | null; error?: string }> =>
+    ipcRenderer.invoke('git:branchBaseContent', worktreePath, branch, filePath),
+
+  getBranchBaseContentBase64: (
+    worktreePath: string,
+    branch: string,
+    filePath: string
+  ): Promise<{ success: boolean; content?: string | null; error?: string }> =>
+    ipcRenderer.invoke('git:branchBaseContentBase64', worktreePath, branch, filePath)
 }
 
 const agentOps = {

--- a/src/renderer/src/components/diff/ImageDiffView.tsx
+++ b/src/renderer/src/components/diff/ImageDiffView.tsx
@@ -80,7 +80,7 @@ export function ImageDiffView({
         // Branch diff: original = branch ref, modified = working tree
         if (isSvg) {
           const [origResult, modResult] = await Promise.all([
-            window.gitOps.getRefContent(worktreePath, compareBranch, filePath),
+            window.gitOps.getBranchBaseContent(worktreePath, compareBranch, filePath),
             window.gitOps.getFileContent(worktreePath, filePath)
           ])
           setOriginalUri(
@@ -91,12 +91,12 @@ export function ImageDiffView({
           )
         } else {
           const [origResult, modResult] = await Promise.all([
-            window.gitOps.getRefContentBase64(worktreePath, compareBranch, filePath),
+            window.gitOps.getBranchBaseContentBase64(worktreePath, compareBranch, filePath),
             window.gitOps.getFileContentBase64(worktreePath, filePath)
           ])
           setOriginalUri(
-            origResult.success && origResult.data
-              ? buildDataUri(origResult.data, origResult.mimeType)
+            origResult.success && origResult.content
+              ? buildDataUri(origResult.content, undefined)
               : null
           )
           setModifiedUri(

--- a/src/renderer/src/components/diff/MonacoDiffView.tsx
+++ b/src/renderer/src/components/diff/MonacoDiffView.tsx
@@ -79,7 +79,7 @@ export default function MonacoDiffView({
       if (compareBranch) {
         // Branch diff: original = branch ref, modified = working tree
         const [origResult, modResult] = await Promise.all([
-          window.gitOps.getRefContent(worktreePath, compareBranch, filePath),
+          window.gitOps.getBranchBaseContent(worktreePath, compareBranch, filePath),
           window.gitOps.getFileContent(worktreePath, filePath)
         ])
 

--- a/src/renderer/src/components/layout/AppLayout.tsx
+++ b/src/renderer/src/components/layout/AppLayout.tsx
@@ -32,6 +32,7 @@ import { useWindowFocusRefresh } from '@/hooks/useWindowFocusRefresh'
 import { useWorktreeWatcher } from '@/hooks/useWorktreeWatcher'
 import { useConnectionWatcher } from '@/hooks/useConnectionWatcher'
 import { useAutoUpdate } from '@/hooks/useAutoUpdate'
+import { useKeepAwake } from '@/hooks/useKeepAwake'
 import { ErrorBoundary, ErrorFallback } from '@/components/error'
 import { ProjectSettingsDialog } from '@/components/projects/ProjectSettingsDialog'
 import { useProjectStore } from '@/stores/useProjectStore'
@@ -87,6 +88,8 @@ export function AppLayout({ children }: AppLayoutProps): React.JSX.Element {
   useConnectionWatcher()
   // Auto-update notifications
   useAutoUpdate()
+  // Keep display awake while opted-in sessions are actively running
+  useKeepAwake()
 
   // Drag-and-drop from Finder
   const activeSessionId = useSessionStore((s) => s.activeSessionId)

--- a/src/renderer/src/components/layout/Header.tsx
+++ b/src/renderer/src/components/layout/Header.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { isMac } from '@/lib/platform'
 import {
   PanelRightClose,
@@ -12,7 +12,8 @@ import {
   Archive,
   ChevronDown,
   FileSearch,
-  X
+  X,
+  Coffee
 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import {
@@ -78,6 +79,10 @@ export function Header(): React.JSX.Element {
   const setActiveSession = useSessionStore((s) => s.setActiveSession)
   const vimMode = useVimModeStore((s) => s.mode)
   const vimModeEnabled = useSettingsStore((s) => s.vimModeEnabled)
+  const keepAwakeEnabled = useSettingsStore((s) => s.keepAwakeEnabled)
+  const sessionStatuses = useWorktreeStatusStore((s) => s.sessionStatuses)
+  const getWorktreeStatus = useWorktreeStatusStore((s) => s.getWorktreeStatus)
+  const getConnectionStatus = useWorktreeStatusStore((s) => s.getConnectionStatus)
   const showVimHints = vimModeEnabled && vimMode === 'normal'
   const [conflictFixFlow, setConflictFixFlow] = useState<ConflictFixFlow | null>(null)
   const { t, supportsFirstCharHint } = useI18n()
@@ -98,6 +103,35 @@ export function Header(): React.JSX.Element {
   // Connection mode detection
   const selectedConnectionId = useConnectionStore((s) => s.selectedConnectionId)
   const isConnectionMode = !!selectedConnectionId && !selectedWorktreeId
+  const isKeepAwakeActive = useMemo(() => {
+    if (!Object.values(sessionStatuses).some(Boolean)) {
+      return false
+    }
+
+    for (const worktrees of worktreesByProject.values()) {
+      for (const worktree of worktrees) {
+        const status = getWorktreeStatus(worktree.id)
+        if (status === 'planning' || status === 'working') {
+          return true
+        }
+      }
+    }
+
+    if (selectedConnectionId) {
+      const status = getConnectionStatus(selectedConnectionId)
+      if (status === 'planning' || status === 'working') {
+        return true
+      }
+    }
+
+    return false
+  }, [
+    worktreesByProject,
+    selectedConnectionId,
+    sessionStatuses,
+    getConnectionStatus,
+    getWorktreeStatus
+  ])
 
   const hasConflicts = useGitStore(
     (state) =>
@@ -492,12 +526,7 @@ export function Header(): React.JSX.Element {
       {isMac() && <div className="w-[72px] flex-shrink-0" />}
       <div className="flex items-center gap-3 flex-1 min-w-0">
         <div className="flex items-center gap-3 min-w-0 rounded-xl border border-border/60 bg-muted/35 px-3 py-1.5">
-          <img
-            src={appLogo}
-            alt="玄圃"
-            className="h-5 w-5 shrink-0 rounded-md"
-            draggable={false}
-          />
+          <img src={appLogo} alt="玄圃" className="h-5 w-5 shrink-0 rounded-md" draggable={false} />
           <span className="text-sm font-semibold">玄圃</span>
         </div>
         {vimModeEnabled && (
@@ -890,6 +919,22 @@ export function Header(): React.JSX.Element {
         >
           <Settings className="h-4 w-4" />
         </Button>
+        {keepAwakeEnabled && (
+          <div
+            className={cn(
+              'inline-flex h-8 w-8 items-center justify-center rounded-lg text-muted-foreground',
+              isKeepAwakeActive && 'text-amber-500'
+            )}
+            title={t(
+              isKeepAwakeActive
+                ? 'header.controls.keepAwakeActiveTitle'
+                : 'header.controls.keepAwakeIdleTitle'
+            )}
+            data-testid="keep-awake-indicator"
+          >
+            <Coffee className="h-4 w-4" />
+          </div>
+        )}
         <Button
           onClick={toggleRightSidebar}
           variant="ghost"

--- a/src/renderer/src/components/settings/SettingsGeneral.tsx
+++ b/src/renderer/src/components/settings/SettingsGeneral.tsx
@@ -22,6 +22,7 @@ export function SettingsGeneral(): React.JSX.Element {
     defaultAgentSdk,
     stripAtMentions,
     autoPullBeforeWorktree,
+    keepAwakeEnabled,
     sessionUiV2Enabled,
     updateSetting,
     resetToDefaults
@@ -326,6 +327,33 @@ export function SettingsGeneral(): React.JSX.Element {
         </button>
       </div>
 
+      {/* Keep awake during active sessions */}
+      <div className="flex items-center justify-between">
+        <div>
+          <label className="text-sm font-medium">{t('settings.general.keepAwake.label')}</label>
+          <p className="text-xs text-muted-foreground">
+            {t('settings.general.keepAwake.description')}
+          </p>
+        </div>
+        <button
+          role="switch"
+          aria-checked={keepAwakeEnabled}
+          onClick={() => updateSetting('keepAwakeEnabled', !keepAwakeEnabled)}
+          className={cn(
+            'relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors',
+            keepAwakeEnabled ? 'bg-primary' : 'bg-muted'
+          )}
+          data-testid="keep-awake-toggle"
+        >
+          <span
+            className={cn(
+              'pointer-events-none block h-4 w-4 rounded-full bg-background shadow-lg ring-0 transition-transform',
+              keepAwakeEnabled ? 'translate-x-4' : 'translate-x-0'
+            )}
+          />
+        </button>
+      </div>
+
       {/* Branch naming */}
       <div className="space-y-2">
         <label className="text-sm font-medium">{t('settings.general.branchNaming.label')}</label>
@@ -364,13 +392,16 @@ export function SettingsGeneral(): React.JSX.Element {
       <div className="space-y-3 pt-4 border-t">
         <div>
           <h4 className="text-sm font-medium">实验性功能</h4>
-          <p className="text-xs text-muted-foreground mt-0.5">以下功能仍在测试中，可能存在不稳定情况</p>
+          <p className="text-xs text-muted-foreground mt-0.5">
+            以下功能仍在测试中，可能存在不稳定情况
+          </p>
         </div>
         <div className="flex items-start justify-between gap-4">
           <div className="space-y-0.5">
             <label className="text-sm font-medium">新版 Session UI</label>
             <p className="text-xs text-muted-foreground">
-              启用重构后的 SessionShell（统一 timeline、三态 Composer、Agent Rail）。关闭后回退到旧版 SessionView。
+              启用重构后的 SessionShell（统一 timeline、三态 Composer、Agent
+              Rail）。关闭后回退到旧版 SessionView。
             </p>
           </div>
           <button

--- a/src/renderer/src/hooks/useKeepAwake.ts
+++ b/src/renderer/src/hooks/useKeepAwake.ts
@@ -1,0 +1,25 @@
+import { useEffect } from 'react'
+import { useSettingsStore } from '@/stores/useSettingsStore'
+import { useWorktreeStatusStore } from '@/stores/useWorktreeStatusStore'
+import { useSessionStore } from '@/stores/useSessionStore'
+
+export function useKeepAwake(): void {
+  const enabled = useSettingsStore((s) => s.keepAwakeEnabled)
+  const sessionStatuses = useWorktreeStatusStore((s) => s.sessionStatuses)
+  const sessionsByWorktree = useSessionStore((s) => s.sessionsByWorktree)
+  const sessionsByConnection = useSessionStore((s) => s.sessionsByConnection)
+
+  useEffect(() => {
+    const shouldKeepAwake =
+      enabled &&
+      [...sessionsByWorktree.values(), ...sessionsByConnection.values()].some((sessions) =>
+        sessions.some((session) => {
+          const status = sessionStatuses[session.id]?.status
+          return status === 'planning' || status === 'working'
+        })
+      )
+
+    const request = window.systemOps?.setKeepAwakeEnabled(shouldKeepAwake)
+    void request?.catch(() => {})
+  }, [enabled, sessionStatuses, sessionsByWorktree, sessionsByConnection])
+}

--- a/src/renderer/src/i18n/messages.ts
+++ b/src/renderer/src/i18n/messages.ts
@@ -94,6 +94,10 @@ export const messages: Record<AppLocale, MessageTree> = {
           description:
             'Remove the @ symbol from file references inserted via the file picker before sending'
         },
+        keepAwake: {
+          label: 'Keep awake during sessions',
+          description: 'Prevent the display from sleeping while a session is actively running.'
+        },
         branchNaming: {
           label: 'Branch Naming',
           description: 'Choose the naming theme for auto-generated worktree branches',
@@ -354,7 +358,8 @@ export const messages: Record<AppLocale, MessageTree> = {
       },
       archivedChats: {
         title: 'Archived Chats',
-        description: 'Browse archived sessions, open them read-only, or restore them to active worktrees.',
+        description:
+          'Browse archived sessions, open them read-only, or restore them to active worktrees.',
         search: {
           placeholder: 'Search session, project, or worktree...'
         },
@@ -370,7 +375,8 @@ export const messages: Record<AppLocale, MessageTree> = {
           updated: 'Updated {date}',
           missingWorktree: 'No active worktree',
           archivedWorktree: 'Parent worktree is archived',
-          restoreDisabled: 'This session can only be viewed because its worktree is archived or missing.'
+          restoreDisabled:
+            'This session can only be viewed because its worktree is archived or missing.'
         },
         empty: {
           title: 'No archived chats',
@@ -965,7 +971,8 @@ export const messages: Record<AppLocale, MessageTree> = {
         authUnknownDescription:
           'Xuanpu could not verify the current auth state for {agent}, but you can already select it if you want to proceed.',
         loginHintClaude: 'Launch Claude Code and follow the interactive sign-in flow.',
-        loginHintCodex: 'Run the login command and complete the ChatGPT or API-key authentication flow.',
+        loginHintCodex:
+          'Run the login command and complete the ChatGPT or API-key authentication flow.',
         loginHintOpencode:
           'Launch OpenCode, then finish provider setup from the interactive session.'
       },
@@ -2011,6 +2018,8 @@ export const messages: Record<AppLocale, MessageTree> = {
         attachExistingPR: 'Attach existing PR',
         sessionHistoryTitle: 'Session History (⌘K)',
         settingsTitle: 'Settings (⌘,)',
+        keepAwakeIdleTitle: 'Keep-awake is enabled',
+        keepAwakeActiveTitle: 'Keep-awake is actively preventing display sleep',
         showSidebar: 'Show sidebar',
         hideSidebar: 'Hide sidebar',
         merged: 'merged',
@@ -2231,6 +2240,10 @@ export const messages: Record<AppLocale, MessageTree> = {
         stripAtMentions: {
           label: '发送前去掉文件提及中的 @',
           description: '通过文件选择器插入文件引用后，在发送前移除前缀 @ 符号'
+        },
+        keepAwake: {
+          label: '会话期间保持唤醒',
+          description: '当会话正在运行时，阻止显示器进入睡眠。'
         },
         branchNaming: {
           label: '分支命名',
@@ -3079,7 +3092,8 @@ export const messages: Record<AppLocale, MessageTree> = {
         loginTitle: '登录指引',
         selectedTitle: '当前选择',
         whyTitle: '说明',
-        recommendedDescription: '玄圃推荐 {agent}，因为它是当前这台机器上最适合直接开箱即用的方案。',
+        recommendedDescription:
+          '玄圃推荐 {agent}，因为它是当前这台机器上最适合直接开箱即用的方案。',
         terminalDescription:
           '终端模式是一个安全兜底。之后你仍然可以在设置里切换到 Claude Code、Codex 或 OpenCode。',
         commandLabel: '建议命令',
@@ -4135,6 +4149,8 @@ export const messages: Record<AppLocale, MessageTree> = {
         attachExistingPR: '关联已有 PR',
         sessionHistoryTitle: '会话历史（⌘K）',
         settingsTitle: '设置（⌘,）',
+        keepAwakeIdleTitle: '保持唤醒已启用',
+        keepAwakeActiveTitle: '正在阻止显示器进入睡眠',
         showSidebar: '显示侧边栏',
         hideSidebar: '隐藏侧边栏',
         merged: '已合并',

--- a/src/renderer/src/stores/useSettingsStore.ts
+++ b/src/renderer/src/stores/useSettingsStore.ts
@@ -133,6 +133,7 @@ export interface AppSettings {
 
   // Git
   autoPullBeforeWorktree: boolean
+  keepAwakeEnabled: boolean
 
   // Appearance
   uiZoomLevel: number
@@ -191,6 +192,7 @@ const DEFAULT_SETTINGS: AppSettings = {
   },
   telemetryEnabled: true,
   autoPullBeforeWorktree: true,
+  keepAwakeEnabled: false,
   uiZoomLevel: 0,
   uiFontScale: 1,
   sessionUiV2Enabled: false
@@ -300,6 +302,7 @@ function extractSettings(state: SettingsState): AppSettings {
     commandFilter: state.commandFilter,
     telemetryEnabled: state.telemetryEnabled,
     autoPullBeforeWorktree: state.autoPullBeforeWorktree,
+    keepAwakeEnabled: state.keepAwakeEnabled,
     uiZoomLevel: state.uiZoomLevel,
     uiFontScale: state.uiFontScale,
     sessionUiV2Enabled: state.sessionUiV2Enabled
@@ -517,6 +520,7 @@ export const useSettingsStore = create<SettingsState>()(
         initialSetupComplete: state.initialSetupComplete,
         commandFilter: state.commandFilter,
         telemetryEnabled: state.telemetryEnabled,
+        keepAwakeEnabled: state.keepAwakeEnabled,
         uiZoomLevel: state.uiZoomLevel,
         uiFontScale: state.uiFontScale,
         sessionUiV2Enabled: state.sessionUiV2Enabled

--- a/src/server/__generated__/resolvers-types.ts
+++ b/src/server/__generated__/resolvers-types.ts
@@ -1650,7 +1650,7 @@ export type WorktreeCreateResult = {
 
 export type WorktreeStatus = 'active' | 'archived'
 
-export type WithIndex<TObject> = TObject & Record<string, any>
+export type WithIndex<TObject> = TObject & Record<string, unknown>
 export type ResolversObject<TObject> = WithIndex<TObject>
 
 export type ResolverTypeWrapper<T> = Promise<T> | T
@@ -1700,8 +1700,8 @@ export interface SubscriptionSubscriberObject<
 }
 
 export interface SubscriptionResolverObject<TResult, TParent, TContext, TArgs> {
-  subscribe: SubscriptionSubscribeFn<any, TParent, TContext, TArgs>
-  resolve: SubscriptionResolveFn<TResult, any, TContext, TArgs>
+  subscribe: SubscriptionSubscribeFn<unknown, TParent, TContext, TArgs>
+  resolve: SubscriptionResolveFn<TResult, unknown, TContext, TArgs>
 }
 
 export type SubscriptionObject<TResult, TKey extends string, TParent, TContext, TArgs> =
@@ -1715,7 +1715,7 @@ export type SubscriptionResolver<
   TContext = Record<PropertyKey, never>,
   TArgs = Record<PropertyKey, never>
 > =
-  | ((...args: any[]) => SubscriptionObject<TResult, TKey, TParent, TContext, TArgs>)
+  | ((...args: unknown[]) => SubscriptionObject<TResult, TKey, TParent, TContext, TArgs>)
   | SubscriptionObject<TResult, TKey, TParent, TContext, TArgs>
 
 export type TypeResolveFn<
@@ -2372,7 +2372,7 @@ export type GitStatusChangedEventResolvers<
   worktreePath?: Resolver<ResolversTypes['String'], ParentType, ContextType>
 }>
 
-export interface JsonScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['JSON'], any> {
+export interface JsonScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['JSON'], unknown> {
   name: 'JSON'
 }
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,6 +1,6 @@
 import { createYoga, createSchema } from 'graphql-yoga'
 import { GraphQLError } from 'graphql'
-import { useServer } from 'graphql-ws/use/ws'
+import { useServer as attachGraphQLWsServer } from 'graphql-ws/use/ws'
 import { createServer as createHttpsServer } from 'node:https'
 import { createServer as createHttpServer } from 'node:http'
 import { readFileSync, readdirSync } from 'node:fs'
@@ -107,7 +107,7 @@ export function startGraphQLServer(opts: ServerOptions): ServerHandle {
     path: yoga.graphqlEndpoint
   })
 
-  useServer(
+  attachGraphQLWsServer(
     {
       schema,
       context: (ctx) => ({

--- a/src/server/resolvers/query/system.resolvers.ts
+++ b/src/server/resolvers/query/system.resolvers.ts
@@ -7,7 +7,7 @@ export const systemQueryResolvers: Resolvers = {
     systemLogDir: () => getLogDir(),
     systemAppVersion: () => getAppVersion(),
     systemAppPaths: () => getAppPaths(),
-    systemDetectAgentSdks: () => detectAgentSdks(),
+    systemDetectAgentSdks: async () => detectAgentSdks(),
     systemServerStatus: () => ({
       uptime: Math.floor(process.uptime()),
       connections: 0,

--- a/src/server/schema/types/results.graphql
+++ b/src/server/schema/types/results.graphql
@@ -87,6 +87,83 @@ type AgentForkResult {
   error: String
 }
 
+# Legacy OpenCode result names kept for backward-compatible GraphQL schema paths.
+type OpenCodeConnectResult {
+  success: Boolean!
+  sessionId: String
+  error: String
+}
+
+type OpenCodeReconnectResult {
+  success: Boolean!
+  sessionStatus: String
+  revertMessageID: String
+  error: String
+}
+
+type OpenCodeMessagesResult {
+  success: Boolean!
+  messages: JSON
+  error: String
+}
+
+type OpenCodeModelsResult {
+  success: Boolean!
+  providers: JSON
+  error: String
+}
+
+type OpenCodeModelInfoResult {
+  success: Boolean!
+  model: JSON
+  error: String
+}
+
+type OpenCodeSessionInfoResult {
+  success: Boolean!
+  revertMessageID: String
+  revertDiff: String
+  error: String
+}
+
+type OpenCodeCommandsResult {
+  success: Boolean!
+  commands: [OpenCodeCommand!]!
+  error: String
+}
+
+type OpenCodeCapabilitiesResult {
+  success: Boolean!
+  capabilities: OpenCodeCapabilities
+  error: String
+}
+
+type OpenCodePermissionListResult {
+  success: Boolean!
+  permissions: [PermissionRequest!]!
+  error: String
+}
+
+type OpenCodeUndoResult {
+  success: Boolean!
+  revertMessageID: String
+  restoredPrompt: String
+  revertDiff: String
+  error: String
+}
+
+type OpenCodeRedoResult {
+  success: Boolean!
+  revertMessageID: String
+  error: String
+}
+
+type OpenCodeForkResult {
+  success: Boolean!
+  sessionId: String
+  error: String
+}
+
 # Git Results
 type GitFileStatusesResult {
   success: Boolean!

--- a/test/codex-session-title-integration.test.ts
+++ b/test/codex-session-title-integration.test.ts
@@ -99,14 +99,17 @@ describe('Codex title integration', () => {
     expect(mockDb.updateSession).toHaveBeenCalledWith('hive-session-1', {
       name: 'Fix auth refresh'
     })
-    expect(mockWindow.webContents.send).toHaveBeenCalledWith('agent:stream', {
-      type: 'session.updated',
-      sessionId: 'hive-session-1',
-      data: {
-        title: 'Fix auth refresh',
-        info: { title: 'Fix auth refresh' }
-      }
-    })
+    expect(mockWindow.webContents.send).toHaveBeenCalledWith(
+      'agent:stream',
+      expect.objectContaining({
+        type: 'session.updated',
+        sessionId: 'hive-session-1',
+        data: {
+          title: 'Fix auth refresh',
+          info: { title: 'Fix auth refresh' }
+        }
+      })
+    )
     expect(mockAutoRenameWorktreeBranch).toHaveBeenCalledWith({
       worktreeId: 'wt-1',
       worktreePath: '/path/to/worktree',

--- a/test/phase-14/session-6/dock-badge.test.ts
+++ b/test/phase-14/session-6/dock-badge.test.ts
@@ -4,6 +4,7 @@ import { vi, describe, test, expect, beforeEach } from 'vitest'
 const mockSetBadge = vi.fn()
 const mockNotificationShow = vi.fn()
 const mockNotificationOn = vi.fn()
+const mockNotificationOptions: Record<string, unknown>[] = []
 let notificationsSupported = true
 
 vi.mock('electron', () => ({
@@ -11,7 +12,9 @@ vi.mock('electron', () => ({
     static isSupported() {
       return notificationsSupported
     }
-    constructor(_opts: Record<string, unknown>) {} // eslint-disable-line @typescript-eslint/no-empty-function
+    constructor(opts: Record<string, unknown>) {
+      mockNotificationOptions.push(opts)
+    }
     on = mockNotificationOn
     show = mockNotificationShow
   },
@@ -68,6 +71,7 @@ function resetServiceState(): void {
 describe('Session 6: Dock Badge', () => {
   beforeEach(() => {
     notificationsSupported = true
+    mockNotificationOptions.length = 0
     resetServiceState()
   })
 
@@ -144,6 +148,18 @@ describe('Session 6: Dock Badge', () => {
     // The fact that all other tests pass with the mock dock confirms
     // the setBadge calls work. The optional chaining is a code-level guarantee.
     notificationService.showSessionComplete(mockSessionData)
+    expect(mockSetBadge).toHaveBeenCalledWith('1')
+  })
+
+  test('pending-user-feedback notifications reuse badge behavior and approval copy', () => {
+    notificationService.showPendingUserFeedback(mockSessionData, 'approval')
+
+    expect(mockNotificationOptions).toHaveLength(1)
+    expect(mockNotificationOptions[0]).toMatchObject({
+      title: 'Test Project',
+      body: '"Test Session" needs your permission'
+    })
+    expect(mockNotificationShow).toHaveBeenCalledTimes(1)
     expect(mockSetBadge).toHaveBeenCalledWith('1')
   })
 })

--- a/test/phase-22/session-11/git-branch-merge-base-diff.test.ts
+++ b/test/phase-22/session-11/git-branch-merge-base-diff.test.ts
@@ -1,0 +1,131 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { rawMock, realpathSyncMock } = vi.hoisted(() => ({
+  rawMock: vi.fn(),
+  realpathSyncMock: vi.fn((worktreePath: string) =>
+    worktreePath === '/repo' ? '/private/repo' : worktreePath
+  )
+}))
+
+vi.mock('fs', async () => {
+  const actual = await vi.importActual<typeof import('fs')>('fs')
+  return {
+    ...actual,
+    realpathSync: realpathSyncMock
+  }
+})
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: vi.fn(() => '/tmp')
+  }
+}))
+
+vi.mock('../../../src/main/services/logger', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn()
+  })
+}))
+
+vi.mock('simple-git', () => ({
+  default: vi.fn(() => ({
+    raw: rawMock
+  }))
+}))
+
+import { GitService } from '../../../src/main/services/git-service'
+
+describe('GitService branch diff merge-base semantics', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    realpathSyncMock.mockImplementation((worktreePath: string) =>
+      worktreePath === '/repo' ? '/private/repo' : worktreePath
+    )
+  })
+
+  it('diffs branch file lists against merge-base', async () => {
+    rawMock.mockImplementation(async (args: string[]) => {
+      if (args[0] === 'merge-base') {
+        return 'abc123\n'
+      }
+
+      if (args[0] === 'diff' && args[1] === '--name-status') {
+        return 'M\tsrc/app.ts\nA\tREADME.md\n'
+      }
+
+      throw new Error(`Unexpected git args: ${args.join(' ')}`)
+    })
+
+    const service = new GitService('/repo')
+
+    await expect(service.getBranchDiffFiles('feature')).resolves.toEqual({
+      success: true,
+      files: [
+        { relativePath: 'src/app.ts', status: 'M' },
+        { relativePath: 'README.md', status: 'A' }
+      ]
+    })
+
+    expect(rawMock).toHaveBeenNthCalledWith(1, ['merge-base', 'HEAD', 'feature'])
+    expect(rawMock).toHaveBeenNthCalledWith(2, ['diff', '--name-status', '--no-renames', 'abc123'])
+  })
+
+  it('diffs a single file against merge-base', async () => {
+    rawMock.mockImplementation(async (args: string[]) => {
+      if (args[0] === 'merge-base') {
+        return 'base456\n'
+      }
+
+      if (args[0] === 'diff') {
+        return '@@ -1 +1 @@\n-old\n+new\n'
+      }
+
+      throw new Error(`Unexpected git args: ${args.join(' ')}`)
+    })
+
+    const service = new GitService('/repo')
+
+    await expect(service.getBranchFileDiff('feature', 'src/app.ts')).resolves.toEqual({
+      success: true,
+      diff: '@@ -1 +1 @@\n-old\n+new\n'
+    })
+
+    expect(rawMock).toHaveBeenNthCalledWith(1, ['merge-base', 'HEAD', 'feature'])
+    expect(rawMock).toHaveBeenNthCalledWith(2, ['diff', 'base456', '--', 'src/app.ts'])
+  })
+
+  it('uses merge-base refs when loading base content for compare views', async () => {
+    rawMock.mockResolvedValue('base789\n')
+
+    const service = new GitService('/repo')
+    const getRefContent = vi
+      .spyOn(service, 'getRefContent')
+      .mockResolvedValue({ success: true, content: 'base content' })
+
+    await expect(service.getBranchBaseContent('feature', 'src/app.ts')).resolves.toEqual({
+      success: true,
+      content: 'base content'
+    })
+
+    expect(getRefContent).toHaveBeenCalledWith('base789', 'src/app.ts')
+  })
+
+  it('falls back to the branch tip when merge-base lookup fails', async () => {
+    rawMock.mockRejectedValueOnce(new Error('merge-base failed'))
+
+    const service = new GitService('/repo')
+    const getRefContent = vi
+      .spyOn(service, 'getRefContent')
+      .mockResolvedValue({ success: true, content: 'branch tip content' })
+
+    await expect(service.getBranchBaseContent('origin/main', 'src/app.ts')).resolves.toEqual({
+      success: true,
+      content: 'branch tip content'
+    })
+
+    expect(getRefContent).toHaveBeenCalledWith('origin/main', 'src/app.ts')
+  })
+})

--- a/test/phase-22/session-11/use-keep-awake.test.tsx
+++ b/test/phase-22/session-11/use-keep-awake.test.tsx
@@ -1,0 +1,132 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, render, waitFor } from '@testing-library/react'
+
+let settingsState = { keepAwakeEnabled: false }
+let worktreeStatusState: {
+  sessionStatuses: Record<string, { status: string; timestamp: number } | null>
+} = {
+  sessionStatuses: {}
+}
+let sessionState: {
+  sessionsByWorktree: Map<string, Array<{ id: string }>>
+  sessionsByConnection: Map<string, Array<{ id: string }>>
+} = {
+  sessionsByWorktree: new Map(),
+  sessionsByConnection: new Map()
+}
+
+const mockSetKeepAwakeEnabled = vi.fn()
+
+vi.mock('@/stores/useSettingsStore', () => ({
+  useSettingsStore: Object.assign(
+    (selector?: (state: typeof settingsState) => unknown) =>
+      selector ? selector(settingsState) : settingsState,
+    {
+      getState: () => settingsState
+    }
+  )
+}))
+
+vi.mock('@/stores/useWorktreeStatusStore', () => ({
+  useWorktreeStatusStore: Object.assign(
+    (selector?: (state: typeof worktreeStatusState) => unknown) =>
+      selector ? selector(worktreeStatusState) : worktreeStatusState,
+    {
+      getState: () => worktreeStatusState
+    }
+  )
+}))
+
+vi.mock('@/stores/useSessionStore', () => ({
+  useSessionStore: Object.assign(
+    (selector?: (state: typeof sessionState) => unknown) =>
+      selector ? selector(sessionState) : sessionState,
+    {
+      getState: () => sessionState
+    }
+  )
+}))
+
+import { useKeepAwake } from '../../../src/renderer/src/hooks/useKeepAwake'
+
+function Harness(): React.JSX.Element | null {
+  useKeepAwake()
+  return null
+}
+
+describe('useKeepAwake', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    settingsState = { keepAwakeEnabled: false }
+    worktreeStatusState = { sessionStatuses: {} }
+    sessionState = {
+      sessionsByWorktree: new Map(),
+      sessionsByConnection: new Map()
+    }
+
+    Object.defineProperty(window, 'systemOps', {
+      writable: true,
+      configurable: true,
+      value: {
+        setKeepAwakeEnabled: mockSetKeepAwakeEnabled.mockResolvedValue({ success: true })
+      }
+    })
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('disables keep-awake when the setting is off', async () => {
+    render(<Harness />)
+
+    await waitFor(() => {
+      expect(mockSetKeepAwakeEnabled).toHaveBeenCalledWith(false)
+    })
+  })
+
+  it('enables keep-awake when a worktree session is planning', async () => {
+    settingsState.keepAwakeEnabled = true
+    sessionState.sessionsByWorktree = new Map([['wt-1', [{ id: 'session-1' }]]])
+    worktreeStatusState.sessionStatuses = {
+      'session-1': { status: 'planning', timestamp: Date.now() }
+    }
+
+    render(<Harness />)
+
+    await waitFor(() => {
+      expect(mockSetKeepAwakeEnabled).toHaveBeenCalledWith(true)
+    })
+  })
+
+  it('enables keep-awake when a connection session is working', async () => {
+    settingsState.keepAwakeEnabled = true
+    sessionState.sessionsByConnection = new Map([['conn-1', [{ id: 'session-2' }]]])
+    worktreeStatusState.sessionStatuses = {
+      'session-2': { status: 'working', timestamp: Date.now() }
+    }
+
+    render(<Harness />)
+
+    await waitFor(() => {
+      expect(mockSetKeepAwakeEnabled).toHaveBeenCalledWith(true)
+    })
+  })
+
+  it('ignores non-blocking statuses like permission and completed', async () => {
+    settingsState.keepAwakeEnabled = true
+    sessionState.sessionsByWorktree = new Map([
+      ['wt-1', [{ id: 'session-3' }, { id: 'session-4' }]]
+    ])
+    worktreeStatusState.sessionStatuses = {
+      'session-3': { status: 'permission', timestamp: Date.now() },
+      'session-4': { status: 'completed', timestamp: Date.now() }
+    }
+
+    render(<Harness />)
+
+    await waitFor(() => {
+      expect(mockSetKeepAwakeEnabled).toHaveBeenCalledWith(false)
+    })
+  })
+})

--- a/test/phase-22/session-2/agent-setup-guard-codex.test.tsx
+++ b/test/phase-22/session-2/agent-setup-guard-codex.test.tsx
@@ -1,14 +1,20 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, waitFor } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 
-// Mutable store state for settings
 let mockSettingsState: {
   initialSetupComplete: boolean
   isLoading: boolean
   updateSetting: ReturnType<typeof vi.fn>
 }
 
-// Mock useSettingsStore
+let wizardProps: {
+  result: OnboardingDoctorResult | null
+  loading: boolean
+  error: string | null
+  onRefresh: () => void
+  onComplete: (sdk: 'claude-code' | 'codex' | 'opencode' | 'terminal') => void
+} | null = null
+
 vi.mock('@/stores/useSettingsStore', () => ({
   useSettingsStore: Object.assign(
     (selector?: (s: unknown) => unknown) => {
@@ -20,47 +26,77 @@ vi.mock('@/stores/useSettingsStore', () => ({
   )
 }))
 
-// Mock AgentNotFoundDialog
-vi.mock('@/components/setup/AgentNotFoundDialog', () => ({
-  AgentNotFoundDialog: () => <div data-testid="agent-not-found-dialog">No Agent Found</div>
+vi.mock('@/components/setup/AgentSetupWizard', () => ({
+  AgentSetupWizard: (props: {
+    result: OnboardingDoctorResult | null
+    loading: boolean
+    error: string | null
+    onRefresh: () => void
+    onComplete: (sdk: 'claude-code' | 'codex' | 'opencode' | 'terminal') => void
+  }) => {
+    wizardProps = props
+
+    return (
+      <div data-testid="agent-setup-wizard">
+        <div data-testid="doctor-loading">{String(props.loading)}</div>
+        <div data-testid="doctor-error">{props.error ?? ''}</div>
+        <div data-testid="recommended-agent">{props.result?.recommendedAgent ?? ''}</div>
+        <button data-testid="wizard-refresh" onClick={() => props.onRefresh()}>
+          refresh
+        </button>
+        <button data-testid="wizard-complete-codex" onClick={() => props.onComplete('codex')}>
+          complete codex
+        </button>
+      </div>
+    )
+  }
 }))
 
-// Mock AgentPickerDialog — respects availableSdks to only show installed providers
-vi.mock('@/components/setup/AgentPickerDialog', () => ({
-  AgentPickerDialog: ({
-    onSelect,
-    availableSdks
-  }: {
-    onSelect: (sdk: string) => void
-    availableSdks: { opencode: boolean; claude: boolean; codex: boolean }
-  }) => (
-    <div data-testid="agent-picker-dialog">
-      {availableSdks.opencode && (
-        <button data-testid="pick-opencode" onClick={() => onSelect('opencode')}>
-          OpenCode
-        </button>
-      )}
-      {availableSdks.claude && (
-        <button data-testid="pick-claude-code" onClick={() => onSelect('claude-code')}>
-          Claude Code
-        </button>
-      )}
-      {availableSdks.codex && (
-        <button data-testid="pick-codex" onClick={() => onSelect('codex')}>
-          Codex
-        </button>
-      )}
-    </div>
-  )
-}))
-
-// Mock window APIs
-const mockDetectAgentSdks = vi.fn()
+const mockRunOnboardingDoctor = vi.fn()
 const mockTrack = vi.fn()
 
-describe('AgentSetupGuard with Codex support', () => {
+const doctorResult: OnboardingDoctorResult = {
+  platform: 'darwin',
+  environmentChecks: [
+    { id: 'git', status: 'ready', reason: 'installed', version: '2.44.0' },
+    { id: 'node', status: 'ready', reason: 'installed', version: 'v20.12.0' }
+  ],
+  agents: [
+    {
+      id: 'claude-code',
+      status: 'ready',
+      reason: 'ready',
+      installed: true,
+      selectable: true,
+      version: '1.2.3',
+      authStatus: 'authenticated'
+    },
+    {
+      id: 'codex',
+      status: 'ready',
+      reason: 'ready',
+      installed: true,
+      selectable: true,
+      version: '0.36.0',
+      authStatus: 'authenticated'
+    },
+    {
+      id: 'opencode',
+      status: 'warning',
+      reason: 'login_required',
+      installed: true,
+      selectable: false,
+      version: '0.9.0',
+      authStatus: 'unknown'
+    }
+  ],
+  recommendedAgent: 'codex'
+}
+
+describe('AgentSetupGuard', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    wizardProps = null
 
     mockSettingsState = {
       initialSetupComplete: false,
@@ -72,7 +108,7 @@ describe('AgentSetupGuard with Codex support', () => {
       writable: true,
       configurable: true,
       value: {
-        detectAgentSdks: mockDetectAgentSdks,
+        runOnboardingDoctor: mockRunOnboardingDoctor,
         quitApp: vi.fn()
       }
     })
@@ -86,110 +122,71 @@ describe('AgentSetupGuard with Codex support', () => {
     })
   })
 
-  it('auto-selects codex when it is the only installed provider', async () => {
-    mockDetectAgentSdks.mockResolvedValue({ opencode: false, claude: false, codex: true })
+  it('requests onboarding doctor results and passes them to the wizard', async () => {
+    mockRunOnboardingDoctor.mockResolvedValue(doctorResult)
 
-    const { AgentSetupGuard } = await import(
-      '@/components/setup/AgentSetupGuard'
-    )
+    const { AgentSetupGuard } = await import('@/components/setup/AgentSetupGuard')
     render(<AgentSetupGuard />)
 
     await waitFor(() => {
-      expect(mockSettingsState.updateSetting).toHaveBeenCalledWith('defaultAgentSdk', 'codex')
-      expect(mockSettingsState.updateSetting).toHaveBeenCalledWith('initialSetupComplete', true)
+      expect(screen.getByTestId('recommended-agent')).toHaveTextContent('codex')
     })
 
+    expect(mockRunOnboardingDoctor).toHaveBeenCalledTimes(1)
+    expect(wizardProps?.loading).toBe(false)
+    expect(wizardProps?.result).toEqual(doctorResult)
+  })
+
+  it('completes setup through the wizard callback and records analytics', async () => {
+    mockRunOnboardingDoctor.mockResolvedValue(doctorResult)
+
+    const { AgentSetupGuard } = await import('@/components/setup/AgentSetupGuard')
+    render(<AgentSetupGuard />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('recommended-agent')).toHaveTextContent('codex')
+    })
+
+    fireEvent.click(screen.getByTestId('wizard-complete-codex'))
+
+    expect(mockSettingsState.updateSetting).toHaveBeenCalledWith('defaultAgentSdk', 'codex')
+    expect(mockSettingsState.updateSetting).toHaveBeenCalledWith('initialSetupComplete', true)
     expect(mockTrack).toHaveBeenCalledWith('onboarding_completed', {
       sdk: 'codex',
-      auto_selected: true
+      auto_selected: false,
+      wizard: true,
+      ready_agents: 2
     })
   })
 
-  it('shows picker with only installed providers (no claude when uninstalled)', async () => {
-    mockDetectAgentSdks.mockResolvedValue({ opencode: true, claude: false, codex: true })
+  it('surfaces onboarding doctor errors and refreshes on demand', async () => {
+    mockRunOnboardingDoctor
+      .mockRejectedValueOnce(new Error('doctor failed'))
+      .mockResolvedValueOnce(doctorResult)
 
-    const { AgentSetupGuard } = await import(
-      '@/components/setup/AgentSetupGuard'
-    )
+    const { AgentSetupGuard } = await import('@/components/setup/AgentSetupGuard')
     render(<AgentSetupGuard />)
 
     await waitFor(() => {
-      expect(screen.getByTestId('agent-picker-dialog')).toBeInTheDocument()
+      expect(screen.getByTestId('doctor-error')).toHaveTextContent('doctor failed')
     })
 
-    // Only opencode and codex buttons should be present
-    expect(screen.getByTestId('pick-opencode')).toBeInTheDocument()
-    expect(screen.getByTestId('pick-codex')).toBeInTheDocument()
-    // Claude should NOT be shown since it's not installed
-    expect(screen.queryByTestId('pick-claude-code')).not.toBeInTheDocument()
-  })
-
-  it('shows picker dialog when all three are installed', async () => {
-    mockDetectAgentSdks.mockResolvedValue({ opencode: true, claude: true, codex: true })
-
-    const { AgentSetupGuard } = await import(
-      '@/components/setup/AgentSetupGuard'
-    )
-    render(<AgentSetupGuard />)
+    fireEvent.click(screen.getByTestId('wizard-refresh'))
 
     await waitFor(() => {
-      expect(screen.getByTestId('agent-picker-dialog')).toBeInTheDocument()
+      expect(screen.getByTestId('recommended-agent')).toHaveTextContent('codex')
     })
 
-    // Verify Codex button is available in the picker
-    expect(screen.getByTestId('pick-codex')).toBeInTheDocument()
-  })
-
-  it('shows none-found dialog when no agents are installed', async () => {
-    mockDetectAgentSdks.mockResolvedValue({ opencode: false, claude: false, codex: false })
-
-    const { AgentSetupGuard } = await import(
-      '@/components/setup/AgentSetupGuard'
-    )
-    render(<AgentSetupGuard />)
-
-    await waitFor(() => {
-      expect(screen.getByTestId('agent-not-found-dialog')).toBeInTheDocument()
-    })
-  })
-
-  it('auto-selects opencode when only opencode is installed (codex false)', async () => {
-    mockDetectAgentSdks.mockResolvedValue({ opencode: true, claude: false, codex: false })
-
-    const { AgentSetupGuard } = await import(
-      '@/components/setup/AgentSetupGuard'
-    )
-    render(<AgentSetupGuard />)
-
-    await waitFor(() => {
-      expect(mockSettingsState.updateSetting).toHaveBeenCalledWith('defaultAgentSdk', 'opencode')
-      expect(mockSettingsState.updateSetting).toHaveBeenCalledWith('initialSetupComplete', true)
-    })
-  })
-
-  it('auto-selects claude-code when only claude is installed (codex false)', async () => {
-    mockDetectAgentSdks.mockResolvedValue({ opencode: false, claude: true, codex: false })
-
-    const { AgentSetupGuard } = await import(
-      '@/components/setup/AgentSetupGuard'
-    )
-    render(<AgentSetupGuard />)
-
-    await waitFor(() => {
-      expect(mockSettingsState.updateSetting).toHaveBeenCalledWith('defaultAgentSdk', 'claude-code')
-      expect(mockSettingsState.updateSetting).toHaveBeenCalledWith('initialSetupComplete', true)
-    })
+    expect(mockRunOnboardingDoctor).toHaveBeenCalledTimes(2)
   })
 
   it('renders nothing when setup is already complete', async () => {
     mockSettingsState.initialSetupComplete = true
 
-    const { AgentSetupGuard } = await import(
-      '@/components/setup/AgentSetupGuard'
-    )
+    const { AgentSetupGuard } = await import('@/components/setup/AgentSetupGuard')
     const { container } = render(<AgentSetupGuard />)
 
     expect(container.innerHTML).toBe('')
-    expect(mockDetectAgentSdks).not.toHaveBeenCalled()
+    expect(mockRunOnboardingDoctor).not.toHaveBeenCalled()
   })
 })

--- a/test/phase-22/session-2/command-launch-utils.test.ts
+++ b/test/phase-22/session-2/command-launch-utils.test.ts
@@ -1,0 +1,124 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { mockExecFile, mockExistsSync } = vi.hoisted(() => ({
+  mockExecFile: vi.fn(),
+  mockExistsSync: vi.fn()
+}))
+
+vi.mock('node:child_process', () => ({
+  default: {
+    execFile: (...args: unknown[]) => mockExecFile(...args),
+    spawn: vi.fn()
+  },
+  execFile: (...args: unknown[]) => mockExecFile(...args),
+  spawn: vi.fn()
+}))
+
+vi.mock('node:fs', async () => {
+  const actual = await vi.importActual<typeof import('node:fs')>('node:fs')
+  return {
+    ...actual,
+    default: {
+      ...actual,
+      existsSync: (path: string) => mockExistsSync(path)
+    },
+    existsSync: (path: string) => mockExistsSync(path)
+  }
+})
+
+import { resolveCommandLaunchSpec } from '../../../src/main/services/command-launch-utils'
+
+const originalPlatform = process.platform
+
+function setPlatform(platform: NodeJS.Platform): void {
+  Object.defineProperty(process, 'platform', {
+    value: platform,
+    configurable: true
+  })
+}
+
+describe('command-launch-utils', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    setPlatform(originalPlatform)
+  })
+
+  afterEach(() => {
+    setPlatform(originalPlatform)
+  })
+
+  it('prefers an executable .exe over .cmd and ignores WindowsApps shims', async () => {
+    setPlatform('win32')
+
+    mockExecFile.mockImplementation(
+      (
+        _command: string,
+        _args: string[],
+        _options: unknown,
+        callback: (...args: unknown[]) => void
+      ) => {
+        callback(
+          null,
+          [
+            'C:\\Users\\slice\\AppData\\Local\\Microsoft\\WindowsApps\\codex.exe',
+            'C:\\Users\\slice\\AppData\\Roaming\\npm\\codex.cmd',
+            'C:\\tools\\codex.exe'
+          ].join('\r\n'),
+          ''
+        )
+      }
+    )
+    mockExistsSync.mockReturnValue(true)
+
+    await expect(resolveCommandLaunchSpec('codex')).resolves.toEqual({
+      command: 'C:\\tools\\codex.exe',
+      shell: false
+    })
+  })
+
+  it('treats .cmd paths with spaces as shell-launched commands on Windows', async () => {
+    setPlatform('win32')
+    mockExistsSync.mockImplementation(
+      (path: string) => path === 'C:\\Program Files\\OpenCode\\opencode.cmd'
+    )
+
+    await expect(
+      resolveCommandLaunchSpec('C:\\Program Files\\OpenCode\\opencode.cmd')
+    ).resolves.toEqual({
+      command: 'C:\\Program Files\\OpenCode\\opencode.cmd',
+      shell: true
+    })
+
+    expect(mockExecFile).not.toHaveBeenCalled()
+  })
+
+  it('treats .exe paths with spaces as direct executables', async () => {
+    setPlatform('win32')
+    mockExistsSync.mockImplementation(
+      (path: string) => path === 'C:\\Program Files\\Codex\\codex.exe'
+    )
+
+    await expect(resolveCommandLaunchSpec('C:\\Program Files\\Codex\\codex.exe')).resolves.toEqual({
+      command: 'C:\\Program Files\\Codex\\codex.exe',
+      shell: false
+    })
+  })
+
+  it('returns null when resolution finds no existing candidate', async () => {
+    setPlatform('darwin')
+
+    mockExecFile.mockImplementation(
+      (
+        _command: string,
+        _args: string[],
+        _options: unknown,
+        callback: (...args: unknown[]) => void
+      ) => {
+        callback(null, '/usr/local/bin/codex\n', '')
+      }
+    )
+    mockExistsSync.mockReturnValue(false)
+
+    await expect(resolveCommandLaunchSpec('codex')).resolves.toBeNull()
+  })
+})

--- a/test/phase-22/session-2/system-info-codex-detection.test.ts
+++ b/test/phase-22/session-2/system-info-codex-detection.test.ts
@@ -1,154 +1,107 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-/**
- * Tests for the codex detection logic in detectAgentSdks().
- *
- * Since the actual system-info.ts module depends on Electron (`app` from 'electron'),
- * we test the detection logic by exercising the same pattern used in the source:
- * shell-out to `which`/`where`, parse the path, and verify with existsSync.
- *
- * This validates:
- *   1. The return type includes `codex: boolean`
- *   2. The detection logic correctly identifies installed/missing codex binary
- *   3. Error handling works for all three binaries
- */
+const { mockCanLaunchOpenCode, mockGetCodexLaunchInfo, mockResolveClaudeBinaryPath } = vi.hoisted(
+  () => ({
+    mockCanLaunchOpenCode: vi.fn(),
+    mockGetCodexLaunchInfo: vi.fn(),
+    mockResolveClaudeBinaryPath: vi.fn()
+  })
+)
 
-describe('system-info: detectAgentSdks codex detection logic', () => {
-  // Replicate the detection logic from system-info.ts without Electron deps
-  let mockExecFileSync: ReturnType<typeof vi.fn>
-  let mockExistsSync: ReturnType<typeof vi.fn>
+vi.mock('../../../src/main/services/opencode-binary-resolver', () => ({
+  canLaunchOpenCode: mockCanLaunchOpenCode
+}))
 
-  function detectAgentSdks(): { opencode: boolean; claude: boolean; codex: boolean } {
-    const whichCmd = process.platform === 'win32' ? 'where' : 'which'
-    const check = (binary: string): boolean => {
-      try {
-        const result = (mockExecFileSync(whichCmd, [binary], {
-          encoding: 'utf-8',
-          timeout: 5000,
-          env: process.env
-        }) as string).trim()
-        const resolved = result.split('\n')[0].trim()
-        return !!resolved && mockExistsSync(resolved)
-      } catch {
-        return false
-      }
-    }
-    return { opencode: check('opencode'), claude: check('claude'), codex: check('codex') }
+vi.mock('../../../src/main/services/codex-binary-resolver', () => ({
+  getCodexLaunchInfo: mockGetCodexLaunchInfo
+}))
+
+vi.mock('../../../src/main/services/claude-binary-resolver', () => ({
+  resolveClaudeBinaryPath: mockResolveClaudeBinaryPath
+}))
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: vi.fn(() => '/tmp'),
+    getVersion: vi.fn(() => '1.0.0')
   }
+}))
 
+vi.mock('../../../src/main/services/logger', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn()
+  }),
+  getLogDir: vi.fn(() => '/tmp/logs')
+}))
+
+import { detectAgentSdks } from '../../../src/main/services/system-info'
+
+describe('system-info: detectAgentSdks', () => {
   beforeEach(() => {
-    mockExecFileSync = vi.fn()
-    mockExistsSync = vi.fn()
+    vi.clearAllMocks()
   })
 
-  it('returns codex: true when codex binary is found', () => {
-    mockExecFileSync.mockImplementation((_cmd: string, args: string[]) => {
-      const binary = args[0]
-      if (binary === 'codex') return '/usr/local/bin/codex\n'
-      throw new Error('not found')
+  it('returns false for every runtime when no launch capability is available', async () => {
+    mockCanLaunchOpenCode.mockResolvedValue(false)
+    mockGetCodexLaunchInfo.mockResolvedValue({
+      spec: null,
+      version: null,
+      supportsAppServer: false
     })
-    mockExistsSync.mockImplementation((p: string) => {
-      return p === '/usr/local/bin/codex'
-    })
+    mockResolveClaudeBinaryPath.mockReturnValue(null)
 
-    const result = detectAgentSdks()
-    expect(result.codex).toBe(true)
-    expect(result.opencode).toBe(false)
-    expect(result.claude).toBe(false)
+    await expect(detectAgentSdks()).resolves.toEqual({
+      opencode: false,
+      claude: false,
+      codex: false
+    })
   })
 
-  it('returns codex: false when codex binary is not found', () => {
-    mockExecFileSync.mockImplementation(() => {
-      throw new Error('not found')
+  it('requires codex app-server capability before reporting codex as available', async () => {
+    mockCanLaunchOpenCode.mockResolvedValue(true)
+    mockResolveClaudeBinaryPath.mockReturnValue('/usr/local/bin/claude')
+
+    mockGetCodexLaunchInfo.mockResolvedValueOnce({
+      spec: { command: '/usr/local/bin/codex', shell: false },
+      version: '0.36.0',
+      supportsAppServer: false
     })
 
-    const result = detectAgentSdks()
-    expect(result.codex).toBe(false)
-    expect(result.opencode).toBe(false)
-    expect(result.claude).toBe(false)
+    await expect(detectAgentSdks()).resolves.toEqual({
+      opencode: true,
+      claude: true,
+      codex: false
+    })
+
+    mockGetCodexLaunchInfo.mockResolvedValueOnce({
+      spec: { command: '/usr/local/bin/codex', shell: false },
+      version: '0.36.0',
+      supportsAppServer: true
+    })
+
+    await expect(detectAgentSdks()).resolves.toEqual({
+      opencode: true,
+      claude: true,
+      codex: true
+    })
   })
 
-  it('returns all three as true when all binaries are found', () => {
-    mockExecFileSync.mockImplementation((_cmd: string, args: string[]) => {
-      const binary = args[0]
-      const paths: Record<string, string> = {
-        opencode: '/usr/local/bin/opencode',
-        claude: '/usr/local/bin/claude',
-        codex: '/usr/local/bin/codex'
-      }
-      if (paths[binary]) return paths[binary] + '\n'
-      throw new Error('not found')
+  it('keeps the existing boolean return shape for renderer and headless callers', async () => {
+    mockCanLaunchOpenCode.mockResolvedValue(true)
+    mockGetCodexLaunchInfo.mockResolvedValue({
+      spec: { command: '/usr/local/bin/codex', shell: false },
+      version: '0.36.0',
+      supportsAppServer: true
     })
-    mockExistsSync.mockReturnValue(true)
+    mockResolveClaudeBinaryPath.mockReturnValue('/usr/local/bin/claude')
 
-    const result = detectAgentSdks()
-    expect(result.opencode).toBe(true)
-    expect(result.claude).toBe(true)
-    expect(result.codex).toBe(true)
-  })
+    const result = await detectAgentSdks()
 
-  it('handles errors gracefully for codex detection', () => {
-    mockExecFileSync.mockImplementation((_cmd: string, args: string[]) => {
-      const binary = args[0]
-      if (binary === 'opencode') return '/usr/local/bin/opencode\n'
-      if (binary === 'codex') throw new Error('command timed out')
-      throw new Error('not found')
-    })
-    mockExistsSync.mockReturnValue(true)
-
-    const result = detectAgentSdks()
-    expect(result.opencode).toBe(true)
-    expect(result.claude).toBe(false)
-    expect(result.codex).toBe(false)
-  })
-
-  it('returns codex: false when binary path does not exist on disk', () => {
-    mockExecFileSync.mockImplementation((_cmd: string, args: string[]) => {
-      const binary = args[0]
-      if (binary === 'codex') return '/usr/local/bin/codex\n'
-      throw new Error('not found')
-    })
-    mockExistsSync.mockReturnValue(false)
-
-    const result = detectAgentSdks()
-    expect(result.codex).toBe(false)
-  })
-
-  it('return type includes all three properties', () => {
-    mockExecFileSync.mockImplementation(() => {
-      throw new Error('not found')
-    })
-
-    const result = detectAgentSdks()
-    expect(result).toHaveProperty('opencode')
-    expect(result).toHaveProperty('claude')
-    expect(result).toHaveProperty('codex')
-  })
-
-  it('uses which command on non-Windows platforms', () => {
-    mockExecFileSync.mockImplementation(() => {
-      throw new Error('not found')
-    })
-
-    detectAgentSdks()
-
-    // All three calls should use 'which' (or 'where' on Windows)
-    const expectedCmd = process.platform === 'win32' ? 'where' : 'which'
-    expect(mockExecFileSync).toHaveBeenCalledTimes(3)
-    expect(mockExecFileSync).toHaveBeenCalledWith(
-      expectedCmd,
-      ['opencode'],
-      expect.objectContaining({ encoding: 'utf-8' })
-    )
-    expect(mockExecFileSync).toHaveBeenCalledWith(
-      expectedCmd,
-      ['claude'],
-      expect.objectContaining({ encoding: 'utf-8' })
-    )
-    expect(mockExecFileSync).toHaveBeenCalledWith(
-      expectedCmd,
-      ['codex'],
-      expect.objectContaining({ encoding: 'utf-8' })
-    )
+    expect(result).toHaveProperty('opencode', true)
+    expect(result).toHaveProperty('claude', true)
+    expect(result).toHaveProperty('codex', true)
   })
 })

--- a/test/phase-22/session-3/codex-health.test.ts
+++ b/test/phase-22/session-3/codex-health.test.ts
@@ -1,14 +1,17 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-/**
- * Tests for codex-health.ts — version parsing, auth output parsing,
- * and health check orchestration.
- *
- * We test the pure parsing functions directly and mock child_process
- * for the async functions that shell out to the codex CLI.
- */
+const {
+  mockEnsureCodexAppServerLaunchSpec,
+  mockGetCodexLaunchInfo,
+  mockGetResolvedCodexVersion,
+  mockExecuteLaunchSpec
+} = vi.hoisted(() => ({
+  mockEnsureCodexAppServerLaunchSpec: vi.fn(),
+  mockGetCodexLaunchInfo: vi.fn(),
+  mockGetResolvedCodexVersion: vi.fn(),
+  mockExecuteLaunchSpec: vi.fn()
+}))
 
-// Mock logger
 vi.mock('../../../src/main/services/logger', () => ({
   createLogger: () => ({
     info: vi.fn(),
@@ -18,303 +21,184 @@ vi.mock('../../../src/main/services/logger', () => ({
   })
 }))
 
-// Mock child_process — must provide default export for jsdom environment
-const mockExecFile = vi.fn()
-vi.mock('node:child_process', () => {
-  return {
-    default: { execFile: (...args: unknown[]) => mockExecFile(...args) },
-    execFile: (...args: unknown[]) => mockExecFile(...args)
-  }
-})
+vi.mock('../../../src/main/services/codex-binary-resolver', () => ({
+  ensureCodexAppServerLaunchSpec: mockEnsureCodexAppServerLaunchSpec,
+  getCodexLaunchInfo: mockGetCodexLaunchInfo,
+  getCodexVersion: mockGetResolvedCodexVersion
+}))
+
+vi.mock('../../../src/main/services/command-launch-utils', () => ({
+  executeLaunchSpec: mockExecuteLaunchSpec
+}))
 
 import {
-  parseVersionOutput,
-  parseAuthOutput,
-  getCodexVersion,
   checkCodexAuth,
-  checkCodexHealth
+  checkCodexHealth,
+  getCodexVersion,
+  parseAuthOutput,
+  parseVersionOutput
 } from '../../../src/main/services/codex-health'
 
 describe('codex-health', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockEnsureCodexAppServerLaunchSpec.mockResolvedValue({ command: 'codex', shell: false })
   })
 
-  // ── parseVersionOutput ─────────────────────────────────────────
-
   describe('parseVersionOutput', () => {
-    it('parses "codex 1.2.3" format', () => {
+    it('parses version strings with a codex prefix', () => {
       expect(parseVersionOutput('codex 1.2.3')).toBe('1.2.3')
-    })
-
-    it('parses "codex/1.2.3" format', () => {
       expect(parseVersionOutput('codex/1.2.3')).toBe('1.2.3')
     })
 
-    it('parses bare version "1.2.3"', () => {
+    it('parses bare and multiline version output', () => {
       expect(parseVersionOutput('1.2.3')).toBe('1.2.3')
-    })
-
-    it('parses version with trailing newline', () => {
-      expect(parseVersionOutput('codex 0.9.1\n')).toBe('0.9.1')
-    })
-
-    it('parses multiline output (takes first line)', () => {
       expect(parseVersionOutput('codex 2.0.0\nsome other info')).toBe('2.0.0')
     })
 
-    it('parses version with pre-release suffix', () => {
-      expect(parseVersionOutput('1.0.0-beta.1')).toBe('1.0.0-beta.1')
-    })
-
-    it('returns null for empty string', () => {
-      expect(parseVersionOutput('')).toBe(null)
-    })
-
-    it('returns null for whitespace-only string', () => {
-      expect(parseVersionOutput('   \n  ')).toBe(null)
-    })
-
-    it('returns raw first line for non-version output', () => {
+    it('returns null for empty output and falls back to the raw first line otherwise', () => {
+      expect(parseVersionOutput('')).toBeNull()
       expect(parseVersionOutput('something unexpected')).toBe('something unexpected')
     })
   })
 
-  // ── parseAuthOutput ────────────────────────────────────────────
-
   describe('parseAuthOutput', () => {
-    it('detects "not logged in" as unauthenticated', () => {
+    it('detects unauthenticated output patterns', () => {
       expect(parseAuthOutput('You are not logged in')).toBe('unauthenticated')
-    })
-
-    it('detects "login required" as unauthenticated', () => {
-      expect(parseAuthOutput('Login required to continue')).toBe('unauthenticated')
-    })
-
-    it('detects "run codex login" as unauthenticated', () => {
       expect(parseAuthOutput('Please run codex login first')).toBe('unauthenticated')
-    })
-
-    it('detects "unauthenticated" keyword as unauthenticated', () => {
       expect(parseAuthOutput('Status: unauthenticated')).toBe('unauthenticated')
     })
 
-    it('detects "not authenticated" as unauthenticated', () => {
-      expect(parseAuthOutput('User is not authenticated')).toBe('unauthenticated')
-    })
-
-    it('parses JSON with authenticated: true', () => {
+    it('detects structured JSON auth status', () => {
       expect(parseAuthOutput('{"authenticated": true}')).toBe('authenticated')
-    })
-
-    it('parses JSON with authenticated: false', () => {
-      expect(parseAuthOutput('{"authenticated": false}')).toBe('unauthenticated')
-    })
-
-    it('parses JSON with isAuthenticated: true', () => {
-      expect(parseAuthOutput('{"isAuthenticated": true}')).toBe('authenticated')
-    })
-
-    it('parses JSON with loggedIn: true', () => {
-      expect(parseAuthOutput('{"loggedIn": true}')).toBe('authenticated')
-    })
-
-    it('parses JSON with loggedIn: false', () => {
       expect(parseAuthOutput('{"loggedIn": false}')).toBe('unauthenticated')
     })
 
-    it('assumes authenticated for unknown text output', () => {
+    it('assumes authenticated when no failure signal is present', () => {
       expect(parseAuthOutput('Logged in as user@example.com')).toBe('authenticated')
     })
-
-    it('is case-insensitive for keyword matching', () => {
-      expect(parseAuthOutput('NOT LOGGED IN')).toBe('unauthenticated')
-    })
   })
-
-  // ── getCodexVersion ────────────────────────────────────────────
 
   describe('getCodexVersion', () => {
-    it('returns version string when codex is installed', async () => {
-      mockExecFile.mockImplementation(
-        (_cmd: string, _args: string[], _opts: unknown, cb: (...a: unknown[]) => void) => {
-          cb(null, 'codex 1.5.0\n')
-        }
-      )
+    it('delegates to the resolver-backed version lookup', async () => {
+      mockGetResolvedCodexVersion.mockResolvedValue('0.36.0')
 
-      const version = await getCodexVersion()
-      expect(version).toBe('1.5.0')
+      await expect(getCodexVersion({ command: 'codex', shell: false })).resolves.toBe('0.36.0')
+      expect(mockGetResolvedCodexVersion).toHaveBeenCalledWith({ command: 'codex', shell: false })
     })
 
-    it('returns null when codex is not installed', async () => {
-      mockExecFile.mockImplementation(
-        (_cmd: string, _args: string[], _opts: unknown, cb: (...a: unknown[]) => void) => {
-          cb(new Error('command not found'))
-        }
-      )
+    it('returns null when resolver-backed version lookup throws', async () => {
+      mockGetResolvedCodexVersion.mockRejectedValue(new Error('boom'))
 
-      const version = await getCodexVersion()
-      expect(version).toBe(null)
-    })
-
-    it('returns null on timeout', async () => {
-      mockExecFile.mockImplementation(
-        (_cmd: string, _args: string[], _opts: unknown, cb: (...a: unknown[]) => void) => {
-          cb(new Error('ETIMEDOUT'))
-        }
-      )
-
-      const version = await getCodexVersion()
-      expect(version).toBe(null)
-    })
-
-    it('calls codex with --version flag', async () => {
-      mockExecFile.mockImplementation(
-        (_cmd: string, _args: string[], _opts: unknown, cb: (...a: unknown[]) => void) => {
-          cb(null, '1.0.0')
-        }
-      )
-
-      await getCodexVersion()
-      expect(mockExecFile).toHaveBeenCalledWith(
-        'codex',
-        ['--version'],
-        expect.objectContaining({ timeout: 5000 }),
-        expect.any(Function)
-      )
+      await expect(getCodexVersion()).resolves.toBeNull()
     })
   })
-
-  // ── checkCodexAuth ─────────────────────────────────────────────
 
   describe('checkCodexAuth', () => {
-    it('returns authenticated when logged in', async () => {
-      mockExecFile.mockImplementation(
-        (_cmd: string, _args: string[], _opts: unknown, cb: (...a: unknown[]) => void) => {
-          cb(null, '{"authenticated": true}')
-        }
-      )
+    it('uses the provided launch spec when available', async () => {
+      mockExecuteLaunchSpec.mockResolvedValue({
+        stdout: '{"authenticated": true}',
+        stderr: ''
+      })
 
-      const status = await checkCodexAuth()
-      expect(status).toBe('authenticated')
+      await expect(checkCodexAuth({ command: 'codex', shell: false })).resolves.toBe(
+        'authenticated'
+      )
+      expect(mockEnsureCodexAppServerLaunchSpec).not.toHaveBeenCalled()
+      expect(mockExecuteLaunchSpec).toHaveBeenCalledWith({ command: 'codex', shell: false }, [
+        'login',
+        'status'
+      ])
     })
 
-    it('returns unauthenticated when not logged in', async () => {
-      mockExecFile.mockImplementation(
-        (_cmd: string, _args: string[], _opts: unknown, cb: (...a: unknown[]) => void) => {
-          cb(null, 'You are not logged in. Run codex login.')
-        }
-      )
+    it('returns unknown when the auth probe fails', async () => {
+      mockExecuteLaunchSpec.mockRejectedValue(new Error('command failed'))
 
-      const status = await checkCodexAuth()
-      expect(status).toBe('unauthenticated')
-    })
-
-    it('returns unknown when command fails', async () => {
-      mockExecFile.mockImplementation(
-        (_cmd: string, _args: string[], _opts: unknown, cb: (...a: unknown[]) => void) => {
-          cb(new Error('command not found'))
-        }
-      )
-
-      const status = await checkCodexAuth()
-      expect(status).toBe('unknown')
-    })
-
-    it('calls codex with login status args', async () => {
-      mockExecFile.mockImplementation(
-        (_cmd: string, _args: string[], _opts: unknown, cb: (...a: unknown[]) => void) => {
-          cb(null, 'ok')
-        }
-      )
-
-      await checkCodexAuth()
-      expect(mockExecFile).toHaveBeenCalledWith(
-        'codex',
-        ['login', 'status'],
-        expect.objectContaining({ timeout: 5000 }),
-        expect.any(Function)
-      )
+      await expect(checkCodexAuth()).resolves.toBe('unknown')
+      expect(mockEnsureCodexAppServerLaunchSpec).toHaveBeenCalledTimes(1)
     })
   })
 
-  // ── checkCodexHealth ───────────────────────────────────────────
-
   describe('checkCodexHealth', () => {
-    it('returns unavailable when codex is not installed', async () => {
-      mockExecFile.mockImplementation(
-        (_cmd: string, _args: string[], _opts: unknown, cb: (...a: unknown[]) => void) => {
-          cb(new Error('command not found'))
-        }
-      )
+    it('returns unavailable when the codex CLI cannot be resolved', async () => {
+      mockGetCodexLaunchInfo.mockResolvedValue({
+        spec: null,
+        version: null,
+        supportsAppServer: false
+      })
 
-      const health = await checkCodexHealth()
-      expect(health.available).toBe(false)
-      expect(health.authStatus).toBe('unknown')
-      expect(health.message).toContain('not found')
+      await expect(checkCodexHealth()).resolves.toEqual({
+        available: false,
+        authStatus: 'unknown',
+        message: 'Codex CLI not found. Install it with: npm install -g @openai/codex'
+      })
     })
 
-    it('returns available with auth status when codex is installed', async () => {
-      mockExecFile.mockImplementation(
-        (_cmd: string, args: string[], _opts: unknown, cb: (...a: unknown[]) => void) => {
-          if (args[0] === '--version') {
-            cb(null, 'codex 1.0.0\n')
-          } else if (args[0] === 'login') {
-            cb(null, '{"authenticated": true}')
-          }
-        }
-      )
+    it('returns unavailable when codex lacks app-server capability', async () => {
+      mockGetCodexLaunchInfo.mockResolvedValue({
+        spec: { command: 'codex', shell: false },
+        version: '0.20.0',
+        supportsAppServer: false
+      })
 
-      const health = await checkCodexHealth()
-      expect(health.available).toBe(true)
-      expect(health.version).toBe('1.0.0')
-      expect(health.authStatus).toBe('authenticated')
-      expect(health.message).toBeUndefined()
+      await expect(checkCodexHealth()).resolves.toEqual({
+        available: false,
+        version: '0.20.0',
+        authStatus: 'unknown',
+        message: 'Codex CLI 0.20.0 does not support codex app-server. Upgrade @openai/codex.'
+      })
     })
 
-    it('returns unauthenticated message when not logged in', async () => {
-      mockExecFile.mockImplementation(
-        (_cmd: string, args: string[], _opts: unknown, cb: (...a: unknown[]) => void) => {
-          if (args[0] === '--version') {
-            cb(null, 'codex 1.0.0\n')
-          } else if (args[0] === 'login') {
-            cb(null, 'not logged in')
-          }
-        }
-      )
+    it('returns available with authenticated status when auth succeeds', async () => {
+      mockGetCodexLaunchInfo.mockResolvedValue({
+        spec: { command: 'codex', shell: false },
+        version: '0.36.0',
+        supportsAppServer: true
+      })
+      mockExecuteLaunchSpec.mockResolvedValue({
+        stdout: '{"authenticated": true}',
+        stderr: ''
+      })
 
-      const health = await checkCodexHealth()
-      expect(health.available).toBe(true)
-      expect(health.authStatus).toBe('unauthenticated')
-      expect(health.message).toContain('codex login')
+      await expect(checkCodexHealth()).resolves.toEqual({
+        available: true,
+        version: '0.36.0',
+        authStatus: 'authenticated'
+      })
     })
 
-    it('skips auth check when checkAuth is false', async () => {
-      mockExecFile.mockImplementation(
-        (_cmd: string, args: string[], _opts: unknown, cb: (...a: unknown[]) => void) => {
-          if (args[0] === '--version') {
-            cb(null, 'codex 1.0.0\n')
-          } else {
-            cb(new Error('should not be called'))
-          }
-        }
-      )
+    it('includes a login hint when auth fails', async () => {
+      mockGetCodexLaunchInfo.mockResolvedValue({
+        spec: { command: 'codex', shell: false },
+        version: '0.36.0',
+        supportsAppServer: true
+      })
+      mockExecuteLaunchSpec.mockResolvedValue({
+        stdout: 'not logged in',
+        stderr: ''
+      })
 
-      const health = await checkCodexHealth({ checkAuth: false })
-      expect(health.available).toBe(true)
-      expect(health.authStatus).toBe('unknown')
+      await expect(checkCodexHealth()).resolves.toEqual({
+        available: true,
+        version: '0.36.0',
+        authStatus: 'unauthenticated',
+        message: 'Codex CLI is not authenticated. Run: codex login'
+      })
     })
 
-    it('health status has correct shape', async () => {
-      mockExecFile.mockImplementation(
-        (_cmd: string, _args: string[], _opts: unknown, cb: (...a: unknown[]) => void) => {
-          cb(new Error('not found'))
-        }
-      )
+    it('skips the auth probe when explicitly requested', async () => {
+      mockGetCodexLaunchInfo.mockResolvedValue({
+        spec: { command: 'codex', shell: false },
+        version: '0.36.0',
+        supportsAppServer: true
+      })
 
-      const health = await checkCodexHealth()
-      expect(health).toHaveProperty('available')
-      expect(health).toHaveProperty('authStatus')
+      await expect(checkCodexHealth({ checkAuth: false })).resolves.toEqual({
+        available: true,
+        version: '0.36.0',
+        authStatus: 'unknown'
+      })
+      expect(mockExecuteLaunchSpec).not.toHaveBeenCalled()
     })
   })
 })

--- a/test/phase-22/session-3/codex-implementer-skeleton.test.ts
+++ b/test/phase-22/session-3/codex-implementer-skeleton.test.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { EventEmitter } from 'node:events'
 
 // Mock logger
 vi.mock('../../../src/main/services/logger', () => ({
@@ -12,7 +13,7 @@ vi.mock('../../../src/main/services/logger', () => ({
 }))
 
 import { CodexImplementer } from '../../../src/main/services/codex-implementer'
-import { CODEX_CAPABILITIES } from '../../../src/main/services/agent-sdk-types'
+import { CODEX_CAPABILITIES } from '../../../src/main/services/agent-runtime-types'
 import { CODEX_DEFAULT_MODEL } from '../../../src/main/services/codex-models'
 
 describe('CodexImplementer skeleton', () => {
@@ -152,9 +153,7 @@ describe('CodexImplementer skeleton', () => {
 
   describe('implemented messaging methods', () => {
     it('prompt throws when session not found', async () => {
-      await expect(impl.prompt('/path', 'session-1', 'hello')).rejects.toThrow(
-        'session not found'
-      )
+      await expect(impl.prompt('/path', 'session-1', 'hello')).rejects.toThrow('session not found')
     })
 
     it('abort returns false for unknown session', async () => {
@@ -178,9 +177,7 @@ describe('CodexImplementer skeleton', () => {
     })
 
     it('renameSession does not throw without dbService', async () => {
-      await expect(
-        impl.renameSession('/path', 'session-1', 'new name')
-      ).resolves.not.toThrow()
+      await expect(impl.renameSession('/path', 'session-1', 'new name')).resolves.not.toThrow()
     })
   })
 
@@ -211,13 +208,91 @@ describe('CodexImplementer skeleton', () => {
     })
   })
 
+  describe('turn timeout handling', () => {
+    beforeEach(() => {
+      vi.useFakeTimers()
+    })
+
+    afterEach(() => {
+      vi.useRealTimers()
+    })
+
+    it('times out after the budget when there is no pending HITL request', async () => {
+      ;(impl as any).manager = new EventEmitter()
+
+      const promise = (impl as any).waitForTurnCompletion(
+        { threadId: 'thread-1' },
+        () => false,
+        1000
+      ) as Promise<void>
+
+      const outcome = promise.then(
+        () => 'resolved',
+        (error) => error
+      )
+
+      await vi.advanceTimersByTimeAsync(1000)
+
+      const error = await outcome
+      expect(error).toBeInstanceOf(Error)
+      expect((error as Error).message).toBe('Turn timed out')
+    })
+
+    it('pauses timeout consumption while HITL is pending and resumes with the remaining budget', async () => {
+      const manager = new EventEmitter()
+      ;(impl as any).manager = manager
+
+      const promise = (impl as any).waitForTurnCompletion(
+        { threadId: 'thread-1' },
+        () => false,
+        1000
+      ) as Promise<void>
+      const outcome = promise.then(
+        () => 'resolved',
+        (error) => error
+      )
+
+      let settled = false
+      void outcome.finally(() => {
+        settled = true
+      })
+
+      await vi.advanceTimersByTimeAsync(400)
+      impl.getPendingQuestions().set('req-1', {
+        threadId: 'thread-1',
+        hiveSessionId: 'hive-1',
+        worktreePath: '/tmp/project'
+      })
+      manager.emit('event', {
+        threadId: 'thread-1',
+        kind: 'request',
+        method: 'question.asked'
+      })
+
+      await vi.advanceTimersByTimeAsync(5000)
+      expect(settled).toBe(false)
+
+      impl.getPendingQuestions().clear()
+      manager.emit('event', {
+        threadId: 'thread-1',
+        method: 'item/tool/requestUserInput/answered'
+      })
+
+      await vi.advanceTimersByTimeAsync(599)
+      expect(settled).toBe(false)
+
+      await vi.advanceTimersByTimeAsync(1)
+      const error = await outcome
+      expect(error).toBeInstanceOf(Error)
+      expect((error as Error).message).toBe('Turn timed out')
+    })
+  })
+
   // ── Unimplemented undo/redo methods throw ──────────────────────
 
   describe('undo/redo methods', () => {
     it('undo throws for unknown session', async () => {
-      await expect(impl.undo('/path', 'session-1', 'hive-1')).rejects.toThrow(
-        'session not found'
-      )
+      await expect(impl.undo('/path', 'session-1', 'hive-1')).rejects.toThrow('session not found')
     })
 
     it('redo throws unsupported', async () => {

--- a/test/phase-22/session-5/codex-prompt-streaming.test.ts
+++ b/test/phase-22/session-5/codex-prompt-streaming.test.ts
@@ -338,10 +338,10 @@ describe('CodexImplementer.prompt()', () => {
 
     const mockDb = {
       updateSession: vi.fn(),
-      getSession: vi
-        .fn()
-        .mockReturnValueOnce({ id: 'hive-session-1', name: 'Fix auth token refresh bug' })
-        .mockReturnValueOnce({ id: 'hive-session-1', name: 'Auth refresh fix' }),
+      getSession: vi.fn().mockReturnValue({
+        id: 'hive-session-1',
+        name: 'Fix auth token refresh bug'
+      }),
       getWorktreeBySessionId: vi.fn().mockReturnValue(null)
     }
     impl.setDatabaseService(mockDb as any)
@@ -375,24 +375,23 @@ describe('CodexImplementer.prompt()', () => {
       .map((c: any[]) => c[1])
       .filter((e: any) => e.type === 'session.updated')
 
-    expect(streamCalls).toEqual([
-      {
-        type: 'session.updated',
-        sessionId: 'hive-session-1',
-        data: {
-          title: 'Fix auth token refresh bug',
-          info: { title: 'Fix auth token refresh bug' }
-        }
-      },
-      {
-        type: 'session.updated',
-        sessionId: 'hive-session-1',
-        data: {
-          title: 'Auth refresh fix',
-          info: { title: 'Auth refresh fix' }
-        }
+    expect(streamCalls).toHaveLength(2)
+    expect(streamCalls[0]).toMatchObject({
+      type: 'session.updated',
+      sessionId: 'hive-session-1',
+      data: {
+        title: 'Fix auth token refresh bug',
+        info: { title: 'Fix auth token refresh bug' }
       }
-    ])
+    })
+    expect(streamCalls[1]).toMatchObject({
+      type: 'session.updated',
+      sessionId: 'hive-session-1',
+      data: {
+        title: 'Auth refresh fix',
+        info: { title: 'Auth refresh fix' }
+      }
+    })
   })
 
   it('starts title generation only once per session', async () => {

--- a/test/settings-i18n.test.tsx
+++ b/test/settings-i18n.test.tsx
@@ -91,6 +91,7 @@ describe('Settings i18n', () => {
       showModelIcons: false,
       showModelProvider: false,
       showUsageIndicator: true,
+      keepAwakeEnabled: true,
       defaultAgentSdk: 'opencode',
       updateChannel: 'stable',
       stripAtMentions: true,
@@ -120,6 +121,7 @@ describe('Settings i18n', () => {
     expect(screen.getByText('通用')).toBeInTheDocument()
     expect(screen.getByText('语言')).toBeInTheDocument()
     expect(screen.getByText('AI 提供方')).toBeInTheDocument()
+    expect(screen.getByText('会话期间保持唤醒')).toBeInTheDocument()
     expect(screen.getByText('分支命名')).toBeInTheDocument()
     expect(screen.getByTestId('reset-all-settings')).toHaveTextContent('重置全部设置')
   })

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -112,6 +112,18 @@ if (typeof window !== 'undefined') {
         getAppPaths: vi.fn().mockResolvedValue({ userData: '/tmp', home: '/tmp', logs: '/tmp' }),
         isLogMode: vi.fn().mockResolvedValue(false),
         detectAgentSdks: vi.fn().mockResolvedValue({ opencode: true, claude: true, codex: false }),
+        detectAgentRuntimes: vi.fn().mockResolvedValue({
+          opencode: true,
+          claude: true,
+          codex: false
+        }),
+        setKeepAwakeEnabled: vi.fn().mockResolvedValue({ success: true }),
+        runOnboardingDoctor: vi.fn().mockResolvedValue({
+          platform: 'darwin',
+          environmentChecks: [],
+          agents: [],
+          recommendedAgent: 'terminal'
+        }),
         quitApp: vi.fn().mockResolvedValue(undefined),
         openInApp: vi.fn().mockResolvedValue({ success: true }),
         openInChrome: vi.fn().mockResolvedValue({ success: true }),


### PR DESCRIPTION
## Summary

- 按“行为迁移 / 本地重写”方式迁入 Hive 上游与运行时稳定性相关的一组改动，不做 cherry-pick。
- 明确保留 Xuanpu 现有 headless / GraphQL server 能力，不实施 `#353` 的 server / GraphQL 删除方案。
- 本 PR 覆盖运行时启动链路、SDK capability 探测、HITL 阻塞与通知、keep-awake、merge-base branch compare、Windows 启动兜底，以及验证过程中发现的 server schema / file write 兼容问题。

## Upstream Scope

本 PR 对应并吸收的上游主题主要包括：

- `#393`、`#395`、`#405`：Windows / OpenCode / Codex 启动链路与 capability probe
- `#424`、`#378`：会话等待用户反馈通知、Codex HITL timeout pause
- `#422`、`#318`、`#340`：keep-awake、merge-base branch diff、Windows 启动 fallback

明确不包含：

- `#353`：不删除 Xuanpu 的 headless / GraphQL server 栈
- 可选增强项 `#390`、`#388`、`#289`：本 PR 未实现

## What Changed

### 1. Runtime startup and capability detection

- 将 `systemDetectAgentSdks` / `window.systemOps.detectAgentRuntimes()` 背后的实现切换为异步 capability probe。
- 新增独立的命令解析与 launch spec 层：
  - `src/main/services/command-launch-utils.ts`
  - `src/main/services/opencode-binary-resolver.ts`
  - `src/main/services/codex-binary-resolver.ts`
- OpenCode 启动链路现在支持：
  - Windows `.exe` / `.cmd` 解析
  - 带空格路径
  - `CRLF` / `LF` 启动输出解析
  - Windows shell 场景下完整进程树回收
- Codex 启动链路现在以 `codex app-server --help` capability 作为硬门槛：
  - 不再只靠 `which/where + existsSync`
  - 将解析到的路径、版本和 capability 结果纳入日志
  - 不支持 `app-server` 时快速失败，不再长时间挂在“连接中”
- `OnboardingDoctor`、桌面 IPC 和 headless GraphQL 查询现在复用同一套 runtime detection 逻辑，避免 GUI 与 headless 检测结果漂移。

### 2. HITL blocking semantics and user-feedback notifications

- `NotificationService` 新增“等待用户反馈”通知路径，区分：
  - `question`
  - `approval`
- Claude / Codex / OpenCode 在真正进入等待用户输入或授权时触发通知。
- 这类通知不受普通 queued follow-up 抑制，因为它们表示会话被用户反馈阻塞。
- Codex 的 `waitForTurnCompletion()` 现在支持 timeout pause：
  - 默认 5 分钟预算保留
  - 进入 pending question / permission 阶段后暂停计时
  - HITL 清理后从剩余预算继续计时
- Pending HITL 的进入与清理点已固定在 request / reply / reject / turn complete / session close / process exit 这些生命周期事件上。

### 3. Keep-awake support and session status UX

- 新增 `keepAwakeEnabled` 设置项并持久化。
- 主进程新增幂等 `powerSaveBlocker` 服务，只在需要时持有 `prevent-display-sleep`。
- renderer 新增 `useKeepAwake()` hook，根据全局 session status 聚合结果驱动 blocker。
- keep-awake 只对 `planning` / `working` 生效；`permission`、`command_approval`、`answering`、`completed`、`plan_ready` 不持有 blocker。
- Header 新增 keep-awake 状态指示器，设置页和文案已补齐 i18n。
- 顺手修复了 Header keep-awake 指示器不会随 status 实时刷新的问题。

### 4. Branch compare correctness via merge-base

- `GitService.getBranchDiffFiles()` 和 `GitService.getBranchFileDiff()` 改为相对 `merge-base` 比较，而不是直接相对 branch tip。
- 新增 Electron IPC / preload 接口：
  - merge-base 文本内容读取
  - merge-base base64 内容读取
- `MonacoDiffView` 与 `ImageDiffView` 在 `compareBranch` 模式下改为读取 merge-base 原始内容，消除 diverged branch 下的“伪回滚”视觉噪音。
- `merge-base` 解析失败时保留 fallback，并记录 warning log。

### 5. Windows startup fallback and diagnostics

- 仅 Windows 启用：`ready-to-show` 3 秒未触发时强制 `show()`。
- 补充：
  - `did-fail-load`
  - `render-process-gone`
  - `unresponsive`
  - `app.whenReady().catch(...)`
  等主进程诊断日志。

### 6. Headless / GraphQL compatibility follow-up fixes

在验证本轮改动时，顺手修复了两类原本已存在、但会阻塞本分支交付的问题：

- 补回 legacy `OpenCode*Result` GraphQL result type 兼容壳，恢复现有 headless schema 的可执行性。
- 修正 `fileWrite` 语义：当父目录存在时允许创建新文件，而不再只允许覆写已存在文件。

这两处修复都不改变“保留 headless 栈”的主方向，反而加强了当前 headless 能力的可用性和回归护栏。

## Verification

已完成的验证包括：

- `pnpm lint`
  - 通过；仓库内仍有既有 warnings，但无 error
- `pnpm build`
- 受影响的 Phase 1-3 定向测试
  - 12 个测试文件，124 个用例通过
- headless / server 基础验证
  - `test/server/config.test.ts`
  - `test/server/tls.test.ts`
- headless GraphQL 主集成验证
  - `test/server/integration/operations.test.ts` 48/48 通过

## Notes

- 本 PR 明确保留 headless / GraphQL server，`EventBus` 与相关 server bootstrap 不做删除。
- `detectAgentRuntimes()` 对外仍然保持布尔结果形状，没有引入新的 renderer 诊断面板；更细粒度的路径 / 版本 / capability 信息只进入日志。
- Codex capability gate 本次采用 capability-based admission，不引入硬编码最低 semver。
