### PR TITLE
feat: finish Codex steer, update_plan, queued notifications, and FDA onboarding

### DIFF
--- a/resources/entitlements.mac.inherit.plist
+++ b/resources/entitlements.mac.inherit.plist
@@ -10,5 +10,7 @@
     <true/>
     <key>com.apple.security.cs.allow-dyld-environment-variables</key>
     <true/>
+    <key>com.apple.security.files.user-selected.read-write</key>
+    <true/>
 </dict>
 </plist>

--- a/resources/entitlements.mac.plist
+++ b/resources/entitlements.mac.plist
@@ -10,5 +10,7 @@
     <true/>
     <key>com.apple.security.cs.allow-dyld-environment-variables</key>
     <true/>
+    <key>com.apple.security.files.user-selected.read-write</key>
+    <true/>
 </dict>
 </plist>

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -45,6 +45,10 @@ import { openCodeService } from './services/opencode-service'
 import { AgentRuntimeManager } from './services/agent-runtime-manager'
 import { resolveClaudeBinaryPath } from './services/claude-binary-resolver'
 import { powerSaveBlockerService } from './services/power-save-blocker'
+import {
+  checkFullDiskAccess,
+  openFullDiskAccessSettings
+} from './services/full-disk-access'
 import { telemetryService } from './services/telemetry-service'
 import { ensureForkDataDir } from './services/fork-data-migration'
 import { APP_BUNDLE_ID, APP_CLI_NAME, APP_PRODUCT_NAME } from '@shared/app-identity'
@@ -457,6 +461,19 @@ function registerSystemHandlers(): void {
       powerSaveBlockerService.disable()
     }
     return { success: true }
+  })
+
+  ipcMain.handle('system:setSessionQueuedState', (_event, sessionId: string, queued: boolean) => {
+    notificationService.setSessionQueuedState(sessionId, queued)
+    return { success: true }
+  })
+
+  ipcMain.handle('system:checkFullDiskAccess', () => {
+    return checkFullDiskAccess()
+  })
+
+  ipcMain.handle('system:openFullDiskAccessSettings', () => {
+    return openFullDiskAccessSettings()
   })
 
   // Set the UI zoom level (clamped to Electron's -5..5 range)

--- a/src/main/ipc/agent-handler-schemas.ts
+++ b/src/main/ipc/agent-handler-schemas.ts
@@ -46,6 +46,7 @@ export const messagesSchema = z.tuple([z.string(), z.string()])
 // Prompt supports both positional and object-style call with varied shapes.
 // Schema is intentionally permissive — the handler body unpacks args manually.
 export const promptSchema = z.array(z.unknown())
+export const steerSchema = z.array(z.unknown())
 
 export const modelsSchema = z.tuple([
   z.object({ runtimeId: runtimeIdSchema.optional() }).optional()

--- a/src/main/ipc/agent-handlers.ts
+++ b/src/main/ipc/agent-handlers.ts
@@ -8,6 +8,8 @@ import type { AgentRuntimeAdapter, PromptOptions } from '../services/agent-runti
 import { ClaudeCodeImplementer } from '../services/claude-code-implementer'
 import {
   createAgentHandler,
+  AgentErrorCode,
+  AgentHandlerError,
   resolveRuntimeId,
   type AgentHandlerContext
 } from './agent-handler-wrapper'
@@ -28,6 +30,7 @@ import {
   planApproveSchema,
   planRejectSchema,
   promptSchema,
+  steerSchema,
   questionRejectSchema,
   questionReplySchema,
   reconnectSchema,
@@ -238,6 +241,94 @@ export function registerAgentHandlers(
         const impl = c.runtimeManager.getImplementer(runtimeId)
         await impl.prompt(worktreePath, runtimeSessionId, messageOrParts, model, options)
         telemetryService.track('prompt_sent', { runtime_id: runtimeId })
+        return {}
+      }
+    })
+  )
+
+  // Steer an actively running turn without interrupting it (Codex-only in this wave).
+  ipcMain.handle(
+    'agent:steer',
+    createAgentHandler(ctx, {
+      channel: 'agent:steer',
+      schema: steerSchema,
+      handler: async (args, c) => {
+        let worktreePath: string
+        let runtimeSessionId: string
+        let messageOrParts:
+          | string
+          | Array<{ type: string; text?: string; mime?: string; url?: string; filename?: string }>
+        let model: { providerID: string; modelID: string; variant?: string } | undefined
+        let options: PromptOptions | undefined
+
+        if (args.length === 1 && typeof args[0] === 'object' && args[0] !== null) {
+          const obj = args[0] as Record<string, unknown>
+          worktreePath = obj.worktreePath as string
+          runtimeSessionId = obj.sessionId as string
+          messageOrParts = (obj.parts as typeof messageOrParts) || [
+            { type: 'text', text: obj.message as string }
+          ]
+          const rawModel = obj.model as Record<string, unknown> | undefined
+          if (
+            rawModel &&
+            typeof rawModel.providerID === 'string' &&
+            typeof rawModel.modelID === 'string'
+          ) {
+            model = {
+              providerID: rawModel.providerID,
+              modelID: rawModel.modelID,
+              variant: typeof rawModel.variant === 'string' ? rawModel.variant : undefined
+            }
+          }
+          const rawOptions = obj.options as Record<string, unknown> | undefined
+          if (rawOptions && typeof rawOptions.codexFastMode === 'boolean') {
+            options = { codexFastMode: rawOptions.codexFastMode }
+          }
+        } else {
+          worktreePath = args[0] as string
+          runtimeSessionId = args[1] as string
+          messageOrParts = args[2] as string
+          const rawModel = args[3] as Record<string, unknown> | undefined
+          if (
+            rawModel &&
+            typeof rawModel.providerID === 'string' &&
+            typeof rawModel.modelID === 'string'
+          ) {
+            model = {
+              providerID: rawModel.providerID,
+              modelID: rawModel.modelID,
+              variant: typeof rawModel.variant === 'string' ? rawModel.variant : undefined
+            }
+          }
+          const rawOptions = args[4] as Record<string, unknown> | undefined
+          if (rawOptions && typeof rawOptions.codexFastMode === 'boolean') {
+            options = { codexFastMode: rawOptions.codexFastMode }
+          }
+        }
+
+        log.info('IPC: agent:steer', {
+          worktreePath,
+          runtimeSessionId,
+          partsCount: Array.isArray(messageOrParts) ? messageOrParts.length : 1
+        })
+
+        const runtimeId = resolveRuntimeId(c, runtimeSessionId)
+        if (runtimeId === 'terminal') {
+          throw new AgentHandlerError(
+            AgentErrorCode.STEER_NOT_SUPPORTED,
+            'Terminal sessions do not support steering'
+          )
+        }
+
+        const impl = c.runtimeManager.getImplementer(runtimeId)
+        if (!impl.capabilities.supportsSteer || !impl.steer) {
+          throw new AgentHandlerError(
+            AgentErrorCode.STEER_NOT_SUPPORTED,
+            `Runtime ${runtimeId} does not support steering`
+          )
+        }
+
+        await impl.steer(worktreePath, runtimeSessionId, messageOrParts, model, options)
         return {}
       }
     })

--- a/src/main/services/agent-runtime-types.ts
+++ b/src/main/services/agent-runtime-types.ts
@@ -5,6 +5,7 @@ export type AgentRuntimeId = 'opencode' | 'claude-code' | 'codex' | 'terminal'
 export interface AgentRuntimeCapabilities {
   supportsUndo: boolean
   supportsRedo: boolean
+  supportsSteer: boolean
   supportsCommands: boolean
   supportsPermissionRequests: boolean
   supportsQuestionPrompts: boolean
@@ -37,6 +38,18 @@ export interface AgentRuntimeAdapter {
 
   // Messaging
   prompt(
+    worktreePath: string,
+    agentSessionId: string,
+    message:
+      | string
+      | Array<
+          | { type: 'text'; text: string }
+          | { type: 'file'; mime: string; url: string; filename?: string }
+        >,
+    modelOverride?: { providerID: string; modelID: string; variant?: string },
+    options?: PromptOptions
+  ): Promise<void>
+  steer?(
     worktreePath: string,
     agentSessionId: string,
     message:
@@ -135,6 +148,7 @@ export interface AgentRuntimeAdapter {
 export const OPENCODE_CAPABILITIES: AgentRuntimeCapabilities = {
   supportsUndo: true,
   supportsRedo: true,
+  supportsSteer: false,
   supportsCommands: true,
   supportsPermissionRequests: true,
   supportsQuestionPrompts: true,
@@ -146,6 +160,7 @@ export const OPENCODE_CAPABILITIES: AgentRuntimeCapabilities = {
 export const CLAUDE_CODE_CAPABILITIES: AgentRuntimeCapabilities = {
   supportsUndo: true,
   supportsRedo: false,
+  supportsSteer: false,
   supportsCommands: true,
   supportsPermissionRequests: true,
   supportsQuestionPrompts: true,
@@ -157,6 +172,7 @@ export const CLAUDE_CODE_CAPABILITIES: AgentRuntimeCapabilities = {
 export const CODEX_CAPABILITIES: AgentRuntimeCapabilities = {
   supportsUndo: true,
   supportsRedo: false,
+  supportsSteer: true,
   supportsCommands: false,
   supportsPermissionRequests: true,
   supportsQuestionPrompts: true,
@@ -168,6 +184,7 @@ export const CODEX_CAPABILITIES: AgentRuntimeCapabilities = {
 export const TERMINAL_CAPABILITIES: AgentRuntimeCapabilities = {
   supportsUndo: false,
   supportsRedo: false,
+  supportsSteer: false,
   supportsCommands: false,
   supportsPermissionRequests: false,
   supportsQuestionPrompts: false,

--- a/src/main/services/codex-activity-mapper.ts
+++ b/src/main/services/codex-activity-mapper.ts
@@ -1,6 +1,11 @@
 import type { SessionActivityCreate, SessionActivityKind, SessionActivityTone } from '../db'
 import type { CodexManagerEvent } from './codex-app-server-manager'
 import { asObject, asString } from './codex-utils'
+import {
+  buildCodexPlanUpdateSummary,
+  buildCodexUpdatePlanCallId,
+  normalizeCodexPlanUpdateTodos
+} from './codex-event-mapper'
 
 function stringifyPayload(payload: unknown): string | null {
   if (payload === undefined) return null
@@ -170,6 +175,27 @@ export function mapCodexManagerEventToActivity(
         'info',
         asString(payload?.threadName) ?? 'Thread title updated'
       )
+
+    case 'turn/plan/updated': {
+      const todos = normalizeCodexPlanUpdateTodos(event.payload)
+      const summary = buildCodexPlanUpdateSummary(todos)
+
+      return buildActivity(
+        sessionId,
+        agentSessionId,
+        event,
+        'session.info',
+        'info',
+        summary,
+        {
+          ...(payload ?? {}),
+          kind: 'update_plan',
+          tool: 'update_plan',
+          callID: buildCodexUpdatePlanCallId(event),
+          todos
+        }
+      )
+    }
 
     default:
       return null

--- a/src/main/services/codex-app-server-manager.ts
+++ b/src/main/services/codex-app-server-manager.ts
@@ -626,6 +626,39 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
     }
   }
 
+  async steerTurn(threadId: string, input: CodexTurnInput, turnId?: string): Promise<void> {
+    const context = this.sessions.get(threadId)
+    if (!context) {
+      throw new Error(`steerTurn: no session found for threadId=${threadId}`)
+    }
+
+    if (!context.session.threadId) {
+      throw new Error('steerTurn: session has no threadId')
+    }
+
+    const targetTurnId = turnId ?? context.session.activeTurnId
+    if (!targetTurnId) {
+      throw new Error('steerTurn: no active turn to steer')
+    }
+
+    const turnInput =
+      input.input && input.input.length > 0
+        ? input.input
+        : input.text
+          ? [{ type: 'text', text: input.text }]
+          : []
+
+    if (turnInput.length === 0) {
+      throw new Error('steerTurn: input is empty')
+    }
+
+    await this.sendRequest(context, 'turn/steer', {
+      threadId: context.session.threadId,
+      turnId: targetTurnId,
+      input: turnInput
+    })
+  }
+
   // ── HITL / control-plane API ──────────────────────────────────
 
   respondToApproval(

--- a/src/main/services/codex-event-mapper.ts
+++ b/src/main/services/codex-event-mapper.ts
@@ -44,6 +44,13 @@ interface ContentDelta {
   text: string
 }
 
+export interface CodexPlanTodo {
+  id: string
+  content: string
+  status: 'pending' | 'in_progress' | 'completed' | 'cancelled'
+  priority: 'high' | 'medium' | 'low'
+}
+
 function toTextPart(text: string): { part: { type: 'text'; text: string }; delta: string } {
   return {
     part: { type: 'text', text },
@@ -145,6 +152,159 @@ function extractContentDelta(event: CodexManagerEvent): ContentDelta | null {
   }
 
   return null
+}
+
+function normalizePlanStatus(value: unknown, item?: Record<string, unknown>): CodexPlanTodo['status'] {
+  switch (value) {
+    case 'pending':
+      return 'pending'
+    case 'in_progress':
+    case 'in-progress':
+    case 'running':
+      return 'in_progress'
+    case 'completed':
+    case 'complete':
+    case 'done':
+      return 'completed'
+    case 'cancelled':
+    case 'canceled':
+      return 'cancelled'
+    default:
+      if (item?.completed === true || item?.done === true) return 'completed'
+      if (item?.cancelled === true || item?.canceled === true) return 'cancelled'
+      if (item?.current === true || item?.active === true || item?.inProgress === true) {
+        return 'in_progress'
+      }
+      return 'pending'
+  }
+}
+
+function normalizePlanPriority(value: unknown): CodexPlanTodo['priority'] {
+  switch (value) {
+    case 'high':
+    case 'medium':
+    case 'low':
+      return value
+    default:
+      return 'medium'
+  }
+}
+
+function extractPlanItemContent(item: Record<string, unknown>): string {
+  const candidates = [
+    item.content,
+    item.title,
+    item.text,
+    item.label,
+    item.task,
+    item.subject,
+    item.activeForm,
+    item.description
+  ]
+
+  for (const candidate of candidates) {
+    if (typeof candidate === 'string' && candidate.trim()) {
+      return candidate.trim()
+    }
+  }
+
+  return ''
+}
+
+function extractPlanItems(value: unknown): unknown[] {
+  if (Array.isArray(value)) return value
+
+  const record = asObject(value)
+  if (!record) return []
+
+  const collections = [
+    record.todos,
+    record.items,
+    record.steps,
+    record.plan,
+    record.checklist,
+    record.checklistItems,
+    record.updates
+  ]
+
+  for (const collection of collections) {
+    if (Array.isArray(collection)) return collection
+
+    const nested = asObject(collection)
+    if (!nested) continue
+
+    const nestedCollections = [
+      nested.todos,
+      nested.items,
+      nested.steps,
+      nested.checklist,
+      nested.checklistItems
+    ]
+
+    for (const nestedCollection of nestedCollections) {
+      if (Array.isArray(nestedCollection)) return nestedCollection
+    }
+  }
+
+  return []
+}
+
+export function normalizeCodexPlanUpdateTodos(payload: unknown): CodexPlanTodo[] {
+  return extractPlanItems(payload).flatMap((item, index) => {
+    if (typeof item === 'string' && item.trim()) {
+      return [
+        {
+          id: `plan-${index}-${item.trim()}`,
+          content: item.trim(),
+          status: 'pending',
+          priority: 'medium'
+        }
+      ]
+    }
+
+    const record = asObject(item)
+    if (!record) return []
+
+    const content = extractPlanItemContent(record)
+    if (!content) return []
+
+    return [
+      {
+        id:
+          (typeof record.id === 'string' && record.id.trim()) ||
+          `plan-${index}-${content}`,
+        content,
+        status: normalizePlanStatus(record.status ?? record.state, record),
+        priority: normalizePlanPriority(record.priority)
+      }
+    ]
+  })
+}
+
+export function buildCodexUpdatePlanCallId(event: CodexManagerEvent): string {
+  const payload = asObject(event.payload)
+  const turnId = event.turnId ?? asString(payload?.turnId) ?? asString(asObject(payload?.turn)?.id)
+  return `${turnId ?? event.threadId}:update_plan`
+}
+
+export function buildCodexPlanUpdateSummary(todos: CodexPlanTodo[]): string {
+  if (todos.length === 0) {
+    return 'Plan updated'
+  }
+
+  const completed = todos.filter((todo) => todo.status === 'completed').length
+  const inProgress = todos.filter((todo) => todo.status === 'in_progress').length
+  const cancelled = todos.filter((todo) => todo.status === 'cancelled').length
+
+  const fragments = [`${completed}/${todos.length} completed`]
+  if (inProgress > 0) {
+    fragments.push(`${inProgress} in progress`)
+  }
+  if (cancelled > 0) {
+    fragments.push(`${cancelled} cancelled`)
+  }
+
+  return fragments.join(', ')
 }
 
 // ── Turn payload extraction ───────────────────────────────────────
@@ -279,6 +439,28 @@ export function mapCodexEventToStreamEvents(
   }
 
   // ── Turn started ──────────────────────────────────────────────
+  if (method === 'turn/plan/updated') {
+    const todos = normalizeCodexPlanUpdateTodos(event.payload)
+
+    return [
+      {
+        type: 'message.part.updated',
+        sessionId: hiveSessionId,
+        data: {
+          part: {
+            type: 'tool',
+            callID: buildCodexUpdatePlanCallId(event),
+            tool: 'update_plan',
+            state: {
+              status: 'completed',
+              input: { todos }
+            }
+          }
+        }
+      }
+    ]
+  }
+
   if (method === 'turn/started') {
     return [
       {

--- a/src/main/services/codex-implementer.ts
+++ b/src/main/services/codex-implementer.ts
@@ -841,6 +841,59 @@ export class CodexImplementer implements AgentSdkImplementer, AgentRuntimeAdapte
     }
   }
 
+  async steer(
+    worktreePath: string,
+    agentSessionId: string,
+    message:
+      | string
+      | Array<
+          | { type: 'text'; text: string }
+          | { type: 'file'; mime: string; url: string; filename?: string }
+        >,
+    _modelOverride?: { providerID: string; modelID: string; variant?: string },
+    _options?: PromptOptions
+  ): Promise<void> {
+    const key = this.getSessionKey(worktreePath, agentSessionId)
+    const session = this.sessions.get(key)
+    if (!session) {
+      throw new Error(`Steer failed: session not found for ${worktreePath} / ${agentSessionId}`)
+    }
+
+    const hasAttachments = Array.isArray(message) && message.some((part) => part.type !== 'text')
+    if (hasAttachments) {
+      throw new Error('Steer only supports text messages')
+    }
+
+    const text =
+      typeof message === 'string'
+        ? message
+        : message
+            .filter((part) => part.type === 'text')
+            .map((part) => part.text)
+            .join('\n')
+
+    if (!text.trim()) {
+      throw new Error('Steer message cannot be empty')
+    }
+
+    const managerSession = this.manager.getSession(session.threadId)
+    const activeTurnId = managerSession?.activeTurnId
+    if (!activeTurnId) {
+      throw new Error('Steer is unavailable because there is no active Codex turn')
+    }
+
+    await this.manager.steerTurn(session.threadId, { text }, activeTurnId)
+
+    const syntheticTimestamp = new Date().toISOString()
+    session.messages.push({
+      role: 'user',
+      steered: true,
+      parts: [{ type: 'text', text, timestamp: syntheticTimestamp }],
+      timestamp: syntheticTimestamp
+    })
+    this.persistCanonicalMessages(session)
+  }
+
   async abort(worktreePath: string, agentSessionId: string): Promise<boolean> {
     const key = this.getSessionKey(worktreePath, agentSessionId)
     const session = this.sessions.get(key)

--- a/src/main/services/full-disk-access.ts
+++ b/src/main/services/full-disk-access.ts
@@ -1,0 +1,100 @@
+import { accessSync, constants } from 'node:fs'
+import { join } from 'node:path'
+import { homedir } from 'node:os'
+import { shell } from 'electron'
+
+import { createLogger } from './logger'
+
+const log = createLogger({ component: 'FullDiskAccessService' })
+
+const FULL_DISK_ACCESS_URIS = [
+  'x-apple.systempreferences:com.apple.settings.PrivacySecurity.extension?Privacy_AllFiles',
+  'x-apple.systempreferences:com.apple.preference.security?Privacy_AllFiles'
+]
+
+const FDA_PROBE_PATHS = [
+  join(homedir(), 'Library', 'Safari', 'Bookmarks.plist'),
+  join(homedir(), 'Library', 'Safari', 'CloudTabs.db'),
+  join(
+    homedir(),
+    'Library',
+    'Preferences',
+    'com.apple.LaunchServices',
+    'com.apple.launchservices.secure.plist'
+  )
+]
+
+export interface FullDiskAccessStatus {
+  supported: boolean
+  granted: boolean
+}
+
+function isPermissionDeniedError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message.toLowerCase() : String(error).toLowerCase()
+  return (
+    message.includes('operation not permitted') ||
+    message.includes('permission denied') ||
+    message.includes('eacces') ||
+    message.includes('eperm')
+  )
+}
+
+export function checkFullDiskAccess(): FullDiskAccessStatus {
+  if (process.platform !== 'darwin') {
+    return { supported: false, granted: false }
+  }
+
+  let denied = false
+  let readable = false
+
+  for (const probePath of FDA_PROBE_PATHS) {
+    try {
+      accessSync(probePath, constants.R_OK)
+      readable = true
+      break
+    } catch (error) {
+      if (isPermissionDeniedError(error)) {
+        denied = true
+        log.info('Full Disk Access probe denied', { probePath })
+      } else {
+        log.debug('Full Disk Access probe skipped', {
+          probePath,
+          error: error instanceof Error ? error.message : String(error)
+        })
+      }
+    }
+  }
+
+  if (readable) {
+    return { supported: true, granted: true }
+  }
+
+  if (denied) {
+    return { supported: true, granted: false }
+  }
+
+  return { supported: true, granted: false }
+}
+
+export async function openFullDiskAccessSettings(): Promise<{ success: boolean; error?: string }> {
+  if (process.platform !== 'darwin') {
+    return { success: false, error: 'Full Disk Access settings are only available on macOS' }
+  }
+
+  for (const uri of FULL_DISK_ACCESS_URIS) {
+    try {
+      await shell.openExternal(uri)
+      return { success: true }
+    } catch (error) {
+      log.warn('Failed to open Full Disk Access settings URI', {
+        uri,
+        error: error instanceof Error ? error.message : String(error)
+      })
+    }
+  }
+
+  return {
+    success: false,
+    error: 'Failed to open macOS Full Disk Access settings'
+  }
+}

--- a/src/main/services/notification-service.ts
+++ b/src/main/services/notification-service.ts
@@ -16,6 +16,7 @@ type PendingUserFeedbackKind = 'question' | 'approval'
 class NotificationService {
   private mainWindow: BrowserWindow | null = null
   private unreadCount = 0
+  private queuedSessionIds = new Set<string>()
 
   setMainWindow(window: BrowserWindow): void {
     this.mainWindow = window
@@ -27,6 +28,13 @@ class NotificationService {
   }
 
   showSessionComplete(data: SessionNotificationData): void {
+    if (this.queuedSessionIds.has(data.sessionId)) {
+      log.info('Skipping completion notification because session still has queued follow-up', {
+        sessionId: data.sessionId
+      })
+      return
+    }
+
     this.showNotification({
       data,
       body: `"${data.sessionName}" completed`
@@ -41,6 +49,17 @@ class NotificationService {
           ? `"${data.sessionName}" needs your answer`
           : `"${data.sessionName}" needs your permission`
     })
+  }
+
+  setSessionQueuedState(sessionId: string, queued: boolean): void {
+    if (!sessionId) return
+
+    if (queued) {
+      this.queuedSessionIds.add(sessionId)
+      return
+    }
+
+    this.queuedSessionIds.delete(sessionId)
   }
 
   private showNotification({ data, body }: { data: SessionNotificationData; body: string }): void {

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -495,7 +495,10 @@ declare global {
       isLogMode: () => Promise<boolean>
       detectAgentRuntimes: () => Promise<{ opencode: boolean; claude: boolean; codex: boolean }>
       setKeepAwakeEnabled: (enabled: boolean) => Promise<{ success: boolean }>
+      setSessionQueuedState: (sessionId: string, queued: boolean) => Promise<{ success: boolean }>
       runOnboardingDoctor: () => Promise<OnboardingDoctorResult>
+      checkFullDiskAccess: () => Promise<{ supported: boolean; granted: boolean }>
+      openFullDiskAccessSettings: () => Promise<{ success: boolean; error?: string }>
       openCommandInTerminal: (
         command: string,
         options?: { cwd?: string }
@@ -685,6 +688,13 @@ declare global {
       ) => Promise<
         import('../shared/types/agent-ipc').AgentIpcResult<{ commands: AgentCommand[] }>
       >
+      steer: (
+        worktreePath: string,
+        sessionId: string,
+        messageOrParts: string | MessagePart[],
+        model?: { providerID: string; modelID: string; variant?: string },
+        options?: { codexFastMode?: boolean }
+      ) => Promise<import('../shared/types/agent-ipc').AgentIpcResult>
       // Rename a session's title via the agent PATCH API
       renameSession: (
         sessionId: string,
@@ -697,6 +707,7 @@ declare global {
           capabilities?: {
             supportsUndo: boolean
             supportsRedo: boolean
+            supportsSteer: boolean
             supportsCommands: boolean
             supportsPermissionRequests: boolean
             supportsQuestionPrompts: boolean

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -439,9 +439,21 @@ const systemOps = {
   setKeepAwakeEnabled: (enabled: boolean): Promise<{ success: boolean }> =>
     ipcRenderer.invoke('system:setKeepAwakeEnabled', enabled),
 
+  setSessionQueuedState: (
+    sessionId: string,
+    queued: boolean
+  ): Promise<{ success: boolean }> =>
+    ipcRenderer.invoke('system:setSessionQueuedState', sessionId, queued),
+
   // Run the first-launch onboarding doctor
   runOnboardingDoctor: (): Promise<OnboardingDoctorResult> =>
     ipcRenderer.invoke('system:runOnboardingDoctor'),
+
+  checkFullDiskAccess: (): Promise<{ supported: boolean; granted: boolean }> =>
+    ipcRenderer.invoke('system:checkFullDiskAccess'),
+
+  openFullDiskAccessSettings: (): Promise<{ success: boolean; error?: string }> =>
+    ipcRenderer.invoke('system:openFullDiskAccessSettings'),
 
   // Open a command in the user's system terminal
   openCommandInTerminal: (
@@ -1232,6 +1244,15 @@ const agentOps = {
   ): Promise<{ success: boolean; error?: string }> =>
     ipcRenderer.invoke('agent:question:reply', { requestId, answers, worktreePath }),
 
+  steer: (
+    worktreePath: string,
+    sessionId: string,
+    messageOrParts: string | MessagePart[],
+    model?: { providerID: string; modelID: string; variant?: string },
+    options?: { codexFastMode?: boolean }
+  ): Promise<{ success: boolean; error?: string; errorCode?: string }> =>
+    ipcRenderer.invoke('agent:steer', worktreePath, sessionId, messageOrParts, model, options),
+
   // Reject/dismiss a pending question from the AI
   questionReject: (
     requestId: string,
@@ -1372,12 +1393,13 @@ const agentOps = {
     sessionId?: string
   ): Promise<{
     success: boolean
-    capabilities?: {
-      supportsUndo: boolean
-      supportsRedo: boolean
-      supportsCommands: boolean
-      supportsPermissionRequests: boolean
-      supportsQuestionPrompts: boolean
+      capabilities?: {
+        supportsUndo: boolean
+        supportsRedo: boolean
+        supportsSteer: boolean
+        supportsCommands: boolean
+        supportsPermissionRequests: boolean
+        supportsQuestionPrompts: boolean
       supportsModelSelection: boolean
       supportsReconnect: boolean
       supportsPartialStreaming: boolean

--- a/src/renderer/src/components/layout/AppLayout.tsx
+++ b/src/renderer/src/components/layout/AppLayout.tsx
@@ -18,6 +18,9 @@ const SettingsModal = lazy(() =>
 const AgentSetupGuard = lazy(() =>
   import('@/components/setup').then((m) => ({ default: m.AgentSetupGuard }))
 )
+const FdaSetupGuard = lazy(() =>
+  import('@/components/setup').then((m) => ({ default: m.FdaSetupGuard }))
+)
 const HelpOverlay = lazy(() =>
   import('@/components/ui/HelpOverlay').then((m) => ({ default: m.HelpOverlay }))
 )
@@ -238,6 +241,7 @@ export function AppLayout({ children }: AppLayoutProps): React.JSX.Element {
         </ErrorBoundary>
         <GlobalProjectSettings />
         <AgentSetupGuard />
+        <FdaSetupGuard />
         <HelpOverlay />
       </Suspense>
     </div>

--- a/src/renderer/src/components/session-hq/AgentTimeline.tsx
+++ b/src/renderer/src/components/session-hq/AgentTimeline.tsx
@@ -20,6 +20,7 @@ import { CopyMessageButton } from '@/components/sessions/CopyMessageButton'
 import { ForkMessageButton } from '@/components/sessions/ForkMessageButton'
 import { Button } from '@/components/ui/button'
 import { useI18n } from '@/i18n/useI18n'
+import { isTodoWriteTool } from '@/components/sessions/tools/todo-utils'
 import {
   BashCard,
   FileReadCard,
@@ -193,7 +194,7 @@ function messageToNodes(message: TimelineMessage): TimelineNode[] {
       } else if (toolName === 'askuserquestion' || toolName === 'ask_user') {
         cardType = 'ask-user'
       } else if (
-        toolName === 'todowrite' || toolName === 'todo_write' ||
+        isTodoWriteTool(toolName) ||
         toolName === 'taskcreate' || toolName === 'task_create' ||
         toolName === 'taskupdate' || toolName === 'task_update' ||
         toolName === 'todoread' || toolName === 'todo_read' ||
@@ -331,6 +332,13 @@ function TimelineNodeView({
       return (
         <div className="group/user-message">
           <div className="bg-blue-500/5 border border-blue-500/20 rounded-[10px] px-3.5 py-2.5">
+            {node.message.steered === true && (
+              <div className="mb-2">
+                <span className="inline-flex items-center rounded-md bg-sky-500/15 px-2 py-0.5 text-[10px] font-semibold text-sky-500">
+                  STEERED
+                </span>
+              </div>
+            )}
             {images.length > 0 && (
               <div className="flex flex-wrap gap-2">
                 {images.map((img, i) => (

--- a/src/renderer/src/components/session-hq/ComposerBar.tsx
+++ b/src/renderer/src/components/session-hq/ComposerBar.tsx
@@ -7,17 +7,24 @@
  */
 
 import React, { useRef, useCallback, useState, useEffect, useMemo } from 'react'
-import { ArrowUp, Square, CornerDownLeft } from 'lucide-react'
+import { ArrowUp, Square, CornerDownLeft, ChevronDown } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { AttachmentButton } from '../sessions/AttachmentButton'
 import { AttachmentPreview, type Attachment } from '../sessions/AttachmentPreview'
 import { SlashCommandPopover } from '../sessions/SlashCommandPopover'
 import { BUILT_IN_SLASH_COMMANDS } from '../sessions/SessionView'
 import { Button } from '@/components/ui/button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger
+} from '@/components/ui/dropdown-menu'
 import type { SessionLifecycle, InterruptItem } from '@/stores/useSessionRuntimeStore'
 import { isComposingKeyboardEvent } from '@/lib/message-composer-shortcuts'
 import {
   determineComposerActions,
+  getActionLabel,
   type ComposerAction,
   type ComposerActionSet
 } from '@/lib/session-send-actions'
@@ -32,9 +39,15 @@ export interface ComposerBarProps {
   pendingCount: number
   firstInterrupt: InterruptItem | null
   /** Called when user executes the primary action with content */
-  onAction: (action: ComposerAction, content: string, attachments: Attachment[]) => void
+  onAction: (
+    action: ComposerAction,
+    content: string,
+    attachments: Attachment[]
+  ) => Promise<boolean>
   /** Whether the session is connected and ready to accept input */
   isConnected: boolean
+  /** Runtime capability gate for steer */
+  supportsSteer?: boolean
   /** Max attachments allowed */
   maxAttachments?: number
   /** Current session mode */
@@ -75,6 +88,7 @@ export function ComposerBar({
   firstInterrupt,
   onAction,
   isConnected,
+  supportsSteer = false,
   maxAttachments = 10,
   mode = 'build',
   onToggleMode,
@@ -135,11 +149,20 @@ export function ComposerBar({
     lifecycle,
     hasInterrupt: firstInterrupt != null,
     hasPendingMessages: pendingCount > 0,
-    isConnected
+    isConnected,
+    supportsSteer
   })
 
   const canSend = content.trim().length > 0 || attachments.length > 0
   const isDisabled = !actionSet.inputEnabled
+  const availableAlternatives = useMemo(
+    () =>
+      actionSet.alternatives.filter((action) => {
+        if (action !== 'steer') return true
+        return supportsSteer && attachments.length === 0
+      }),
+    [actionSet.alternatives, attachments.length, supportsSteer]
+  )
 
   // Auto-resize textarea
   useEffect(() => {
@@ -162,27 +185,44 @@ export function ComposerBar({
     if (ta) ta.style.height = 'auto'
   }, [sessionId])
 
-  const handleSubmit = useCallback(() => {
+  const handleActionSelection = useCallback(
+    async (action: ComposerAction): Promise<void> => {
+      const hasContent = content.trim().length > 0 || attachments.length > 0
+
+      if (action === 'stop_and_send' && !hasContent) {
+        await onAction('stop_and_send', '', [])
+        return
+      }
+
+      if (!hasContent && action !== 'reply_interrupt') return
+
+      const consumed = await onAction(action, content.trim(), attachments)
+      if (consumed) {
+        clearInput()
+      }
+    },
+    [attachments, clearInput, content, onAction]
+  )
+
+  const handleSubmit = useCallback(async () => {
     if (!actionSet.primary) return
 
-    // Stop actions don't need content
     if (actionSet.primary === 'stop_and_send' && !canSend) {
-      onAction('stop_and_send', '', [])
+      await handleActionSelection('stop_and_send')
       return
     }
 
     if (!canSend && actionSet.primary !== 'reply_interrupt') return
 
-    onAction(actionSet.primary, content.trim(), attachments)
-    clearInput()
-  }, [actionSet.primary, canSend, content, attachments, onAction, clearInput])
+    await handleActionSelection(actionSet.primary)
+  }, [actionSet.primary, canSend, handleActionSelection])
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
       if (isComposingKeyboardEvent(e.nativeEvent)) return
       if (e.key === 'Enter' && !e.shiftKey) {
         e.preventDefault()
-        handleSubmit()
+        void handleSubmit()
       }
     },
     [handleSubmit]
@@ -247,6 +287,9 @@ export function ComposerBar({
   const buttonEnabled =
     actionSet.primary != null &&
     (actionSet.iconHint === 'stop' || canSend || actionSet.primary === 'reply_interrupt')
+  const alternativesEnabled =
+    availableAlternatives.length > 0 &&
+    (canSend || availableAlternatives.includes('stop_and_send'))
 
   return (
     <div
@@ -345,9 +388,44 @@ export function ComposerBar({
 
         <div className="flex-1" />
 
+        {availableAlternatives.length > 0 && (
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <button
+                type="button"
+                disabled={!alternativesEnabled}
+                className={cn(
+                  'h-8 w-8 rounded-full flex items-center justify-center shrink-0 transition-colors',
+                  alternativesEnabled
+                    ? 'border border-border/70 bg-background/70 text-muted-foreground hover:bg-background'
+                    : 'border border-border/50 bg-muted text-muted-foreground cursor-not-allowed'
+                )}
+                aria-label="More send actions"
+                title="More send actions"
+              >
+                <ChevronDown className="h-4 w-4" />
+              </button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" className="w-44">
+              {availableAlternatives.map((action) => (
+                <DropdownMenuItem
+                  key={action}
+                  onClick={() => {
+                    void handleActionSelection(action)
+                  }}
+                >
+                  {getActionLabel(action)}
+                </DropdownMenuItem>
+              ))}
+            </DropdownMenuContent>
+          </DropdownMenu>
+        )}
+
         {/* Send / Stop icon button */}
         <button
-          onClick={handleSubmit}
+          onClick={() => {
+            void handleSubmit()
+          }}
           disabled={!buttonEnabled}
           className={cn(
             'h-8 w-8 rounded-full flex items-center justify-center shrink-0 transition-colors',

--- a/src/renderer/src/components/session-hq/SessionShell.tsx
+++ b/src/renderer/src/components/session-hq/SessionShell.tsx
@@ -65,13 +65,14 @@ import {
 } from '@/lib/message-actions'
 import { useI18n } from '@/i18n/useI18n'
 import { toast } from 'sonner'
+import { isTodoWriteTool } from '@/components/sessions/tools/todo-utils'
 
 // ---------------------------------------------------------------------------
 // Extract mission tasks from committed timeline messages
 // ---------------------------------------------------------------------------
 
 function extractMissionTasks(messages: TimelineMessage[]): MissionTask[] {
-  // Scan from end to find the latest TodoWrite
+  // Scan from end to find the latest todo-like tool snapshot
   for (let i = messages.length - 1; i >= 0; i--) {
     const msg = messages[i]
     if (msg.role !== 'assistant') continue
@@ -79,7 +80,7 @@ function extractMissionTasks(messages: TimelineMessage[]): MissionTask[] {
     for (const part of msg.parts ?? []) {
       if (part.type !== 'tool_use' || !part.toolUse) continue
       const toolName = part.toolUse.name?.toLowerCase() ?? ''
-      if (toolName !== 'todowrite' && toolName !== 'todo_write') continue
+      if (!isTodoWriteTool(toolName)) continue
 
       const todos = part.toolUse.input?.todos
       if (!Array.isArray(todos)) continue
@@ -357,6 +358,7 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
 
   // Incremented when session.commands_available fires — triggers ComposerBar re-fetch
   const [commandsVersion, setCommandsVersion] = useState(0)
+  const [supportsSteer, setSupportsSteer] = useState(agentSdk === 'codex')
   const [editingMessageId, setEditingMessageId] = useState<string | null>(null)
   const [editingContent, setEditingContent] = useState('')
   const [forkingMessageId, setForkingMessageId] = useState<string | null>(null)
@@ -364,6 +366,31 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
   const [forkConfirmDismissChecked, setForkConfirmDismissChecked] = useState(false)
 
   const streamingContentRef = useRef(_initBuffer?.streamingContent ?? '')
+
+  useEffect(() => {
+    if (!droidSessionId || !window.agentOps?.capabilities) {
+      setSupportsSteer(agentSdk === 'codex')
+      return
+    }
+
+    let cancelled = false
+
+    window.agentOps
+      .capabilities(droidSessionId)
+      .then((result) => {
+        if (cancelled) return
+        setSupportsSteer(Boolean(result.success && result.capabilities?.supportsSteer))
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setSupportsSteer(agentSdk === 'codex')
+        }
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [agentSdk, droidSessionId])
 
   // --- Streaming parts for real-time tool rendering ---
   const [streamingParts, setStreamingParts] = useState<SharedStreamingPart[]>(
@@ -819,7 +846,7 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
 
             // --- Mission Control: detect todo/task tools ---
             const lowerToolName = toolName?.toLowerCase() ?? ''
-            if (lowerToolName === 'todowrite' || lowerToolName === 'todo_write') {
+            if (isTodoWriteTool(lowerToolName)) {
               const todos = (state.input as Record<string, unknown>)?.todos
               if (Array.isArray(todos)) {
                 const newTasks: MissionTask[] = todos.map(
@@ -1068,8 +1095,9 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
 
   // --- Composer action handler ---
   const handleComposerAction = useCallback(
-    async (action: ComposerAction, content: string, attachments: Attachment[]) => {
-      if (!worktreePath || !droidSessionId) return
+    async (action: ComposerAction, content: string, attachments: Attachment[]): Promise<boolean> => {
+      if (!worktreePath || !droidSessionId) return false
+      let optimisticMessageId: string | null = null
 
       // Pure stop (no content) — just abort, don't clear anything
       if (action === 'stop_and_send' && !content.trim()) {
@@ -1078,7 +1106,7 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
         } catch (err) {
           console.error('[SessionShell] abort failed:', err)
         }
-        return
+        return false
       }
 
       if (action === 'send' || action === 'stop_and_send' || action === 'steer') {
@@ -1108,6 +1136,7 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
           timestamp: new Date().toISOString(),
           ...(optimisticAttachments.length > 0 ? { attachments: optimisticAttachments } : {})
         }
+        optimisticMessageId = optimisticMsg.id
         appendOptimistic(optimisticMsg)
         // Sync ref immediately so MissionControl's streaming callback can find
         // the user message before the next useEffect tick
@@ -1127,6 +1156,7 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
             }
             return window.agentOps.prompt(wp, sid, messageParts ?? c, requestModel)
           },
+          steer: (wp, sid, c) => window.agentOps.steer(wp, sid, c, requestModel),
           abort: (wp, sid) => window.agentOps.abort(wp, sid),
           queueMessage: (sid, msg) => useSessionRuntimeStore.getState().queueMessage(sid, msg)
         })
@@ -1134,12 +1164,33 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
         if (!consumed && (action === 'send' || action === 'stop_and_send')) {
           setIsStreaming(false)
         }
+
+        return consumed
       } catch (err) {
         console.error('[SessionShell] action failed:', err)
+        if (optimisticMessageId) {
+          optimisticRef.current = optimisticRef.current.filter((msg) => msg.id !== optimisticMessageId)
+          timelineMessagesRef.current = timelineMessagesRef.current.filter(
+            (msg) => msg.id !== optimisticMessageId
+          )
+          setMessages((prev) => prev.filter((msg) => msg.id !== optimisticMessageId))
+          flushBuffer()
+        }
+        toast.error(err instanceof Error ? err.message : 'Failed to send message')
         setIsStreaming(false)
+        return false
       }
     },
-    [worktreePath, droidSessionId, sessionId, appendOptimistic, flushBuffer, requestModel]
+    [
+      worktreePath,
+      droidSessionId,
+      sessionId,
+      appendOptimistic,
+      flushBuffer,
+      optimisticRef,
+      requestModel,
+      setMessages
+    ]
   )
 
   const canEditUserMessage = useCallback(
@@ -1509,6 +1560,7 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
           firstInterrupt={composerInterrupt}
           onAction={handleComposerAction}
           isConnected={!!droidSessionId && !!worktreePath}
+          supportsSteer={supportsSteer}
           mode={mode}
           onToggleMode={toggleMode}
           pendingPlan={pendingPlan}

--- a/src/renderer/src/components/session-hq/cards/TodoCard.tsx
+++ b/src/renderer/src/components/session-hq/cards/TodoCard.tsx
@@ -124,7 +124,13 @@ export function TodoCard(props: TodoCardProps): React.JSX.Element {
   // --- Tool use mode ---
   const { toolUse } = props
   const items = parseItems(toolUse)
-  const toolLabel = toolUse.name === 'TodoWrite' ? 'Task List' : toolUse.name
+  const lowerToolName = toolUse.name.toLowerCase()
+  const toolLabel =
+    toolUse.name === 'TodoWrite'
+      ? 'Task List'
+      : lowerToolName === 'update_plan'
+        ? 'Plan Update'
+        : toolUse.name
 
   return (
     <ActionCard

--- a/src/renderer/src/components/sessions/MessageRenderer.tsx
+++ b/src/renderer/src/components/sessions/MessageRenderer.tsx
@@ -90,6 +90,7 @@ export function MessageRenderer({
           timestamp={message.timestamp}
           isPlanMode={isPlanMode}
           isAskMode={isAskMode}
+          isSteered={message.steered === true}
           attachments={message.attachments}
           isEditing={isEditing}
           isLastUserMessage={isLastUserMessage}

--- a/src/renderer/src/components/sessions/SessionView.tsx
+++ b/src/renderer/src/components/sessions/SessionView.tsx
@@ -148,6 +148,7 @@ export interface OpenCodeMessage {
   role: 'user' | 'assistant' | 'system'
   content: string
   timestamp: string
+  steered?: boolean
   /** Interleaved parts for assistant messages with tool calls */
   parts?: StreamingPart[]
   /** File attachments for user messages (images, PDFs, etc.) */

--- a/src/renderer/src/components/sessions/UserBubble.tsx
+++ b/src/renderer/src/components/sessions/UserBubble.tsx
@@ -7,6 +7,7 @@ interface UserBubbleProps {
   timestamp?: string
   isPlanMode?: boolean
   isAskMode?: boolean
+  isSteered?: boolean
   attachments?: MessagePart[]
   isEditing?: boolean
   isLastUserMessage?: boolean
@@ -22,6 +23,7 @@ export function UserBubble({
   content,
   isPlanMode,
   isAskMode,
+  isSteered,
   attachments,
   isEditing,
   canEdit,
@@ -73,6 +75,14 @@ export function UserBubble({
               data-testid="ask-mode-badge"
             >
               ASK
+            </span>
+          )}
+          {isSteered && (
+            <span
+              className="inline-flex items-center px-2 py-0.5 rounded-md text-[10px] font-semibold bg-sky-500/15 text-sky-500 mb-1"
+              data-testid="steered-mode-badge"
+            >
+              STEERED
             </span>
           )}
           {imageAttachments.length > 0 && (

--- a/src/renderer/src/components/sessions/tools/todo-utils.ts
+++ b/src/renderer/src/components/sessions/tools/todo-utils.ts
@@ -18,7 +18,7 @@ export interface TodoTrackerSnapshot {
 
 export function isTodoWriteTool(name: string): boolean {
   const lower = name.toLowerCase()
-  return lower.includes('todowrite') || lower.includes('todo_write')
+  return lower.includes('todowrite') || lower.includes('todo_write') || lower === 'update_plan'
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/src/renderer/src/components/settings/SettingsPrivacy.tsx
+++ b/src/renderer/src/components/settings/SettingsPrivacy.tsx
@@ -1,12 +1,17 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useCallback } from 'react'
 import { useSettingsStore } from '@/stores/useSettingsStore'
 import { cn } from '@/lib/utils'
 import { useI18n } from '@/i18n/useI18n'
+import { Button } from '@/components/ui/button'
+import { toast } from 'sonner'
 
 export function SettingsPrivacy(): React.JSX.Element {
   const updateSetting = useSettingsStore((s) => s.updateSetting)
   const [enabled, setEnabled] = useState(true)
   const [loaded, setLoaded] = useState(false)
+  const [platform, setPlatform] = useState<string | null>(null)
+  const [fdaStatus, setFdaStatus] = useState<{ supported: boolean; granted: boolean } | null>(null)
+  const [fdaChecking, setFdaChecking] = useState(false)
   const { t } = useI18n()
 
   useEffect(() => {
@@ -21,11 +26,59 @@ export function SettingsPrivacy(): React.JSX.Element {
       })
   }, [])
 
+  useEffect(() => {
+    let cancelled = false
+
+    window.systemOps
+      .getPlatform()
+      .then((value) => {
+        if (!cancelled) {
+          setPlatform(value)
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setPlatform(null)
+        }
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  const refreshFdaStatus = useCallback(async (): Promise<void> => {
+    if (platform !== 'darwin') return
+
+    setFdaChecking(true)
+    try {
+      const result = await window.systemOps.checkFullDiskAccess()
+      setFdaStatus(result)
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : t('settings.privacy.fda.checkFailed'))
+    } finally {
+      setFdaChecking(false)
+    }
+  }, [platform, t])
+
+  useEffect(() => {
+    if (platform === 'darwin') {
+      void refreshFdaStatus()
+    }
+  }, [platform, refreshFdaStatus])
+
   const handleToggle = () => {
     const newValue = !enabled
     setEnabled(newValue)
     updateSetting('telemetryEnabled', newValue)
     window.analyticsOps.setEnabled(newValue)
+  }
+
+  const handleOpenFdaSettings = async () => {
+    const result = await window.systemOps.openFullDiskAccessSettings()
+    if (!result.success) {
+      toast.error(result.error || t('settings.privacy.fda.openFailed'))
+    }
   }
 
   if (!loaded) return <div />
@@ -77,6 +130,56 @@ export function SettingsPrivacy(): React.JSX.Element {
           {t('settings.privacy.neverCollect.description')}
         </p>
       </div>
+
+      {platform === 'darwin' && (
+        <div className="rounded-md border border-border bg-background/50 p-4 space-y-3">
+          <div>
+            <div className="text-sm font-medium">{t('settings.privacy.fda.title')}</div>
+            <p className="text-xs text-muted-foreground mt-0.5">
+              {t('settings.privacy.fda.description')}
+            </p>
+          </div>
+
+          <div className="flex items-center justify-between gap-3">
+            <div className="text-sm">
+              {fdaStatus?.granted
+                ? t('settings.privacy.fda.statusGranted')
+                : t('settings.privacy.fda.statusNotGranted')}
+            </div>
+            <div
+              className={cn(
+                'inline-flex items-center rounded-full px-2.5 py-1 text-xs font-medium',
+                fdaStatus?.granted
+                  ? 'bg-emerald-500/10 text-emerald-600 dark:text-emerald-400'
+                  : 'bg-amber-500/10 text-amber-600 dark:text-amber-400'
+              )}
+            >
+              {fdaChecking
+                ? t('settings.privacy.fda.checking')
+                : fdaStatus?.granted
+                  ? t('settings.privacy.fda.grantedBadge')
+                  : t('settings.privacy.fda.notGrantedBadge')}
+            </div>
+          </div>
+
+          <div className="flex flex-wrap gap-2">
+            <Button type="button" variant="outline" size="sm" onClick={() => void refreshFdaStatus()}>
+              {t('settings.privacy.fda.checkAgain')}
+            </Button>
+            <Button type="button" size="sm" onClick={() => void handleOpenFdaSettings()}>
+              {t('settings.privacy.fda.openSettings')}
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={() => updateSetting('fdaOnboardingDismissed', false)}
+            >
+              {t('settings.privacy.fda.showOnboardingAgain')}
+            </Button>
+          </div>
+        </div>
+      )}
     </div>
   )
 }

--- a/src/renderer/src/components/setup/FdaSetupGuard.tsx
+++ b/src/renderer/src/components/setup/FdaSetupGuard.tsx
@@ -1,0 +1,80 @@
+import { useCallback, useEffect, useState } from 'react'
+import { Button } from '@/components/ui/button'
+import { useSettingsStore } from '@/stores/useSettingsStore'
+import { useI18n } from '@/i18n/useI18n'
+import { toast } from 'sonner'
+
+export function FdaSetupGuard(): React.JSX.Element | null {
+  const { t } = useI18n()
+  const initialSetupComplete = useSettingsStore((s) => s.initialSetupComplete)
+  const dismissed = useSettingsStore((s) => s.fdaOnboardingDismissed)
+  const updateSetting = useSettingsStore((s) => s.updateSetting)
+
+  const [platform, setPlatform] = useState<string | null>(null)
+  const [status, setStatus] = useState<{ supported: boolean; granted: boolean } | null>(null)
+  const [checking, setChecking] = useState(false)
+
+  const refreshStatus = useCallback(async (): Promise<void> => {
+    setChecking(true)
+    try {
+      const [nextPlatform, nextStatus] = await Promise.all([
+        window.systemOps.getPlatform(),
+        window.systemOps.checkFullDiskAccess()
+      ])
+      setPlatform(nextPlatform)
+      setStatus(nextStatus)
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : t('settings.privacy.fda.checkFailed'))
+    } finally {
+      setChecking(false)
+    }
+  }, [t])
+
+  useEffect(() => {
+    if (!initialSetupComplete || dismissed) return
+    void refreshStatus()
+  }, [dismissed, initialSetupComplete, refreshStatus])
+
+  if (
+    !initialSetupComplete ||
+    dismissed ||
+    platform !== 'darwin' ||
+    !status?.supported ||
+    status.granted
+  ) {
+    return null
+  }
+
+  const handleOpenSettings = async () => {
+    const result = await window.systemOps.openFullDiskAccessSettings()
+    if (!result.success) {
+      toast.error(result.error || t('settings.privacy.fda.openFailed'))
+    }
+  }
+
+  return (
+    <div className="fixed bottom-6 right-6 z-50 w-[360px] rounded-2xl border border-border/70 bg-background/95 p-4 shadow-2xl backdrop-blur-xl">
+      <div className="space-y-2">
+        <div className="text-sm font-semibold">{t('settings.privacy.fda.guardTitle')}</div>
+        <p className="text-sm text-muted-foreground">{t('settings.privacy.fda.guardDescription')}</p>
+      </div>
+
+      <div className="mt-4 flex flex-wrap gap-2">
+        <Button type="button" size="sm" onClick={() => void handleOpenSettings()}>
+          {t('settings.privacy.fda.openSettings')}
+        </Button>
+        <Button type="button" size="sm" variant="outline" onClick={() => void refreshStatus()}>
+          {checking ? t('settings.privacy.fda.checking') : t('settings.privacy.fda.checkAgain')}
+        </Button>
+        <Button
+          type="button"
+          size="sm"
+          variant="ghost"
+          onClick={() => updateSetting('fdaOnboardingDismissed', true)}
+        >
+          {t('settings.privacy.fda.skipForNow')}
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/setup/index.ts
+++ b/src/renderer/src/components/setup/index.ts
@@ -1,1 +1,2 @@
 export { AgentSetupGuard } from './AgentSetupGuard'
+export { FdaSetupGuard } from './FdaSetupGuard'

--- a/src/renderer/src/i18n/messages.ts
+++ b/src/renderer/src/i18n/messages.ts
@@ -241,6 +241,24 @@ export const messages: Record<AppLocale, MessageTree> = {
           label: 'Send anonymous usage analytics',
           description: 'Help improve Xuanpu by sharing anonymous feature usage data'
         },
+        fda: {
+          title: 'Full Disk Access',
+          description: 'Helps Xuanpu and agent runtimes read files in protected macOS locations.',
+          statusGranted: 'Full Disk Access is granted.',
+          statusNotGranted: 'Full Disk Access is not granted.',
+          grantedBadge: 'Granted',
+          notGrantedBadge: 'Not granted',
+          checking: 'Checking...',
+          checkAgain: 'Check Again',
+          openSettings: 'Open System Settings',
+          showOnboardingAgain: 'Show onboarding again',
+          skipForNow: 'Skip for now',
+          guardTitle: 'Grant Full Disk Access',
+          guardDescription:
+            'Some coding tasks need access to files protected by macOS. You can enable Full Disk Access now or dismiss this reminder.',
+          checkFailed: 'Failed to check Full Disk Access status',
+          openFailed: 'Failed to open Full Disk Access settings'
+        },
         collect: {
           title: 'What we collect:',
           description: 'Feature usage counts, app version, platform (macOS/Windows/Linux).'
@@ -2382,6 +2400,24 @@ export const messages: Record<AppLocale, MessageTree> = {
         analytics: {
           label: '发送匿名使用分析数据',
           description: '通过共享匿名功能使用数据帮助改进玄圃'
+        },
+        fda: {
+          title: '完全磁盘访问权限',
+          description: '帮助玄圃和 Agent 运行时读取 macOS 受保护目录中的文件。',
+          statusGranted: '已授予完全磁盘访问权限。',
+          statusNotGranted: '尚未授予完全磁盘访问权限。',
+          grantedBadge: '已授予',
+          notGrantedBadge: '未授予',
+          checking: '检查中...',
+          checkAgain: '重新检查',
+          openSettings: '打开系统设置',
+          showOnboardingAgain: '再次显示引导',
+          skipForNow: '暂时跳过',
+          guardTitle: '授予完全磁盘访问权限',
+          guardDescription:
+            '部分编码任务需要访问 macOS 保护的文件。你可以现在开启完全磁盘访问权限，或先关闭这条提醒。',
+          checkFailed: '检查完全磁盘访问权限状态失败',
+          openFailed: '打开完全磁盘访问权限设置失败'
         },
         collect: {
           title: '我们会收集：',

--- a/src/renderer/src/lib/opencode-transcript.ts
+++ b/src/renderer/src/lib/opencode-transcript.ts
@@ -39,6 +39,7 @@ export interface OpenCodeMessage {
   role: 'user' | 'assistant' | 'system'
   content: string
   timestamp: string
+  steered?: boolean
   parts?: StreamingPart[]
   /** File attachments for user messages (images, PDFs, etc.) */
   attachments?: MessagePart[]
@@ -289,6 +290,7 @@ function mapMessage(rawMessage: unknown, index: number): MappedMessage {
       role,
       content,
       timestamp,
+      ...(messageRecord?.steered === true || info?.steered === true ? { steered: true } : {}),
       parts: mappedParts.length > 0 ? mappedParts : undefined,
       ...(role === 'user' && fileAttachments.length > 0
         ? { attachments: fileAttachments }

--- a/src/renderer/src/lib/session-send-actions.ts
+++ b/src/renderer/src/lib/session-send-actions.ts
@@ -29,6 +29,7 @@ export interface ComposerInput {
   hasInterrupt: boolean
   hasPendingMessages: boolean
   isConnected: boolean
+  supportsSteer?: boolean
 }
 
 /** Result of the state-machine evaluation */
@@ -60,7 +61,7 @@ export interface ComposerActionSet {
  *   5. retry → queue (primary), stop+send (alt)
  */
 export function determineComposerActions(input: ComposerInput): ComposerActionSet {
-  const { lifecycle, hasInterrupt, hasPendingMessages, isConnected } = input
+  const { lifecycle, hasInterrupt, hasPendingMessages, isConnected, supportsSteer = false } = input
 
   // 1. Not connected
   if (!isConnected) {
@@ -100,7 +101,7 @@ export function determineComposerActions(input: ComposerInput): ComposerActionSe
     case 'materializing':
       return {
         primary: 'stop_and_send',
-        alternatives: ['queue', 'steer'],
+        alternatives: supportsSteer ? ['queue', 'steer'] : ['queue'],
         inputEnabled: true,
         primaryLabel: 'Stop',
         iconHint: 'stop'
@@ -173,6 +174,12 @@ export interface SendContext {
     sessionId: string,
     content: string
   ) => Promise<{ success: boolean; error?: string }>
+  /** IPC: steer the active turn */
+  steer: (
+    worktreePath: string,
+    sessionId: string,
+    content: string
+  ) => Promise<{ success: boolean; error?: string }>
   /** IPC: abort the current agent run */
   abort: (
     worktreePath: string,
@@ -198,9 +205,22 @@ export async function executeSendAction(
   attachments: Array<{ kind: string; id: string; name: string; mime: string; [k: string]: unknown }>,
   ctx: SendContext
 ): Promise<boolean> {
+  const ensureSuccess = async (
+    op: Promise<{ success: boolean; error?: string }>,
+    fallbackMessage: string
+  ): Promise<void> => {
+    const result = await op
+    if (!result.success) {
+      throw new Error(result.error || fallbackMessage)
+    }
+  }
+
   switch (action) {
     case 'send': {
-      await ctx.prompt(ctx.worktreePath, ctx.sessionId, content)
+      await ensureSuccess(
+        ctx.prompt(ctx.worktreePath, ctx.sessionId, content),
+        'Failed to send message'
+      )
       return true
     }
 
@@ -211,24 +231,38 @@ export async function executeSendAction(
     }
 
     case 'steer': {
-      // Steer = send the message while the agent is busy; the agent reads it
-      // as redirecting context and adjusts its current task.
-      await ctx.prompt(ctx.worktreePath, ctx.sessionId, content)
+      if (attachments.length > 0) {
+        throw new Error('Steer only supports text messages')
+      }
+
+      await ensureSuccess(
+        ctx.steer(ctx.worktreePath, ctx.sessionId, content),
+        'Failed to steer active turn'
+      )
       return true
     }
 
     case 'stop_and_send': {
-      await ctx.abort(ctx.worktreePath, ctx.sessionId)
+      await ensureSuccess(
+        ctx.abort(ctx.worktreePath, ctx.sessionId),
+        'Failed to stop active turn'
+      )
       // Brief delay so the abort propagates before the new prompt
       await new Promise((r) => setTimeout(r, 100))
-      await ctx.prompt(ctx.worktreePath, ctx.sessionId, content)
+      await ensureSuccess(
+        ctx.prompt(ctx.worktreePath, ctx.sessionId, content),
+        'Failed to send message after stopping active turn'
+      )
       return true
     }
 
     case 'reply_interrupt': {
       // The interrupt dock handles the structured reply; the composer just
       // sends the free-text content as a regular prompt.
-      await ctx.prompt(ctx.worktreePath, ctx.sessionId, content)
+      await ensureSuccess(
+        ctx.prompt(ctx.worktreePath, ctx.sessionId, content),
+        'Failed to reply to interrupt'
+      )
       return true
     }
   }

--- a/src/renderer/src/stores/useSessionRuntimeStore.ts
+++ b/src/renderer/src/stores/useSessionRuntimeStore.ts
@@ -164,6 +164,20 @@ export type SessionRuntimeStore = SessionRuntimeStoreState & SessionRuntimeStore
 const EMPTY_INTERRUPT_QUEUE: readonly InterruptItem[] = []
 const EMPTY_PENDING_MESSAGES: readonly PendingMessage[] = []
 
+function syncQueuedState(sessionId: string, queued: boolean): void {
+  if (typeof window === 'undefined' || !window.systemOps?.setSessionQueuedState) {
+    return
+  }
+
+  window.systemOps.setSessionQueuedState(sessionId, queued).catch((error) => {
+    console.warn('[SessionRuntimeStore] Failed to sync queued state', {
+      sessionId,
+      queued,
+      error
+    })
+  })
+}
+
 function ensureSession(
   sessions: Map<string, SessionRuntimeState>,
   sessionId: string
@@ -346,16 +360,19 @@ export const useSessionRuntimeStore = create<SessionRuntimeStore>()((set, get) =
       pending.set(sessionId, queue)
       return { pendingMessages: pending }
     })
+    syncQueuedState(sessionId, true)
   },
 
   dequeueMessage(sessionId) {
     // P1-5 CR fix: read-then-write inside the set() updater to avoid TOCTOU race
     let first: PendingMessage | null = null
+    let stillQueued = false
     set((state) => {
       const queue = state.pendingMessages.get(sessionId)
       if (!queue || queue.length === 0) return state
       const [head, ...rest] = queue
       first = head
+      stillQueued = rest.length > 0
       const pending = new Map(state.pendingMessages)
       if (rest.length === 0) {
         pending.delete(sessionId)
@@ -364,6 +381,9 @@ export const useSessionRuntimeStore = create<SessionRuntimeStore>()((set, get) =
       }
       return { pendingMessages: pending }
     })
+    if (first) {
+      syncQueuedState(sessionId, stillQueued)
+    }
     return first
   },
 
@@ -376,16 +396,22 @@ export const useSessionRuntimeStore = create<SessionRuntimeStore>()((set, get) =
   },
 
   clearPendingMessages(sessionId) {
+    let changed = false
     set((state) => {
       const pending = new Map(state.pendingMessages)
       if (!pending.has(sessionId)) return state
+      changed = true
       pending.delete(sessionId)
       return { pendingMessages: pending }
     })
+    if (changed) {
+      syncQueuedState(sessionId, false)
+    }
   },
 
   // -- Cleanup --
   clearSession(sessionId) {
+    const hadPending = get().pendingMessages.has(sessionId)
     set((state) => {
       const sessions = new Map(state.sessions)
       const queues = new Map(state.interruptQueues)
@@ -397,5 +423,8 @@ export const useSessionRuntimeStore = create<SessionRuntimeStore>()((set, get) =
     })
     _sessionEventCallbacks.delete(sessionId)
     _streamingBuffers.delete(sessionId)
+    if (hadPending) {
+      syncQueuedState(sessionId, false)
+    }
   }
 }))

--- a/src/renderer/src/stores/useSettingsStore.ts
+++ b/src/renderer/src/stores/useSettingsStore.ts
@@ -130,6 +130,7 @@ export interface AppSettings {
 
   // Privacy
   telemetryEnabled: boolean
+  fdaOnboardingDismissed: boolean
 
   // Git
   autoPullBeforeWorktree: boolean
@@ -191,6 +192,7 @@ const DEFAULT_SETTINGS: AppSettings = {
     enabled: false
   },
   telemetryEnabled: true,
+  fdaOnboardingDismissed: false,
   autoPullBeforeWorktree: true,
   keepAwakeEnabled: false,
   uiZoomLevel: 0,
@@ -301,6 +303,7 @@ function extractSettings(state: SettingsState): AppSettings {
     initialSetupComplete: state.initialSetupComplete,
     commandFilter: state.commandFilter,
     telemetryEnabled: state.telemetryEnabled,
+    fdaOnboardingDismissed: state.fdaOnboardingDismissed,
     autoPullBeforeWorktree: state.autoPullBeforeWorktree,
     keepAwakeEnabled: state.keepAwakeEnabled,
     uiZoomLevel: state.uiZoomLevel,
@@ -520,6 +523,7 @@ export const useSettingsStore = create<SettingsState>()(
         initialSetupComplete: state.initialSetupComplete,
         commandFilter: state.commandFilter,
         telemetryEnabled: state.telemetryEnabled,
+        fdaOnboardingDismissed: state.fdaOnboardingDismissed,
         keepAwakeEnabled: state.keepAwakeEnabled,
         uiZoomLevel: state.uiZoomLevel,
         uiFontScale: state.uiFontScale,

--- a/src/shared/lib/timeline-mappers.ts
+++ b/src/shared/lib/timeline-mappers.ts
@@ -285,6 +285,7 @@ function mapRawMessage(rawMessage: unknown, index: number): MappedMessage {
       role,
       content,
       timestamp,
+      ...(messageRecord?.steered === true || info?.steered === true ? { steered: true } : {}),
       parts: mappedParts.length > 0 ? mappedParts : undefined,
       ...(role === 'user' && fileAttachments.length > 0
         ? { attachments: fileAttachments }
@@ -362,6 +363,7 @@ export function mapDbRowsToTimelineMessages(messages: DbSessionMessage[]): Timel
   return messages
     .filter((m) => !(m.role === 'user' && isSyntheticUserMessage(m.content)))
     .map((message) => {
+    const parsedMessage = parseJson<Record<string, unknown>>(message.opencode_message_json)
     const parsedParts = parseJson<unknown[]>(message.opencode_parts_json)
     const parts = Array.isArray(parsedParts)
       ? parsedParts
@@ -374,6 +376,7 @@ export function mapDbRowsToTimelineMessages(messages: DbSessionMessage[]): Timel
       role: message.role,
       content: message.content,
       timestamp: message.created_at,
+      ...(parsedMessage?.steered === true ? { steered: true } : {}),
       parts: parts && parts.length > 0 ? parts : undefined
     }
   })
@@ -538,30 +541,57 @@ function parseToolPartFromActivity(activity: DbSessionActivity): StreamingPart |
 }
 
 function parsePlanPartFromActivity(activity: DbSessionActivity): StreamingPart | null {
-  if (activity.kind !== 'plan.ready') return null
   const payload = parseJson<Record<string, unknown>>(activity.payload_json)
-  const plan =
-    (typeof payload?.plan === 'string' && payload.plan.trim()) ||
-    (typeof payload?.planContent === 'string' && payload.planContent.trim()) ||
-    ''
-  if (!plan) return null
+  if (activity.kind === 'plan.ready') {
+    const plan =
+      (typeof payload?.plan === 'string' && payload.plan.trim()) ||
+      (typeof payload?.planContent === 'string' && payload.planContent.trim()) ||
+      ''
+    if (!plan) return null
 
-  const toolUseId =
-    (typeof payload?.toolUseID === 'string' && payload.toolUseID) ||
-    activity.item_id ||
-    activity.request_id ||
-    activity.id
+    const toolUseId =
+      (typeof payload?.toolUseID === 'string' && payload.toolUseID) ||
+      activity.item_id ||
+      activity.request_id ||
+      activity.id
 
-  return {
-    type: 'tool_use',
-    toolUse: {
-      id: toolUseId,
-      name: 'ExitPlanMode',
-      input: { plan },
-      status: 'pending',
-      startTime: Date.parse(activity.created_at) || Date.now()
+    return {
+      type: 'tool_use',
+      toolUse: {
+        id: toolUseId,
+        name: 'ExitPlanMode',
+        input: { plan },
+        status: 'pending',
+        startTime: Date.parse(activity.created_at) || Date.now()
+      }
     }
   }
+
+  if (
+    activity.kind === 'session.info' &&
+    payload?.kind === 'update_plan' &&
+    Array.isArray(payload.todos)
+  ) {
+    const toolUseId =
+      (typeof payload.callID === 'string' && payload.callID) ||
+      activity.item_id ||
+      activity.request_id ||
+      activity.id
+
+    return {
+      type: 'tool_use',
+      toolUse: {
+        id: toolUseId,
+        name: 'update_plan',
+        input: { todos: payload.todos },
+        status: 'success',
+        startTime: Date.parse(activity.created_at) || Date.now(),
+        endTime: Date.parse(activity.created_at) || Date.now()
+      }
+    }
+  }
+
+  return null
 }
 
 function upsertToolPart(

--- a/src/shared/lib/timeline-types.ts
+++ b/src/shared/lib/timeline-types.ts
@@ -69,6 +69,7 @@ export interface TimelineMessage {
   role: 'user' | 'assistant' | 'system'
   content: string
   timestamp: string
+  steered?: boolean
   parts?: StreamingPart[]
   /** File attachments for user messages (images, PDFs, etc.) */
   attachments?: MessagePart[]

--- a/src/shared/types/agent-ipc.ts
+++ b/src/shared/types/agent-ipc.ts
@@ -16,6 +16,7 @@ export const AgentErrorCodeValues = [
   'INVALID_PARAM',
   'UNKNOWN_RUNTIME',
   'RUNTIME_UNAVAILABLE',
+  'STEER_NOT_SUPPORTED',
   'SESSION_NOT_FOUND',
   'INTERNAL_ERROR'
 ] as const

--- a/test/phase-14/session-6/dock-badge.test.ts
+++ b/test/phase-14/session-6/dock-badge.test.ts
@@ -162,4 +162,32 @@ describe('Session 6: Dock Badge', () => {
     expect(mockNotificationShow).toHaveBeenCalledTimes(1)
     expect(mockSetBadge).toHaveBeenCalledWith('1')
   })
+
+  test('suppresses completion notification while session still has queued follow-up', () => {
+    notificationService.setSessionQueuedState(mockSessionData.sessionId, true)
+
+    notificationService.showSessionComplete(mockSessionData)
+
+    expect(mockNotificationShow).not.toHaveBeenCalled()
+    expect(mockSetBadge).not.toHaveBeenCalled()
+  })
+
+  test('queued-state suppression does not affect pending-user-feedback notifications', () => {
+    notificationService.setSessionQueuedState(mockSessionData.sessionId, true)
+
+    notificationService.showPendingUserFeedback(mockSessionData, 'question')
+
+    expect(mockNotificationShow).toHaveBeenCalledTimes(1)
+    expect(mockSetBadge).toHaveBeenCalledWith('1')
+  })
+
+  test('completion notification resumes after queued state is cleared', () => {
+    notificationService.setSessionQueuedState(mockSessionData.sessionId, true)
+    notificationService.setSessionQueuedState(mockSessionData.sessionId, false)
+
+    notificationService.showSessionComplete(mockSessionData)
+
+    expect(mockNotificationShow).toHaveBeenCalledTimes(1)
+    expect(mockSetBadge).toHaveBeenCalledWith('1')
+  })
 })

--- a/test/phase-19/session-2/todo-utils.test.ts
+++ b/test/phase-19/session-2/todo-utils.test.ts
@@ -10,6 +10,7 @@ describe('todo utils', () => {
     expect(isTodoWriteTool('TodoWrite')).toBe(true)
     expect(isTodoWriteTool('mcp_todowrite')).toBe(true)
     expect(isTodoWriteTool('todo_write')).toBe(true)
+    expect(isTodoWriteTool('update_plan')).toBe(true)
     expect(isTodoWriteTool('Write')).toBe(false)
   })
 

--- a/test/phase-22/session-3/codex-implementer-skeleton.test.ts
+++ b/test/phase-22/session-3/codex-implementer-skeleton.test.ts
@@ -208,6 +208,91 @@ describe('CodexImplementer skeleton', () => {
     })
   })
 
+  describe('steer', () => {
+    it('throws when there is no active Codex turn', async () => {
+      ;(impl as any).sessions.set('/worktree::thread-1', {
+        threadId: 'thread-1',
+        hiveSessionId: 'hive-1',
+        worktreePath: '/worktree',
+        status: 'running',
+        messages: [],
+        liveAssistantDraft: null,
+        revertMessageID: null,
+        revertDiff: null,
+        titleGenerated: true,
+        titleGenerationStarted: true
+      })
+      ;(impl as any).manager = {
+        getSession: vi.fn().mockReturnValue({ activeTurnId: null }),
+        steerTurn: vi.fn()
+      }
+
+      await expect(impl.steer('/worktree', 'thread-1', 'redirect')).rejects.toThrow(
+        'Steer is unavailable because there is no active Codex turn'
+      )
+    })
+
+    it('rejects attachments because steer is text-only', async () => {
+      ;(impl as any).sessions.set('/worktree::thread-1', {
+        threadId: 'thread-1',
+        hiveSessionId: 'hive-1',
+        worktreePath: '/worktree',
+        status: 'running',
+        messages: [],
+        liveAssistantDraft: null,
+        revertMessageID: null,
+        revertDiff: null,
+        titleGenerated: true,
+        titleGenerationStarted: true
+      })
+
+      await expect(
+        impl.steer('/worktree', 'thread-1', [
+          { type: 'text', text: 'redirect' },
+          { type: 'file', mime: 'image/png', url: 'data:image/png;base64,abc', filename: 'a.png' }
+        ])
+      ).rejects.toThrow('Steer only supports text messages')
+    })
+
+    it('calls manager.steerTurn and persists a steered user message', async () => {
+      const replaceSessionMessages = vi.fn()
+      impl.setDatabaseService({
+        replaceSessionMessages
+      } as any)
+
+      const session = {
+        threadId: 'thread-1',
+        hiveSessionId: 'hive-1',
+        worktreePath: '/worktree',
+        status: 'running',
+        messages: [],
+        liveAssistantDraft: null,
+        revertMessageID: null,
+        revertDiff: null,
+        titleGenerated: true,
+        titleGenerationStarted: true
+      }
+      ;(impl as any).sessions.set('/worktree::thread-1', session)
+
+      const steerTurn = vi.fn().mockResolvedValue(undefined)
+      ;(impl as any).manager = {
+        getSession: vi.fn().mockReturnValue({ activeTurnId: 'turn-1' }),
+        steerTurn
+      }
+
+      await impl.steer('/worktree', 'thread-1', 'redirect the task')
+
+      expect(steerTurn).toHaveBeenCalledWith('thread-1', { text: 'redirect the task' }, 'turn-1')
+      expect(session.messages).toHaveLength(1)
+      expect(session.messages[0]).toMatchObject({
+        role: 'user',
+        steered: true,
+        parts: [{ type: 'text', text: 'redirect the task' }]
+      })
+      expect(replaceSessionMessages).toHaveBeenCalledTimes(1)
+    })
+  })
+
   describe('turn timeout handling', () => {
     beforeEach(() => {
       vi.useFakeTimers()

--- a/test/phase-22/session-5/codex-app-server-manager.test.ts
+++ b/test/phase-22/session-5/codex-app-server-manager.test.ts
@@ -307,3 +307,73 @@ describe('CodexAppServerManager — collaborationMode in sendTurn', () => {
     expect(params.collaborationMode.settings.reasoning_effort).toBe('low')
   })
 })
+
+describe('CodexAppServerManager.steerTurn', () => {
+  let manager: CodexAppServerManager
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    manager = new CodexAppServerManager()
+  })
+
+  afterEach(() => {
+    manager.stopAll()
+    manager.removeAllListeners()
+  })
+
+  function seedSession(context: CodexSessionContext): void {
+    const sessionsMap = (manager as any).sessions as Map<string, CodexSessionContext>
+    sessionsMap.set(context.session.threadId!, context)
+  }
+
+  function getWrittenMessages(stdin: { write: ReturnType<typeof vi.fn> }): any[] {
+    return stdin.write.mock.calls.map((call: any[]) => JSON.parse((call[0] as string).trim()))
+  }
+
+  it('sends turn/steer with the active turn id by default', async () => {
+    const { context, stdin } = createTestContext({ activeTurnId: 'turn-active-1' })
+    seedSession(context)
+
+    const steerPromise = manager.steerTurn('thread-123', {
+      text: 'course correct'
+    })
+
+    const messages = getWrittenMessages(stdin)
+    const steerMsg = messages.find((message: any) => message.method === 'turn/steer')
+    expect(steerMsg).toBeDefined()
+    expect(steerMsg.params).toEqual({
+      threadId: 'thread-123',
+      turnId: 'turn-active-1',
+      input: [{ type: 'text', text: 'course correct' }]
+    })
+
+    manager.handleStdoutLine(
+      context,
+      JSON.stringify({ id: steerMsg.id, result: { ok: true } })
+    )
+
+    await steerPromise
+  })
+
+  it('uses explicit turnId override when provided', async () => {
+    const { context, stdin } = createTestContext({ activeTurnId: 'turn-active-1' })
+    seedSession(context)
+
+    const steerPromise = manager.steerTurn(
+      'thread-123',
+      { text: 'course correct' },
+      'turn-override-9'
+    )
+
+    const messages = getWrittenMessages(stdin)
+    const steerMsg = messages.find((message: any) => message.method === 'turn/steer')
+    expect(steerMsg?.params.turnId).toBe('turn-override-9')
+
+    manager.handleStdoutLine(
+      context,
+      JSON.stringify({ id: steerMsg.id, result: { ok: true } })
+    )
+
+    await steerPromise
+  })
+})

--- a/test/phase-22/session-5/codex-event-mapper.test.ts
+++ b/test/phase-22/session-5/codex-event-mapper.test.ts
@@ -235,6 +235,55 @@ describe('mapCodexEventToStreamEvents', () => {
 
   // ── Turn started ────────────────────────────────────────────
 
+  describe('turn/plan/updated', () => {
+    it('maps plan updates into a synthetic update_plan tool event', () => {
+      const event = makeEvent({
+        method: 'turn/plan/updated',
+        turnId: 'turn-plan-1',
+        payload: {
+          items: [
+            { id: 'a', content: 'Inspect logs', status: 'completed' },
+            { id: 'b', content: 'Patch timeout', status: 'in_progress' }
+          ]
+        }
+      })
+
+      const result = mapCodexEventToStreamEvents(event, HIVE_SESSION)
+
+      expect(result).toHaveLength(1)
+      expect(result[0]).toEqual({
+        type: 'message.part.updated',
+        sessionId: HIVE_SESSION,
+        data: {
+          part: {
+            type: 'tool',
+            callID: 'turn-plan-1:update_plan',
+            tool: 'update_plan',
+            state: {
+              status: 'completed',
+              input: {
+                todos: [
+                  {
+                    id: 'a',
+                    content: 'Inspect logs',
+                    status: 'completed',
+                    priority: 'medium'
+                  },
+                  {
+                    id: 'b',
+                    content: 'Patch timeout',
+                    status: 'in_progress',
+                    priority: 'medium'
+                  }
+                ]
+              }
+            }
+          }
+        }
+      })
+    })
+  })
+
   describe('turn/started', () => {
     it('maps to session.status busy', () => {
       const event = makeEvent({ method: 'turn/started' })

--- a/test/phase-23/session-send-actions.test.ts
+++ b/test/phase-23/session-send-actions.test.ts
@@ -12,9 +12,7 @@ import {
   createPendingMessage,
   getActionLabel,
   _resetPendingIdCounter,
-  type ComposerInput,
-  type ComposerAction,
-  type ComposerActionSet
+  type ComposerInput
 } from '../../src/renderer/src/lib/session-send-actions'
 
 import { useSessionRuntimeStore } from '../../src/renderer/src/stores/useSessionRuntimeStore'
@@ -38,6 +36,7 @@ function makeSendContext(overrides: Partial<Parameters<typeof executeSendAction>
     worktreePath: '/test/path',
     sessionId: 'sess-1',
     prompt: vi.fn().mockResolvedValue({ success: true }),
+    steer: vi.fn().mockResolvedValue({ success: true }),
     abort: vi.fn().mockResolvedValue({ success: true }),
     queueMessage: vi.fn(),
     ...overrides
@@ -138,19 +137,24 @@ describe('determineComposerActions', () => {
 
   describe('busy lifecycle', () => {
     it('returns stop_and_send with queue and steer alternatives', () => {
-      const result = determineComposerActions(makeInput({ lifecycle: 'busy' }))
+      const result = determineComposerActions(makeInput({ lifecycle: 'busy', supportsSteer: true }))
       expect(result.primary).toBe('stop_and_send')
       expect(result.inputEnabled).toBe(true)
       expect(result.iconHint).toBe('stop')
       expect(result.primaryLabel).toBe('Stop')
       expect(result.alternatives).toEqual(['queue', 'steer'])
     })
+
+    it('omits steer when runtime does not support it', () => {
+      const result = determineComposerActions(makeInput({ lifecycle: 'busy', supportsSteer: false }))
+      expect(result.alternatives).toEqual(['queue'])
+    })
   })
 
   describe('materializing lifecycle', () => {
     it('returns stop_and_send (same as busy)', () => {
       const result = determineComposerActions(
-        makeInput({ lifecycle: 'materializing' })
+        makeInput({ lifecycle: 'materializing', supportsSteer: true })
       )
       expect(result.primary).toBe('stop_and_send')
       expect(result.alternatives).toEqual(['queue', 'steer'])
@@ -241,11 +245,23 @@ describe('executeSendAction', () => {
     expect(ctx.prompt).not.toHaveBeenCalled()
   })
 
-  it('steer: calls prompt (sends while busy)', async () => {
+  it('steer: calls steer IPC (sends while busy)', async () => {
     const ctx = makeSendContext()
     const result = await executeSendAction('steer', 'change direction', [], ctx)
     expect(result).toBe(true)
-    expect(ctx.prompt).toHaveBeenCalledWith('/test/path', 'sess-1', 'change direction')
+    expect(ctx.steer).toHaveBeenCalledWith('/test/path', 'sess-1', 'change direction')
+  })
+
+  it('steer: rejects attachments', async () => {
+    const ctx = makeSendContext()
+    await expect(
+      executeSendAction(
+        'steer',
+        'change direction',
+        [{ kind: 'data', id: 'a1', name: 'image.png', mime: 'image/png' }],
+        ctx
+      )
+    ).rejects.toThrow('Steer only supports text messages')
   })
 
   it('stop_and_send: calls abort then prompt', async () => {
@@ -305,6 +321,13 @@ describe('drainNextPending', () => {
 // ===========================================================================
 
 describe('useSessionRuntimeStore pending messages', () => {
+  it('syncs queued-state true when queueing a message', () => {
+    const syncSpy = vi.spyOn(window.systemOps, 'setSessionQueuedState')
+    const store = useSessionRuntimeStore.getState()
+    store.queueMessage('sess-1', createPendingMessage('test'))
+    expect(syncSpy).toHaveBeenCalledWith('sess-1', true)
+  })
+
   it('queues and retrieves pending messages', () => {
     const store = useSessionRuntimeStore.getState()
     const msg = createPendingMessage('test')
@@ -336,18 +359,22 @@ describe('useSessionRuntimeStore pending messages', () => {
   })
 
   it('dequeueMessage cleans up Map entry when queue is emptied', () => {
+    const syncSpy = vi.spyOn(window.systemOps, 'setSessionQueuedState')
     const store = useSessionRuntimeStore.getState()
     store.queueMessage('sess-1', createPendingMessage('only'))
     store.dequeueMessage('sess-1')
     expect(useSessionRuntimeStore.getState().pendingMessages.has('sess-1')).toBe(false)
+    expect(syncSpy).toHaveBeenLastCalledWith('sess-1', false)
   })
 
   it('clearPendingMessages removes all pending for session', () => {
+    const syncSpy = vi.spyOn(window.systemOps, 'setSessionQueuedState')
     const store = useSessionRuntimeStore.getState()
     store.queueMessage('sess-1', createPendingMessage('a'))
     store.queueMessage('sess-1', createPendingMessage('b'))
     store.clearPendingMessages('sess-1')
     expect(useSessionRuntimeStore.getState().getPendingCount('sess-1')).toBe(0)
+    expect(syncSpy).toHaveBeenLastCalledWith('sess-1', false)
   })
 
   it('clearPendingMessages is no-op for unknown session', () => {
@@ -366,12 +393,14 @@ describe('useSessionRuntimeStore pending messages', () => {
   })
 
   it('clearSession also clears pending messages', () => {
+    const syncSpy = vi.spyOn(window.systemOps, 'setSessionQueuedState')
     const store = useSessionRuntimeStore.getState()
     store.queueMessage('sess-1', createPendingMessage('test'))
     store.setLifecycle('sess-1', 'busy')
     store.clearSession('sess-1')
     expect(useSessionRuntimeStore.getState().getPendingCount('sess-1')).toBe(0)
     expect(useSessionRuntimeStore.getState().pendingMessages.has('sess-1')).toBe(false)
+    expect(syncSpy).toHaveBeenLastCalledWith('sess-1', false)
   })
 
   it('maintains separate queues per session', () => {

--- a/test/settings/full-disk-access-ui.test.tsx
+++ b/test/settings/full-disk-access-ui.test.tsx
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import { SettingsPrivacy } from '../../src/renderer/src/components/settings/SettingsPrivacy'
+import { FdaSetupGuard } from '../../src/renderer/src/components/setup/FdaSetupGuard'
+import { useSettingsStore } from '../../src/renderer/src/stores/useSettingsStore'
+
+describe('Full Disk Access UI', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    useSettingsStore.setState({
+      isLoading: false,
+      initialSetupComplete: true,
+      fdaOnboardingDismissed: false,
+      locale: 'en',
+      telemetryEnabled: true
+    } as never)
+
+    vi.mocked(window.analyticsOps.isEnabled).mockResolvedValue(true)
+    vi.mocked(window.systemOps.getPlatform).mockResolvedValue('darwin')
+    vi.mocked(window.systemOps.checkFullDiskAccess).mockResolvedValue({
+      supported: true,
+      granted: false
+    })
+    vi.mocked(window.systemOps.openFullDiskAccessSettings).mockResolvedValue({ success: true })
+  })
+
+  it('shows the onboarding guard on macOS when FDA is not granted', async () => {
+    render(<FdaSetupGuard />)
+
+    expect(await screen.findByText('Grant Full Disk Access')).toBeInTheDocument()
+    expect(screen.getByText('Open System Settings')).toBeInTheDocument()
+  })
+
+  it('dismisses the onboarding guard when skipping for now', async () => {
+    const user = userEvent.setup()
+    render(<FdaSetupGuard />)
+
+    await user.click(await screen.findByRole('button', { name: 'Skip for now' }))
+
+    await waitFor(() => {
+      expect(useSettingsStore.getState().fdaOnboardingDismissed).toBe(true)
+    })
+  })
+
+  it('renders FDA status and actions inside SettingsPrivacy', async () => {
+    const user = userEvent.setup()
+    render(<SettingsPrivacy />)
+
+    expect(await screen.findByText('Full Disk Access')).toBeInTheDocument()
+    expect(screen.getByText('Full Disk Access is not granted.')).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'Check Again' }))
+    expect(window.systemOps.checkFullDiskAccess).toHaveBeenCalledTimes(2)
+
+    await user.click(screen.getByRole('button', { name: 'Open System Settings' }))
+    expect(window.systemOps.openFullDiskAccessSettings).toHaveBeenCalledTimes(1)
+  })
+})

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -26,6 +26,49 @@ if (typeof window !== 'undefined') {
     }))
   })
 
+  if (!document.fonts) {
+    Object.defineProperty(document, 'fonts', {
+      writable: true,
+      configurable: true,
+      value: {
+        load: vi.fn().mockResolvedValue([])
+      }
+    })
+  }
+
+  if (!HTMLCanvasElement.prototype.getContext) {
+    Object.defineProperty(HTMLCanvasElement.prototype, 'getContext', {
+      writable: true,
+      configurable: true,
+      value: vi.fn(() => ({
+        fillRect: vi.fn(),
+        clearRect: vi.fn(),
+        getImageData: vi.fn(),
+        putImageData: vi.fn(),
+        createImageData: vi.fn(),
+        setTransform: vi.fn(),
+        drawImage: vi.fn(),
+        save: vi.fn(),
+        fillText: vi.fn(),
+        restore: vi.fn(),
+        beginPath: vi.fn(),
+        moveTo: vi.fn(),
+        lineTo: vi.fn(),
+        closePath: vi.fn(),
+        stroke: vi.fn(),
+        translate: vi.fn(),
+        scale: vi.fn(),
+        rotate: vi.fn(),
+        arc: vi.fn(),
+        fill: vi.fn(),
+        measureText: vi.fn(() => ({ width: 0 })),
+        transform: vi.fn(),
+        rect: vi.fn(),
+        clip: vi.fn()
+      }))
+    })
+  }
+
   if (typeof window.localStorage?.getItem !== 'function') {
     const storage = new Map<string, string>()
     Object.defineProperty(window, 'localStorage', {
@@ -117,6 +160,9 @@ if (typeof window !== 'undefined') {
           claude: true,
           codex: false
         }),
+        setSessionQueuedState: vi.fn().mockResolvedValue({ success: true }),
+        checkFullDiskAccess: vi.fn().mockResolvedValue({ supported: true, granted: false }),
+        openFullDiskAccessSettings: vi.fn().mockResolvedValue({ success: true }),
         setKeepAwakeEnabled: vi.fn().mockResolvedValue({ success: true }),
         runOnboardingDoctor: vi.fn().mockResolvedValue({
           platform: 'darwin',


### PR DESCRIPTION
## Summary

This stacked PR continues the stability-focused follow-up wave on top of #18.

It finishes four areas that were still missing from the Codex/session workstream:

- real Codex steer
- Codex `turn/plan/updated` -> visible `update_plan` flow
- queued follow-up completion-notification suppression on the runtime queue path
- macOS Full Disk Access detection and onboarding

## What Changed

### 1. Codex steer is now a real protocol feature

- Added `supportsSteer` to runtime capabilities and wired `agent:steer` through preload + main IPC.
- Implemented real Codex `turn/steer` dispatch in the app-server manager.
- Added Codex-side validation in the implementer: session must exist, the current turn must still be active, and the steer payload must be text-only.
- Persisted steered user messages into the canonical transcript and exposed a `STEERED` badge in the new SessionShell timeline.
- Updated the new HQ composer path so busy sessions surface a true steer action instead of silently reusing `prompt()`.
- Failure paths now keep the draft/queued content intact and avoid leaving optimistic ghost messages behind.

### 2. Codex `update_plan` now shows up as a first-class checklist flow

- Mapped `turn/plan/updated` into a synthetic `update_plan` tool event.
- Normalized Codex checklist item states into the existing todo model: `pending`, `in_progress`, `completed`, `cancelled`.
- Added activity summaries for plan updates so the session activity stream records progress instead of swallowing the event.
- Extended timeline restoration and renderer todo detection so `update_plan` reuses the same todo/checklist rendering pipeline as TodoWrite.
- Updated MissionControl extraction to treat `update_plan` as a todo-like source in the new SessionShell path.

### 3. Queued follow-up completion notifications are suppressed until the session is truly done

- Added a queued-session state map inside `NotificationService`.
- Completion notifications are now skipped while the SessionShell/runtime queue still has pending auto-follow-up messages.
- Pending-user-feedback notifications are intentionally not suppressed.
- Synced runtime-queue mutations (queue, dequeue, clear, clearSession) back to the main process via fire-and-forget `system:setSessionQueuedState`.

### 4. macOS Full Disk Access detection and onboarding

- Added a dedicated main-process FDA service plus Electron IPC methods to check status and open the system settings target.
- Tightened probe semantics so FDA is only considered granted when a protected probe path is actually readable.
- Added `fdaOnboardingDismissed` to persisted app settings.
- Added a new top-level `FdaSetupGuard` that appears after initial setup on macOS when FDA is still missing.
- Extended Settings -> Privacy with a live FDA status section and retry / open-settings actions.
- Added the user-selected read/write entitlement to both macOS entitlement plist files.

## Scope Boundaries

This PR intentionally does **not**:

- add compatibility work for legacy `SessionView`
- expand GraphQL/headless APIs for steer/FDA/queued state
- introduce board/kanban/product-divergence features
- add Codex plan approval semantics beyond displaying `update_plan` progress

## Verification

Ran successfully:

- `pnpm build`
- `pnpm lint`
- `pnpm vitest run test/phase-23/session-send-actions.test.ts test/phase-14/session-6/dock-badge.test.ts test/phase-22/session-5/codex-app-server-manager.test.ts test/phase-22/session-5/codex-event-mapper.test.ts test/phase-22/session-3/codex-implementer-skeleton.test.ts test/phase-19/session-2/todo-utils.test.ts test/settings/full-disk-access-ui.test.tsx test/settings-i18n.test.tsx`

## Notes

- This PR is stacked on top of #18 and should be reviewed with base branch `codex/hive-pr-integration`.
- I also smoke-ran the old `test/session-2/layout.test.tsx`; it still has pre-existing expectation drift around header/sidebar/theme/usage mocks and is not caused by this follow-up diff.
