### PR TITLE
feat: 会话级服务商/模型选择 + 首条消息后锁定

### DIFF
--- a/src/main/db/database.ts
+++ b/src/main/db/database.ts
@@ -200,6 +200,8 @@ export class DatabaseService {
     this.safeAddColumn('worktrees', 'context', 'TEXT DEFAULT NULL')
     this.safeAddColumn('worktrees', 'github_pr_number', 'INTEGER DEFAULT NULL')
     this.safeAddColumn('worktrees', 'github_pr_url', 'TEXT DEFAULT NULL')
+    this.safeAddColumn('worktrees', 'last_agent_sdk', 'TEXT DEFAULT NULL')
+    this.safeAddColumn('sessions', 'first_message_at', 'INTEGER DEFAULT NULL')
     this.safeAddColumn('connections', 'pinned', 'INTEGER NOT NULL DEFAULT 0')
 
     db.exec(`
@@ -1330,6 +1332,13 @@ export class DatabaseService {
     )
 
     db.prepare('UPDATE sessions SET updated_at = ? WHERE id = ?').run(now, data.session_id)
+
+    // Mark the session as locked once the first activity lands. This freezes the
+    // agent_sdk + model so a user can no longer change them mid-conversation.
+    // The UPDATE is a no-op after the first hit thanks to the WHERE clause.
+    db.prepare(
+      'UPDATE sessions SET first_message_at = ? WHERE id = ? AND first_message_at IS NULL'
+    ).run(Date.now(), data.session_id)
 
     const row = db.prepare('SELECT * FROM session_activities WHERE id = ?').get(id) as
       | SessionActivity

--- a/src/main/db/schema.ts
+++ b/src/main/db/schema.ts
@@ -1,4 +1,4 @@
-export const CURRENT_SCHEMA_VERSION = 13
+export const CURRENT_SCHEMA_VERSION = 14
 
 export const SCHEMA_SQL = `
 -- Projects table
@@ -34,6 +34,7 @@ CREATE TABLE IF NOT EXISTS worktrees (
   last_model_provider_id TEXT,
   last_model_id TEXT,
   last_model_variant TEXT,
+  last_agent_sdk TEXT DEFAULT NULL,
   attachments TEXT DEFAULT '[]',
   pinned INTEGER NOT NULL DEFAULT 0,
   context TEXT DEFAULT NULL,
@@ -57,6 +58,7 @@ CREATE TABLE IF NOT EXISTS sessions (
   model_id TEXT,
   model_variant TEXT,
   color TEXT DEFAULT NULL,
+  first_message_at INTEGER DEFAULT NULL,
   created_at TEXT NOT NULL,
   updated_at TEXT NOT NULL,
   completed_at TEXT
@@ -431,6 +433,22 @@ export const MIGRATIONS: Migration[] = [
     name: 'add_session_color',
     up: `-- NOTE: ALTER TABLE for color is handled idempotently by
          -- ensureSessionColumns() in database.ts to avoid "duplicate column" errors.`,
+    down: `-- SQLite cannot drop columns; this is a no-op for safety`
+  },
+  {
+    version: 14,
+    name: 'add_session_level_provider_lock',
+    // NOTE: ALTER TABLE for sessions.first_message_at and worktrees.last_agent_sdk
+    // is handled idempotently by ensureConnectionTables() in database.ts via
+    // safeAddColumn(). This migration also backfills first_message_at for any
+    // historical sessions that already have activity, locking them so the
+    // provider/model can no longer be changed mid-conversation.
+    up: `
+      UPDATE sessions
+         SET first_message_at = CAST((julianday(created_at) - 2440587.5) * 86400000 AS INTEGER)
+       WHERE first_message_at IS NULL
+         AND id IN (SELECT DISTINCT session_id FROM session_activities);
+    `,
     down: `-- SQLite cannot drop columns; this is a no-op for safety`
   }
 ]

--- a/src/main/db/types.ts
+++ b/src/main/db/types.ts
@@ -52,6 +52,7 @@ export interface Worktree {
   last_model_provider_id: string | null
   last_model_id: string | null
   last_model_variant: string | null
+  last_agent_sdk: 'opencode' | 'claude-code' | 'codex' | 'terminal' | null
   attachments: string // JSON array of Attachment objects
   pinned: number // 0 = not pinned, 1 = pinned
   context: string | null
@@ -78,6 +79,7 @@ export interface WorktreeUpdate {
   last_model_provider_id?: string | null
   last_model_id?: string | null
   last_model_variant?: string | null
+  last_agent_sdk?: 'opencode' | 'claude-code' | 'codex' | 'terminal' | null
   pinned?: number
   github_pr_number?: number | null
   github_pr_url?: string | null
@@ -99,6 +101,7 @@ export interface Session {
   model_provider_id: string | null
   model_id: string | null
   model_variant: string | null
+  first_message_at: number | null
   created_at: string
   updated_at: string
   completed_at: string | null
@@ -126,6 +129,7 @@ export interface SessionUpdate {
   model_id?: string | null
   model_variant?: string | null
   color?: string | null
+  first_message_at?: number | null
   updated_at?: string
   completed_at?: string | null
 }

--- a/src/main/ipc/agent-handlers.ts
+++ b/src/main/ipc/agent-handlers.ts
@@ -47,6 +47,13 @@ const log = createLogger({ component: 'AgentHandlers' })
 // when the ID changes.
 const injectedWorktrees = new Set<string>()
 
+// Dedupe concurrent agent:connect calls per hive session. React StrictMode
+// double-invokes the renderer effect in dev, and stray callers may also retry —
+// without dedupe each call spins up a fresh runtime session (e.g. an extra
+// Codex thread) that nobody owns. The entry is cleared once the connect
+// settles so genuine reconnects after teardown still work.
+const inflightConnects = new Map<string, Promise<{ sessionId: string }>>()
+
 export function registerAgentHandlers(
   mainWindow: BrowserWindow,
   runtimeManager?: AgentRuntimeManager,
@@ -82,9 +89,45 @@ export function registerAgentHandlers(
           return { sessionId: hiveSessionId }
         }
         const impl = c.runtimeManager.getImplementer(runtimeId)
-        const result = await impl.connect(worktreePath, hiveSessionId)
-        telemetryService.track('session_started', { runtime_id: runtimeId })
-        return { ...result }
+
+        // Dedupe concurrent connects for the same hive session so StrictMode
+        // double-mount doesn't create duplicate runtime sessions.
+        const existing = inflightConnects.get(hiveSessionId)
+        if (existing) {
+          log.info('IPC: agent:connect reusing in-flight connect', { hiveSessionId })
+          const reused = await existing
+          return { ...reused }
+        }
+
+        const connectPromise = (async () => {
+          const result = await impl.connect(worktreePath, hiveSessionId)
+          // Persist opencode_session_id atomically in the main process so
+          // resolveRuntimeId() can route subsequent prompts/reconnects without
+          // depending on the renderer winning a state race.
+          if (result?.sessionId && result.sessionId !== hiveSessionId) {
+            try {
+              c.dbService.updateSession(hiveSessionId, {
+                opencode_session_id: result.sessionId
+              })
+            } catch (err) {
+              log.warn('Failed to persist opencode_session_id after connect', {
+                hiveSessionId,
+                runtimeSessionId: result.sessionId,
+                error: err instanceof Error ? err.message : String(err)
+              })
+            }
+          }
+          return result
+        })()
+
+        inflightConnects.set(hiveSessionId, connectPromise)
+        try {
+          const result = await connectPromise
+          telemetryService.track('session_started', { runtime_id: runtimeId })
+          return { ...result }
+        } finally {
+          inflightConnects.delete(hiveSessionId)
+        }
       }
     })
   )

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -60,6 +60,7 @@ interface Worktree {
   last_model_provider_id: string | null
   last_model_id: string | null
   last_model_variant: string | null
+  last_agent_sdk: 'opencode' | 'claude-code' | 'codex' | 'terminal' | null
   attachments: string // JSON array of Attachment objects
   pinned: number // 0 = not pinned, 1 = pinned
   context: string | null
@@ -82,6 +83,7 @@ interface Session {
   model_provider_id: string | null
   model_id: string | null
   model_variant: string | null
+  first_message_at: number | null
   created_at: string
   updated_at: string
   completed_at: string | null
@@ -271,6 +273,7 @@ declare global {
             status?: 'active' | 'archived'
             last_message_at?: number | null
             last_accessed_at?: string
+            last_agent_sdk?: 'opencode' | 'claude-code' | 'codex' | 'terminal' | null
           }
         ) => Promise<Worktree | null>
         delete: (id: string) => Promise<boolean>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -71,7 +71,12 @@ const db = {
       ipcRenderer.invoke('db:worktree:getRecentlyActive', cutoffMs),
     update: (
       id: string,
-      data: { name?: string; status?: 'active' | 'archived'; last_accessed_at?: string }
+      data: {
+        name?: string
+        status?: 'active' | 'archived'
+        last_accessed_at?: string
+        last_agent_sdk?: 'opencode' | 'claude-code' | 'codex' | 'terminal' | null
+      }
     ) => ipcRenderer.invoke('db:worktree:update', id, data),
     delete: (id: string) => ipcRenderer.invoke('db:worktree:delete', id),
     archive: (id: string) => ipcRenderer.invoke('db:worktree:archive', id),

--- a/src/renderer/src/components/session-hq/SessionHeader.tsx
+++ b/src/renderer/src/components/session-hq/SessionHeader.tsx
@@ -5,7 +5,8 @@
  * Right: context capsule │ cost capsule
  */
 
-import { DollarSign, Clock3, Layers3, TriangleAlert } from 'lucide-react'
+import { useMemo, useState } from 'react'
+import { DollarSign, Clock3, Layers3, TriangleAlert, Lock, TerminalSquare, Check } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { ModelSelector } from '../sessions/ModelSelector'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
@@ -18,9 +19,15 @@ import {
 } from '@/components/ui/popover'
 import { useShallow } from 'zustand/react/shallow'
 import { useContextStore } from '@/stores/useContextStore'
+import { useSettingsStore } from '@/stores/useSettingsStore'
+import { useSessionStore } from '@/stores/useSessionStore'
+import { useI18n } from '@/i18n/useI18n'
+import { toast } from '@/lib/toast'
 import type { SessionLifecycle } from '@/stores/useSessionRuntimeStore'
 import type { UsageAnalyticsSessionSummary } from '@shared/types/usage-analytics'
 import { formatModelLabelSummary, getSessionSummaryModelLabels } from '@/lib/model-labels'
+
+type AgentSdk = 'opencode' | 'claude-code' | 'codex' | 'terminal'
 
 const PROVIDER_LABELS: Record<string, string> = {
   'claude-code': 'Claude',
@@ -68,20 +75,104 @@ function getBarColor(percent: number): string {
 }
 
 function ProviderCapsule({
+  sessionId,
   sdk,
-  lifecycle
+  lifecycle,
+  locked
 }: {
+  sessionId: string
   sdk: string
   lifecycle: SessionLifecycle
+  locked: boolean
 }): React.JSX.Element {
+  const { t } = useI18n()
   const label = PROVIDER_LABELS[sdk] ?? sdk
   const meta = LIFECYCLE_META[lifecycle] ?? LIFECYCLE_META.idle
+  const availableAgentSdks = useSettingsStore((s) => s.availableAgentSdks)
+  const [open, setOpen] = useState(false)
+
+  const enabledSdks = useMemo<AgentSdk[]>(() => {
+    const list: AgentSdk[] = []
+    if (availableAgentSdks?.opencode) list.push('opencode')
+    if (availableAgentSdks?.claude) list.push('claude-code')
+    if (availableAgentSdks?.codex) list.push('codex')
+    list.push('terminal')
+    return list
+  }, [availableAgentSdks])
+
+  if (locked) {
+    return (
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span
+            className="inline-flex items-center gap-1.5 border border-border/40 rounded-md px-2 py-1 text-[11px] font-medium text-muted-foreground cursor-default"
+            data-testid="provider-capsule-locked"
+          >
+            <span className={cn('h-1.5 w-1.5 rounded-full', meta.dotClass)} />
+            {label}
+            <Lock className="h-3 w-3 opacity-70" />
+          </span>
+        </TooltipTrigger>
+        <TooltipContent side="bottom" sideOffset={6} className="max-w-[240px]">
+          <div className="space-y-1">
+            <div className="font-medium text-[11px]">{t('newSessionDialog.lock.header')}</div>
+            <div className="text-[10px] opacity-80">{t('newSessionDialog.lock.description')}</div>
+          </div>
+        </TooltipContent>
+      </Tooltip>
+    )
+  }
+
+  async function handleSelectSdk(next: AgentSdk): Promise<void> {
+    setOpen(false)
+    if (next === sdk) return
+    const result = await useSessionStore.getState().updateSessionAgent(sessionId, {
+      agentSdk: next
+    })
+    if (!result.success) {
+      toast.error(result.error || 'Failed to update provider')
+    }
+  }
 
   return (
-    <span className="inline-flex items-center gap-1.5 border border-border/40 rounded-md px-2 py-1 text-[11px] font-medium text-muted-foreground">
-      <span className={cn('h-1.5 w-1.5 rounded-full', meta.dotClass)} />
-      {label}
-    </span>
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          className="inline-flex items-center gap-1.5 border border-border/40 rounded-md px-2 py-1 text-[11px] font-medium text-muted-foreground hover:bg-muted/40 hover:text-foreground transition-colors cursor-pointer"
+          data-testid="provider-capsule"
+        >
+          <span className={cn('h-1.5 w-1.5 rounded-full', meta.dotClass)} />
+          {label}
+        </button>
+      </PopoverTrigger>
+      <PopoverContent align="start" className="w-44 p-1">
+        {enabledSdks.map((s) => {
+          const active = s === sdk
+          return (
+            <button
+              key={s}
+              type="button"
+              onClick={() => {
+                void handleSelectSdk(s)
+              }}
+              className={cn(
+                'flex w-full items-center justify-between gap-2 rounded-md px-2 py-1.5 text-xs transition-colors',
+                active
+                  ? 'bg-primary/10 text-primary'
+                  : 'text-foreground hover:bg-muted/60'
+              )}
+            >
+              <span className="flex items-center gap-1.5">
+                {s === 'terminal' && <TerminalSquare className="h-3.5 w-3.5 text-emerald-500" />}
+                {PROVIDER_LABELS[s] ?? s}
+              </span>
+              {active && <Check className="h-3.5 w-3.5" />}
+            </button>
+          )
+        })}
+      </PopoverContent>
+    </Popover>
   )
 }
 
@@ -297,6 +388,7 @@ export interface SessionHeaderProps {
     agent_sdk: string
     model_id: string | null
     model_provider_id: string | null
+    first_message_at?: number | null
   }
   lifecycle: SessionLifecycle
   modelId?: string
@@ -318,11 +410,25 @@ export function SessionHeader({
 }: SessionHeaderProps): React.JSX.Element {
   const effectiveModelId = modelId ?? session.model_id ?? ''
   const effectiveProviderId = providerId ?? session.model_provider_id ?? ''
+  const locked = session.first_message_at != null
+  const isTerminal = session.agent_sdk === 'terminal'
 
   return (
     <div className="flex items-center gap-2 px-4 py-2 border-b border-border/60 shrink-0">
-      <ProviderCapsule sdk={session.agent_sdk} lifecycle={lifecycle} />
-      <ModelSelector sessionId={sessionId} compact showProviderPrefix={false} />
+      <ProviderCapsule
+        sessionId={sessionId}
+        sdk={session.agent_sdk}
+        lifecycle={lifecycle}
+        locked={locked}
+      />
+      {!isTerminal && (
+        <ModelSelector
+          sessionId={sessionId}
+          compact
+          showProviderPrefix={false}
+          disabled={locked}
+        />
+      )}
 
       <div className="flex-1" />
 

--- a/src/renderer/src/components/sessions/ModelSelector.tsx
+++ b/src/renderer/src/components/sessions/ModelSelector.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react'
-import { Check, ChevronDown, Search, Star } from 'lucide-react'
+import { Check, ChevronDown, Lock, Search, Star } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { useSettingsStore, resolveModelForSdk } from '@/stores/useSettingsStore'
 import { useSessionStore } from '@/stores/useSessionStore'
@@ -46,6 +46,8 @@ interface ModelSelectorProps {
   showProviderPrefix?: boolean
   // Compact capsule style for SessionHeader
   compact?: boolean
+  // When true, disables the selector (e.g. session has already sent first message)
+  disabled?: boolean
 }
 
 export function ModelSelector({
@@ -54,7 +56,8 @@ export function ModelSelector({
   onChange,
   agentSdkOverride,
   showProviderPrefix = true,
-  compact = false
+  compact = false,
+  disabled = false
 }: ModelSelectorProps): React.JSX.Element {
   const { t } = useI18n()
   // Read per-session model from session store (with global fallback)
@@ -322,20 +325,26 @@ export function ModelSelector({
       <DropdownMenu
         open={dropdownOpen}
         onOpenChange={(open) => {
+          if (disabled) {
+            setDropdownOpen(false)
+            return
+          }
           setDropdownOpen(open)
           if (!open) setFilter('')
           else setTimeout(() => filterInputRef.current?.focus(), 0)
         }}
       >
-        <DropdownMenuTrigger asChild>
+        <DropdownMenuTrigger asChild disabled={disabled}>
           <button
+            disabled={disabled}
             className={cn(
               'flex items-center gap-1 transition-colors select-none',
               compact
                 ? 'border border-border/40 rounded-md px-2 py-1 text-[11px] font-medium text-muted-foreground hover:bg-muted/40 hover:text-foreground'
-                : 'px-2 py-0.5 rounded-full text-[11px] font-medium border bg-muted/50 border-border text-muted-foreground hover:bg-muted hover:text-foreground'
+                : 'px-2 py-0.5 rounded-full text-[11px] font-medium border bg-muted/50 border-border text-muted-foreground hover:bg-muted hover:text-foreground',
+              disabled && 'opacity-70 cursor-not-allowed hover:bg-transparent hover:text-muted-foreground'
             )}
-            title={t('modelSelector.title')}
+            title={disabled ? t('newSessionDialog.lock.description') : t('modelSelector.title')}
             aria-label={t('modelSelector.ariaLabel', { model: displayName })}
             data-testid="model-selector"
           >
@@ -350,7 +359,11 @@ export function ModelSelector({
                 {selectedModel.variant}
               </span>
             )}
-            <ChevronDown className="h-3 w-3 shrink-0 opacity-50" />
+            {disabled ? (
+              <Lock className="h-3 w-3 shrink-0 opacity-60" />
+            ) : (
+              <ChevronDown className="h-3 w-3 shrink-0 opacity-50" />
+            )}
           </button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="start" className="w-64 max-h-80 overflow-y-auto">

--- a/src/renderer/src/components/sessions/NewSessionDialog.tsx
+++ b/src/renderer/src/components/sessions/NewSessionDialog.tsx
@@ -1,0 +1,257 @@
+/**
+ * NewSessionDialog — capture session name + provider + model before creation.
+ *
+ * Provider/model can still be edited from the SessionHeader after creation,
+ * but only until the first message is sent (after which they lock).
+ */
+
+import { useEffect, useMemo, useState } from 'react'
+import { TerminalSquare, Lock } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle
+} from '@/components/ui/dialog'
+import { ModelSelector } from './ModelSelector'
+import { useSettingsStore, resolveModelForSdk } from '@/stores/useSettingsStore'
+import { useSessionStore } from '@/stores/useSessionStore'
+import { useWorktreeStore } from '@/stores/useWorktreeStore'
+import { useI18n } from '@/i18n/useI18n'
+import { toast } from '@/lib/toast'
+
+type AgentSdk = 'opencode' | 'claude-code' | 'codex' | 'terminal'
+
+const PROVIDER_LABELS: Record<AgentSdk, string> = {
+  'claude-code': 'Claude Code',
+  opencode: 'OpenCode',
+  codex: 'Codex',
+  terminal: 'Terminal'
+}
+
+interface NewSessionDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  // Exactly one of these must be set.
+  worktreeId?: string | null
+  projectId?: string | null
+  connectionId?: string | null
+  // Number that will be used to generate the default name (e.g. "Session 3")
+  defaultIndex: number
+}
+
+export function NewSessionDialog({
+  open,
+  onOpenChange,
+  worktreeId,
+  projectId,
+  connectionId,
+  defaultIndex
+}: NewSessionDialogProps): React.JSX.Element {
+  const { t } = useI18n()
+  const availableAgentSdks = useSettingsStore((s) => s.availableAgentSdks)
+  const defaultAgentSdk = useSettingsStore((s) => s.defaultAgentSdk)
+
+  // Worktree's last-used SDK (if creating in worktree mode) — wins over global default
+  const worktreesByProject = useWorktreeStore((s) => s.worktreesByProject)
+  const worktreeLastAgentSdk = useMemo<AgentSdk | null>(() => {
+    if (!worktreeId) return null
+    for (const worktrees of worktreesByProject.values()) {
+      const w = worktrees.find((w) => w.id === worktreeId)
+      if (w) return (w.last_agent_sdk as AgentSdk | null) ?? null
+    }
+    return null
+  }, [worktreeId, worktreesByProject])
+
+  const enabledSdks = useMemo<AgentSdk[]>(() => {
+    const list: AgentSdk[] = []
+    if (availableAgentSdks?.opencode) list.push('opencode')
+    if (availableAgentSdks?.claude) list.push('claude-code')
+    if (availableAgentSdks?.codex) list.push('codex')
+    list.push('terminal')
+    return list
+  }, [availableAgentSdks])
+
+  const initialSdk = useMemo<AgentSdk>(() => {
+    const fallback = defaultAgentSdk ?? 'opencode'
+    const candidate = worktreeLastAgentSdk ?? fallback
+    return enabledSdks.includes(candidate) ? candidate : enabledSdks[0] ?? 'opencode'
+  }, [worktreeLastAgentSdk, defaultAgentSdk, enabledSdks])
+
+  const [name, setName] = useState('')
+  const [agentSdk, setAgentSdk] = useState<AgentSdk>(initialSdk)
+  const [model, setModel] = useState<{
+    providerID: string
+    modelID: string
+    variant?: string
+  } | null>(null)
+  const [submitting, setSubmitting] = useState(false)
+
+  // Reset state every time the dialog opens
+  useEffect(() => {
+    if (!open) return
+    setName('')
+    setAgentSdk(initialSdk)
+    setModel(null)
+    setSubmitting(false)
+  }, [open, initialSdk])
+
+  // Auto-resolve a default model when SDK changes (skip terminal)
+  useEffect(() => {
+    if (!open) return
+    if (agentSdk === 'terminal') {
+      setModel(null)
+      return
+    }
+    const resolved = resolveModelForSdk(agentSdk)
+    if (resolved) {
+      setModel({
+        providerID: resolved.providerID,
+        modelID: resolved.modelID,
+        variant: resolved.variant ?? undefined
+      })
+    } else {
+      setModel(null)
+    }
+  }, [agentSdk, open])
+
+  const isTerminal = agentSdk === 'terminal'
+  const placeholder = isTerminal
+    ? `Terminal ${defaultIndex}`
+    : `Session ${defaultIndex}`
+
+  async function handleCreate(): Promise<void> {
+    if (submitting) return
+    setSubmitting(true)
+    try {
+      const trimmed = name.trim()
+      const store = useSessionStore.getState()
+      let result: { success: boolean; error?: string }
+
+      if (connectionId) {
+        result = await store.createConnectionSession(connectionId, agentSdk, undefined, {
+          name: trimmed || undefined,
+          model: isTerminal ? null : model
+        })
+      } else if (worktreeId && projectId) {
+        result = await store.createSession(worktreeId, projectId, agentSdk, undefined, {
+          name: trimmed || undefined,
+          model: isTerminal ? null : model
+        })
+      } else {
+        result = { success: false, error: 'Missing scope for new session' }
+      }
+
+      if (!result.success) {
+        toast.error(result.error || t('sessionTabs.errors.createSession'))
+        setSubmitting(false)
+        return
+      }
+      onOpenChange(false)
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : t('sessionTabs.errors.createSession')
+      )
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>{t('newSessionDialog.title')}</DialogTitle>
+          <DialogDescription>{t('newSessionDialog.description')}</DialogDescription>
+        </DialogHeader>
+
+        <div className="grid gap-4">
+          {/* Name */}
+          <div className="grid gap-1.5">
+            <label className="text-xs font-medium text-muted-foreground">
+              {t('newSessionDialog.fields.name')}
+            </label>
+            <input
+              autoFocus
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' && !e.nativeEvent.isComposing) {
+                  e.preventDefault()
+                  void handleCreate()
+                }
+              }}
+              placeholder={placeholder}
+              className="h-9 w-full rounded-md border border-border bg-background px-3 text-sm outline-none focus:ring-2 focus:ring-primary/40"
+            />
+          </div>
+
+          {/* Provider */}
+          <div className="grid gap-1.5">
+            <label className="text-xs font-medium text-muted-foreground">
+              {t('newSessionDialog.fields.provider')}
+            </label>
+            <div className="grid grid-cols-2 gap-1.5">
+              {enabledSdks.map((sdk) => {
+                const active = sdk === agentSdk
+                return (
+                  <button
+                    key={sdk}
+                    type="button"
+                    onClick={() => setAgentSdk(sdk)}
+                    className={cn(
+                      'flex items-center justify-center gap-1.5 rounded-md border px-3 py-2 text-xs font-medium transition-colors',
+                      active
+                        ? 'border-primary bg-primary/10 text-primary'
+                        : 'border-border bg-background text-muted-foreground hover:bg-muted/40 hover:text-foreground'
+                    )}
+                  >
+                    {sdk === 'terminal' && (
+                      <TerminalSquare className="h-3.5 w-3.5 text-emerald-500" />
+                    )}
+                    {PROVIDER_LABELS[sdk]}
+                  </button>
+                )
+              })}
+            </div>
+          </div>
+
+          {/* Model */}
+          <div className="grid gap-1.5">
+            <label className="text-xs font-medium text-muted-foreground">
+              {t('newSessionDialog.fields.model')}
+            </label>
+            {isTerminal ? (
+              <div className="flex items-center gap-1.5 rounded-md border border-dashed border-border/60 px-3 py-2 text-xs text-muted-foreground">
+                <Lock className="h-3 w-3" />
+                {t('newSessionDialog.terminalNoModel')}
+              </div>
+            ) : (
+              <ModelSelector
+                value={model}
+                onChange={(m) => setModel(m)}
+                agentSdkOverride={agentSdk === 'terminal' ? 'opencode' : agentSdk}
+                showProviderPrefix={false}
+                compact
+              />
+            )}
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={submitting}>
+            {t('newSessionDialog.actions.cancel')}
+          </Button>
+          <Button onClick={handleCreate} disabled={submitting}>
+            {submitting
+              ? t('newSessionDialog.actions.creating')
+              : t('newSessionDialog.actions.create')}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/renderer/src/components/sessions/SessionTabs.tsx
+++ b/src/renderer/src/components/sessions/SessionTabs.tsx
@@ -43,6 +43,7 @@ import { toast } from '@/lib/toast'
 import { assignSessionHints } from '@/lib/hint-utils'
 import { HintBadge } from '@/components/ui/HintBadge'
 import { useI18n } from '@/i18n/useI18n'
+import { NewSessionDialog } from './NewSessionDialog'
 import {
   ContextMenu,
   ContextMenuContent,
@@ -615,6 +616,7 @@ export function SessionTabs(): React.JSX.Element | null {
   const [showRightArrow, setShowRightArrow] = useState(false)
   const [draggedTabId, setDraggedTabId] = useState<string | null>(null)
   const [dragOverTabId, setDragOverTabId] = useState<string | null>(null)
+  const [newSessionDialogOpen, setNewSessionDialogOpen] = useState(false)
 
   // Individual selectors — only re-render when the subscribed field changes
   const activeWorktreeId = useSessionStore((s) => s.activeWorktreeId)
@@ -849,22 +851,16 @@ export function SessionTabs(): React.JSX.Element | null {
     }
   }
 
-  // Handle creating a new session
-  const handleCreateSession = async () => {
+  // Handle creating a new session — opens the dialog so the user can pick
+  // name + provider + model. The right-click menu still bypasses the dialog
+  // for power users.
+  const handleCreateSession = () => {
     if (isConnectionMode && selectedConnectionId) {
-      const result = await createConnectionSession(selectedConnectionId)
-      if (!result.success) {
-        toast.error(result.error || t('sessionTabs.errors.createSession'))
-      }
+      setNewSessionDialogOpen(true)
       return
     }
-
     if (!selectedWorktreeId || !project) return
-
-    const result = await createSession(selectedWorktreeId, project.id)
-    if (!result.success) {
-      toast.error(result.error || t('sessionTabs.errors.createSession'))
-    }
+    setNewSessionDialogOpen(true)
   }
 
   // Handle creating a new session with a specific agent SDK (from context menu)
@@ -1126,6 +1122,21 @@ export function SessionTabs(): React.JSX.Element | null {
           </ContextMenuItem>
         </ContextMenuContent>
       </ContextMenu>
+
+      <NewSessionDialog
+        open={newSessionDialogOpen}
+        onOpenChange={setNewSessionDialogOpen}
+        worktreeId={isConnectionMode ? null : selectedWorktreeId}
+        projectId={isConnectionMode ? null : project?.id ?? null}
+        connectionId={isConnectionMode ? selectedConnectionId : null}
+        defaultIndex={
+          isConnectionMode && selectedConnectionId
+            ? (sessionsByConnection.get(selectedConnectionId)?.length ?? 0) + 1
+            : selectedWorktreeId
+              ? (sessionsByWorktree.get(selectedWorktreeId)?.length ?? 0) + 1
+              : 1
+        }
+      />
 
       {/* Left scroll arrow */}
       {showLeftArrow && (

--- a/src/renderer/src/i18n/messages.ts
+++ b/src/renderer/src/i18n/messages.ts
@@ -1799,7 +1799,29 @@ export const messages: Record<AppLocale, MessageTree> = {
     },
     sessionStore: {
       errors: {
-        createConnectionSession: 'Failed to create connection session'
+        createConnectionSession: 'Failed to create connection session',
+        sessionNotFound: 'Session not found',
+        sessionLocked: 'Session is locked because the conversation has already started'
+      }
+    },
+    newSessionDialog: {
+      title: 'New session',
+      description: 'Pick a provider and model. You can change them until the first message is sent.',
+      fields: {
+        name: 'Name',
+        provider: 'Provider',
+        model: 'Model'
+      },
+      terminalNoModel: 'Terminal sessions do not use a model.',
+      actions: {
+        create: 'Create',
+        creating: 'Creating…',
+        cancel: 'Cancel'
+      },
+      lock: {
+        header: 'Locked',
+        description:
+          'Provider and model are locked once the first message has been sent. Start a new session to switch.'
       }
     },
     commandPalette: {
@@ -3924,7 +3946,28 @@ export const messages: Record<AppLocale, MessageTree> = {
     },
     sessionStore: {
       errors: {
-        createConnectionSession: '创建连接会话失败'
+        createConnectionSession: '创建连接会话失败',
+        sessionNotFound: '找不到会话',
+        sessionLocked: '会话已开始，无法再更改服务商或模型'
+      }
+    },
+    newSessionDialog: {
+      title: '新建会话',
+      description: '选择服务商和模型。发送第一条消息前都可修改。',
+      fields: {
+        name: '会话名',
+        provider: '服务商',
+        model: '模型'
+      },
+      terminalNoModel: '终端会话不使用模型。',
+      actions: {
+        create: '创建',
+        creating: '创建中…',
+        cancel: '取消'
+      },
+      lock: {
+        header: '已锁定',
+        description: '发送第一条消息后服务商和模型将被锁定。如需切换请新建会话。'
       }
     },
     commandPalette: {

--- a/src/renderer/src/stores/useSessionStore.ts
+++ b/src/renderer/src/stores/useSessionStore.ts
@@ -36,9 +36,18 @@ interface Session {
   model_provider_id: string | null
   model_id: string | null
   model_variant: string | null
+  first_message_at: number | null
   created_at: string
   updated_at: string
   completed_at: string | null
+}
+
+// Options for creating a session from the new session dialog (or quick paths)
+export interface CreateSessionOptions {
+  name?: string
+  agentSdk?: 'opencode' | 'claude-code' | 'codex' | 'terminal'
+  model?: SelectedModel | null
+  initialMode?: SessionMode
 }
 
 interface SessionState {
@@ -85,8 +94,16 @@ interface SessionState {
     worktreeId: string,
     projectId: string,
     agentSdkOverride?: 'opencode' | 'claude-code' | 'codex' | 'terminal',
-    initialMode?: SessionMode
+    initialMode?: SessionMode,
+    options?: { name?: string; model?: SelectedModel | null }
   ) => Promise<{ success: boolean; session?: Session; error?: string }>
+  updateSessionAgent: (
+    sessionId: string,
+    update: {
+      agentSdk?: 'opencode' | 'claude-code' | 'codex' | 'terminal'
+      model?: SelectedModel | null
+    }
+  ) => Promise<{ success: boolean; error?: string }>
   closeSession: (sessionId: string) => Promise<{ success: boolean; error?: string }>
   reopenSession: (
     sessionId: string,
@@ -133,7 +150,8 @@ interface SessionState {
   createConnectionSession: (
     connectionId: string,
     agentSdkOverride?: 'opencode' | 'claude-code' | 'codex' | 'terminal',
-    initialMode?: SessionMode
+    initialMode?: SessionMode,
+    options?: { name?: string; model?: SelectedModel | null }
   ) => Promise<{ success: boolean; session?: Session; error?: string }>
   setActiveConnectionSession: (sessionId: string | null) => void
   setActiveConnection: (connectionId: string | null) => void
@@ -280,20 +298,46 @@ export const useSessionStore = create<SessionState>()(
         worktreeId: string,
         projectId: string,
         agentSdkOverride?: 'opencode' | 'claude-code' | 'codex' | 'terminal',
-        initialMode?: SessionMode
+        initialMode?: SessionMode,
+        options?: { name?: string; model?: SelectedModel | null }
       ) => {
         try {
-          // Resolve default agent SDK from settings
+          // Resolve default agent SDK: explicit override → worktree.last_agent_sdk → settings default
           const { useSettingsStore } = await import('./useSettingsStore')
+          let worktreeLastAgentSdk:
+            | 'opencode'
+            | 'claude-code'
+            | 'codex'
+            | 'terminal'
+            | null
+            | undefined
+          const worktreesByProject = useWorktreeStore.getState().worktreesByProject
+          for (const worktrees of worktreesByProject.values()) {
+            const w = worktrees.find((w) => w.id === worktreeId)
+            if (w) {
+              worktreeLastAgentSdk = (w as { last_agent_sdk?: typeof worktreeLastAgentSdk })
+                .last_agent_sdk
+              break
+            }
+          }
           const defaultAgentSdk =
-            agentSdkOverride ?? useSettingsStore.getState().defaultAgentSdk ?? 'opencode'
+            agentSdkOverride ??
+            worktreeLastAgentSdk ??
+            useSettingsStore.getState().defaultAgentSdk ??
+            'opencode'
 
           const isTerminal = defaultAgentSdk === 'terminal'
 
           // Terminal sessions skip model resolution entirely
           let defaultModel: { providerID: string; modelID: string; variant?: string } | null = null
 
-          if (!isTerminal) {
+          if (options?.model) {
+            defaultModel = {
+              providerID: options.model.providerID,
+              modelID: options.model.modelID,
+              variant: options.model.variant
+            }
+          } else if (!isTerminal) {
             const { resolveModelForSdk } = await import('./useSettingsStore')
             const configuredDefaultSdk = useSettingsStore.getState().defaultAgentSdk ?? 'opencode'
 
@@ -343,10 +387,14 @@ export const useSessionStore = create<SessionState>()(
           const existingSessions = get().sessionsByWorktree.get(worktreeId) || []
           const sessionNumber = existingSessions.length + 1
 
+          const sessionName =
+            options?.name?.trim() ||
+            (isTerminal ? `Terminal ${sessionNumber}` : `Session ${sessionNumber}`)
+
           const session = await window.db.session.create({
             worktree_id: worktreeId,
             project_id: projectId,
-            name: isTerminal ? `Terminal ${sessionNumber}` : `Session ${sessionNumber}`,
+            name: sessionName,
             agent_sdk: defaultAgentSdk,
             ...(defaultModel
               ? {
@@ -356,6 +404,19 @@ export const useSessionStore = create<SessionState>()(
                 }
               : {})
           })
+
+          // Persist last_agent_sdk on the worktree so the next session defaults to it.
+          // Fire-and-forget; not critical to the create flow.
+          if (worktreeLastAgentSdk !== defaultAgentSdk) {
+            window.db.worktree
+              .update(worktreeId, { last_agent_sdk: defaultAgentSdk })
+              .then(() => {
+                useWorktreeStore.getState().updateWorktreeLastAgentSdk(worktreeId, defaultAgentSdk)
+              })
+              .catch(() => {
+                /* non-critical */
+              })
+          }
 
           // Clear file viewer so the new session takes focus in MainPane
           const { useFileViewerStore } = await import('./useFileViewerStore')
@@ -753,6 +814,149 @@ export const useSessionStore = create<SessionState>()(
         } catch {
           return false
         }
+      },
+
+      // Update agent_sdk and/or model for a session. Locked once the session
+      // has received its first activity (first_message_at is set).
+      updateSessionAgent: async (
+        sessionId: string,
+        update: {
+          agentSdk?: 'opencode' | 'claude-code' | 'codex' | 'terminal'
+          model?: SelectedModel | null
+        }
+      ) => {
+        // Look up the session across both scopes
+        let target: Session | null = null
+        let scope: { type: 'worktree'; scopeId: string } | { type: 'connection'; scopeId: string } | null =
+          null
+        for (const [worktreeId, sessions] of get().sessionsByWorktree.entries()) {
+          const found = sessions.find((s) => s.id === sessionId)
+          if (found) {
+            target = found
+            scope = { type: 'worktree', scopeId: worktreeId }
+            break
+          }
+        }
+        if (!target) {
+          for (const [connectionId, sessions] of get().sessionsByConnection.entries()) {
+            const found = sessions.find((s) => s.id === sessionId)
+            if (found) {
+              target = found
+              scope = { type: 'connection', scopeId: connectionId }
+              break
+            }
+          }
+        }
+
+        if (!target) {
+          return { success: false, error: t('sessionStore.errors.sessionNotFound') }
+        }
+        if (target.first_message_at != null) {
+          return { success: false, error: t('sessionStore.errors.sessionLocked') }
+        }
+
+        const newAgentSdk = update.agentSdk ?? target.agent_sdk
+        const isTerminal = newAgentSdk === 'terminal'
+
+        // Resolve model: explicit override → per-SDK default → current session model (if SDK unchanged)
+        let nextModel: SelectedModel | null = null
+        if (update.model) {
+          nextModel = update.model
+        } else if (!isTerminal) {
+          if (newAgentSdk === target.agent_sdk && target.model_id && target.model_provider_id) {
+            nextModel = {
+              providerID: target.model_provider_id,
+              modelID: target.model_id,
+              variant: target.model_variant ?? undefined
+            }
+          } else {
+            const { resolveModelForSdk } = await import('./useSettingsStore')
+            const resolved = resolveModelForSdk(newAgentSdk)
+            if (resolved) {
+              nextModel = {
+                providerID: resolved.providerID,
+                modelID: resolved.modelID,
+                variant: resolved.variant ?? undefined
+              }
+            }
+          }
+        }
+
+        try {
+          await window.db.session.update(sessionId, {
+            agent_sdk: newAgentSdk,
+            model_provider_id: isTerminal ? null : nextModel?.providerID ?? null,
+            model_id: isTerminal ? null : nextModel?.modelID ?? null,
+            model_variant: isTerminal ? null : nextModel?.variant ?? null
+          })
+        } catch (error) {
+          return {
+            success: false,
+            error: error instanceof Error ? error.message : 'Failed to update session agent'
+          }
+        }
+
+        // Update in-memory state in the scope we found
+        set((state) => {
+          const updater = (s: Session): Session =>
+            s.id === sessionId
+              ? {
+                  ...s,
+                  agent_sdk: newAgentSdk,
+                  model_provider_id: isTerminal ? null : nextModel?.providerID ?? null,
+                  model_id: isTerminal ? null : nextModel?.modelID ?? null,
+                  model_variant: isTerminal ? null : nextModel?.variant ?? null
+                }
+              : s
+
+          if (scope?.type === 'worktree') {
+            const newMap = new Map(state.sessionsByWorktree)
+            const sessions = newMap.get(scope.scopeId) || []
+            newMap.set(scope.scopeId, sessions.map(updater))
+            return { sessionsByWorktree: newMap }
+          }
+          if (scope?.type === 'connection') {
+            const newMap = new Map(state.sessionsByConnection)
+            const sessions = newMap.get(scope.scopeId) || []
+            newMap.set(scope.scopeId, sessions.map(updater))
+            return { sessionsByConnection: newMap }
+          }
+          return {}
+        })
+
+        // Persist last_agent_sdk on the worktree (worktree-scoped sessions only)
+        if (scope?.type === 'worktree' && newAgentSdk !== target.agent_sdk) {
+          window.db.worktree
+            .update(scope.scopeId, { last_agent_sdk: newAgentSdk })
+            .then(() => {
+              useWorktreeStore
+                .getState()
+                .updateWorktreeLastAgentSdk(scope!.scopeId as string, newAgentSdk)
+            })
+            .catch(() => {
+              /* non-critical */
+            })
+        }
+
+        // Push the new model to the agent backend (SDK-aware)
+        if (!isTerminal && nextModel) {
+          try {
+            await window.agentOps.setModel({ ...nextModel, runtimeId: newAgentSdk })
+          } catch (error) {
+            console.error('Failed to push model to agent backend:', error)
+          }
+          // Remember this model per-SDK so future sessions inherit it
+          try {
+            const { useSettingsStore } = await import('./useSettingsStore')
+            useSettingsStore
+              .getState()
+              .setSelectedModelForSdk(newAgentSdk, nextModel, { skipBackendPush: true })
+          } catch {
+            /* non-critical */
+          }
+        }
+
+        return { success: true }
       },
 
       // Reorder tabs
@@ -1290,7 +1494,8 @@ export const useSessionStore = create<SessionState>()(
       createConnectionSession: async (
         connectionId: string,
         agentSdkOverride?: 'opencode' | 'claude-code' | 'codex' | 'terminal',
-        initialMode?: SessionMode
+        initialMode?: SessionMode,
+        options?: { name?: string; model?: SelectedModel | null }
       ) => {
         try {
           // Look up the connection to get the first member's project_id
@@ -1308,8 +1513,13 @@ export const useSessionStore = create<SessionState>()(
             const { useSettingsStore } = await import('./useSettingsStore')
             defaultAgentSdk =
               agentSdkOverride ?? useSettingsStore.getState().defaultAgentSdk ?? 'opencode'
-            // Terminal sessions skip model resolution
-            if (defaultAgentSdk !== 'terminal') {
+            if (options?.model) {
+              defaultModel = {
+                providerID: options.model.providerID,
+                modelID: options.model.modelID,
+                variant: options.model.variant
+              }
+            } else if (defaultAgentSdk !== 'terminal') {
               const configuredDefaultSdk = useSettingsStore.getState().defaultAgentSdk ?? 'opencode'
 
               // Priority 1: mode-specific default (only when session SDK matches the
@@ -1337,11 +1547,15 @@ export const useSessionStore = create<SessionState>()(
           const existingSessions = get().sessionsByConnection.get(connectionId) || []
           const sessionNumber = existingSessions.length + 1
 
+          const sessionName =
+            options?.name?.trim() ||
+            (isTerminal ? `Terminal ${sessionNumber}` : `Session ${sessionNumber}`)
+
           const session = await window.db.session.create({
             worktree_id: null,
             project_id: projectId,
             connection_id: connectionId,
-            name: isTerminal ? `Terminal ${sessionNumber}` : `Session ${sessionNumber}`,
+            name: sessionName,
             agent_sdk: defaultAgentSdk,
             ...(defaultModel
               ? {

--- a/src/renderer/src/stores/useWorktreeStore.ts
+++ b/src/renderer/src/stores/useWorktreeStore.ts
@@ -130,6 +130,10 @@ interface WorktreeState {
   ) => Promise<{ success: boolean; worktree?: Worktree; error?: string }>
   updateWorktreeBranch: (worktreeId: string, newBranch: string) => void
   updateWorktreeModel: (worktreeId: string, model: SelectedModel) => void
+  updateWorktreeLastAgentSdk: (
+    worktreeId: string,
+    agentSdk: 'opencode' | 'claude-code' | 'codex' | 'terminal'
+  ) => void
   reorderWorktrees: (projectId: string, fromIndex: number, toIndex: number) => void
   appendSessionTitle: (worktreeId: string, title: string) => void
 }
@@ -599,6 +603,25 @@ export const useWorktreeStore = create<WorktreeState>((set, get) => ({
                 last_model_variant: model.variant ?? null
               }
             : w
+        )
+        if (updated.some((w, i) => w !== worktrees[i])) {
+          newMap.set(projectId, updated)
+        }
+      }
+      return { worktreesByProject: newMap }
+    })
+  },
+
+  // Update a worktree's last-used agent SDK in the store
+  updateWorktreeLastAgentSdk: (
+    worktreeId: string,
+    agentSdk: 'opencode' | 'claude-code' | 'codex' | 'terminal'
+  ) => {
+    set((state) => {
+      const newMap = new Map(state.worktreesByProject)
+      for (const [projectId, worktrees] of newMap.entries()) {
+        const updated = worktrees.map((w) =>
+          w.id === worktreeId ? { ...w, last_agent_sdk: agentSdk } : w
         )
         if (updated.some((w, i) => w !== worktrees[i])) {
           newMap.set(projectId, updated)

--- a/src/shared/types/session.ts
+++ b/src/shared/types/session.ts
@@ -12,6 +12,7 @@ export interface Session {
   model_id: string | null
   model_variant: string | null
   color: string | null
+  first_message_at: number | null
   created_at: string
   updated_at: string
   completed_at: string | null

--- a/src/shared/types/worktree.ts
+++ b/src/shared/types/worktree.ts
@@ -12,6 +12,7 @@ export interface Worktree {
   last_model_provider_id: string | null
   last_model_id: string | null
   last_model_variant: string | null
+  last_agent_sdk: 'opencode' | 'claude-code' | 'codex' | 'terminal' | null
   created_at: string
   last_accessed_at: string
 }


### PR DESCRIPTION
## Summary
- 将 AI 服务商（Claude Code / OpenCode / Codex / Terminal）和模型从 worktree 级提升为会话级，新建会话通过对话框单独配置
- 首条消息发送后自动锁定服务商与模型，避免中途切换破坏对话上下文；会话名始终可改
- worktree 记忆最近一次使用的服务商，作为新建会话时的默认值

## 改动概览
**数据层（schema v14）**
- `sessions.first_message_at`：首条消息时间戳，作为锁定信号
- `worktrees.last_agent_sdk`：记忆 worktree 最近用的 SDK
- `upsertSessionActivity` 中央埋点：所有 SDK 共用一处写入首条消息时间，无需逐 SDK 改造

**Store**
- `createSession` / `createConnectionSession` 接受 `{name, model}` 选项，从 worktree.last_agent_sdk → settings.defaultAgentSdk → 'opencode' 解析默认 SDK，并回写 last_agent_sdk
- 新增 `updateSessionAgent`：校验 `first_message_at == null` 后才允许改服务商/模型，同步更新 DB / 内存 / worktree / agent backend / 每 SDK 设置

**UI**
- `NewSessionDialog`：左键 Plus 触发，含名称/服务商（2 列按钮）/模型（ModelSelector 受控模式）
- `SessionTabs`：右键 Plus 的快速直建保留为旁路
- `SessionHeader.ProviderCapsule`：未锁时改为 Popover 切换服务商；锁定时显示 Lock 图标 + Tooltip
- `ModelSelector`：新增 `disabled`，锁定后 Trigger 不可点，ChevronDown → Lock，Tooltip 切换为锁定提示
- terminal 会话不渲染 ModelSelector

**i18n**
- 补齐 `sessionStore.errors.{sessionNotFound, sessionLocked}` 与 `newSessionDialog.*` 中英文文案

## 兼容性
- 历史会话视为已锁定（迁移脚本回填 first_message_at）
- 现有 worktree 默认 last_agent_sdk = NULL，回退至全局默认

## Test plan
- [ ] 新建 worktree 会话：左键 Plus → 对话框 → 选 Claude Code + 模型 → 创建成功，使用所选 SDK 启动
- [ ] 新建 connection 会话：同上路径，无 worktree 回写
- [ ] 右键 Plus 快速建会话：直接走选定 SDK，跳过对话框
- [ ] worktree 记忆：先建 Codex 会话，再次新建 → 默认值为 Codex
- [ ] SessionHeader 改服务商：未发送消息时点击 ProviderCapsule → Popover 列出可用 SDK，切换生效
- [ ] 锁定行为：发送首条消息后，ProviderCapsule 出现 🔒 不可点；ModelSelector Trigger 禁用 + Lock 图标
- [ ] terminal 会话：ProviderCapsule 仍可切换，ModelSelector 不显示
- [ ] 历史会话打开：直接呈锁定态
- [ ] i18n：中英文切换文案正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)