### PR TITLE
fix: guard session streams by run epoch

### DIFF
--- a/src/main/services/claude-code-implementer.ts
+++ b/src/main/services/claude-code-implementer.ts
@@ -22,7 +22,7 @@ import { CommandFilterService, type CommandFilterSettings } from './command-filt
 import { createLspMcpServerConfig, LspService } from './lsp'
 import { APP_SETTINGS_DB_KEY } from '@shared/types/settings'
 import { getActiveAppHomeDir } from '@shared/app-identity'
-import { emitAgentEvent } from '@shared/lib/normalize-agent-event'
+import { beginSessionRun, emitAgentEvent } from '@shared/lib/normalize-agent-event'
 import { resolveRuntimeModelId } from '@shared/usage/models'
 import { calculateUsageCost, resolvePricingModelKey } from '@shared/usage/pricing'
 
@@ -424,6 +424,8 @@ export class ClaudeCodeImplementer implements AgentSdkImplementer, AgentRuntimeA
     if (!session) {
       throw new Error(`Prompt failed: session not found for ${worktreePath} / ${agentSessionId}`)
     }
+
+    beginSessionRun(session.hiveSessionId)
 
     // Clear revert boundary — a new prompt invalidates prior undo state
     session.revertMessageID = null

--- a/src/main/services/codex-implementer.ts
+++ b/src/main/services/codex-implementer.ts
@@ -17,7 +17,7 @@ import { asNumber, asObject, asString } from './codex-utils'
 import { generateCodexSessionTitle } from './codex-session-title'
 import type { DatabaseService } from '../db/database'
 import { autoRenameWorktreeBranch } from './git-service'
-import { emitAgentEvent } from '@shared/lib/normalize-agent-event'
+import { beginSessionRun, emitAgentEvent } from '@shared/lib/normalize-agent-event'
 
 const log = createLogger({ component: 'CodexImplementer' })
 
@@ -498,6 +498,8 @@ export class CodexImplementer implements AgentSdkImplementer, AgentRuntimeAdapte
     if (!session) {
       throw new Error(`Prompt failed: session not found for ${worktreePath} / ${agentSessionId}`)
     }
+
+    beginSessionRun(session.hiveSessionId)
 
     // Extract text from message
     let text: string

--- a/src/main/services/opencode-service.ts
+++ b/src/main/services/opencode-service.ts
@@ -7,7 +7,7 @@ import { autoRenameWorktreeBranch } from './git-service'
 import { getEventBus } from '../../server/event-bus'
 import type { AgentSdkImplementer } from './agent-runtime-types'
 import type { AgentRuntimeAdapter } from './agent-runtime-types'
-import { emitAgentEvent } from '@shared/lib/normalize-agent-event'
+import { beginSessionRun, emitAgentEvent } from '@shared/lib/normalize-agent-event'
 
 const log = createLogger({ component: 'OpenCodeService' })
 
@@ -669,6 +669,13 @@ class OpenCodeService implements AgentSdkImplementer, AgentRuntimeAdapter {
 
     if (!this.instance) {
       throw new Error('No OpenCode instance available')
+    }
+
+    const hiveSessionId =
+      this.getMappedHiveSessionId(this.instance, opencodeSessionId, worktreePath) ??
+      getDatabase().getSessionByOpenCodeSessionId(opencodeSessionId)?.id
+    if (hiveSessionId) {
+      beginSessionRun(hiveSessionId)
     }
 
     const { variant, ...model } = modelOverride ?? this.getSelectedModel()

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -1356,9 +1356,13 @@ declare global {
   interface CanonicalAgentEvent {
     type: string
     sessionId: string
+    eventId: string
+    sessionSequence: number
+    runEpoch: number
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     data: any
     childSessionId?: string
+    sourceChannel?: 'agent:stream'
     /** session.status event payload -- only present when type === 'session.status' */
     statusPayload?: {
       type: 'idle' | 'busy' | 'retry'

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -585,9 +585,13 @@ const loggingOps = {
 export interface CanonicalAgentEvent {
   type: string
   sessionId: string
+  eventId: string
+  sessionSequence: number
+  runEpoch: number
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   data: any
   childSessionId?: string
+  sourceChannel?: 'agent:stream'
   /** session.status event payload -- only present when type === 'session.status' */
   statusPayload?: {
     type: 'idle' | 'busy' | 'retry'

--- a/src/renderer/src/hooks/useAgentEventBridge.ts
+++ b/src/renderer/src/hooks/useAgentEventBridge.ts
@@ -29,7 +29,11 @@ import { useSettingsStore } from '@/stores/useSettingsStore'
 import { useContextStore } from '@/stores/useContextStore'
 import { useRecentStore } from '@/stores/useRecentStore'
 import { useUsageStore, resolveUsageProvider } from '@/stores'
-import { useSessionRuntimeStore, clearStreamingBuffer } from '@/stores/useSessionRuntimeStore'
+import {
+  useSessionRuntimeStore,
+  clearStreamingBuffer,
+  acceptSessionEvent
+} from '@/stores/useSessionRuntimeStore'
 import {
   extractTokens,
   extractCost,
@@ -254,6 +258,15 @@ export function useAgentEventBridge(): void {
       ? window.agentOps.onStream((event: CanonicalAgentEvent) => {
           const sessionId = event.sessionId
           const activeId = useSessionStore.getState().activeSessionId
+
+          const guard = acceptSessionEvent(event)
+          if (!guard.accepted) {
+            return
+          }
+
+          if (guard.advancedRun) {
+            clearStreamingBuffer(sessionId)
+          }
 
           // Always dispatch to per-session callbacks (SessionView streaming)
           runtime.dispatchToSession(sessionId, event)

--- a/src/renderer/src/stores/useSessionRuntimeStore.ts
+++ b/src/renderer/src/stores/useSessionRuntimeStore.ts
@@ -106,6 +106,90 @@ export function clearStreamingBuffer(sessionId: string): void {
 }
 
 // ---------------------------------------------------------------------------
+// Per-session event guard registry (module-level, non-reactive)
+// Tracks the active run epoch and latest accepted sessionSequence so the global
+// event bridge can drop stale events before they reach any mounted view.
+// ---------------------------------------------------------------------------
+
+export interface SessionEventGuardState {
+  activeRunEpoch: number
+  lastAppliedSequence: number
+}
+
+export interface SessionEventGuardResult {
+  accepted: boolean
+  advancedRun: boolean
+  state: SessionEventGuardState
+}
+
+const _sessionEventGuards = new Map<string, SessionEventGuardState>()
+const DEFAULT_EVENT_GUARD_STATE: Readonly<SessionEventGuardState> = {
+  activeRunEpoch: 0,
+  lastAppliedSequence: -1
+}
+
+export function getSessionEventGuardState(sessionId: string): SessionEventGuardState | undefined {
+  const state = _sessionEventGuards.get(sessionId)
+  return state ? { ...state } : undefined
+}
+
+export function acceptSessionEvent(
+  event: Pick<CanonicalAgentEvent, 'sessionId' | 'runEpoch' | 'sessionSequence'>
+): SessionEventGuardResult {
+  const current = _sessionEventGuards.get(event.sessionId) ?? DEFAULT_EVENT_GUARD_STATE
+  const nextRunEpoch = event.runEpoch
+  const nextSequence = event.sessionSequence
+
+  if (nextRunEpoch < current.activeRunEpoch) {
+    return {
+      accepted: false,
+      advancedRun: false,
+      state: { ...current }
+    }
+  }
+
+  if (nextRunEpoch > current.activeRunEpoch) {
+    const nextState = {
+      activeRunEpoch: nextRunEpoch,
+      lastAppliedSequence: nextSequence
+    }
+    _sessionEventGuards.set(event.sessionId, nextState)
+    return {
+      accepted: true,
+      advancedRun: true,
+      state: { ...nextState }
+    }
+  }
+
+  if (nextSequence <= current.lastAppliedSequence) {
+    return {
+      accepted: false,
+      advancedRun: false,
+      state: { ...current }
+    }
+  }
+
+  const nextState = {
+    activeRunEpoch: current.activeRunEpoch,
+    lastAppliedSequence: nextSequence
+  }
+  _sessionEventGuards.set(event.sessionId, nextState)
+  return {
+    accepted: true,
+    advancedRun: false,
+    state: { ...nextState }
+  }
+}
+
+export function clearSessionEventGuard(sessionId: string): void {
+  _sessionEventGuards.delete(sessionId)
+}
+
+export function resetSessionEventGuardsForTests(): void {
+  _sessionEventGuards.clear()
+}
+
+// ---------------------------------------------------------------------------
 // Store
 // ---------------------------------------------------------------------------
 
@@ -397,5 +481,6 @@ export const useSessionRuntimeStore = create<SessionRuntimeStore>()((set, get) =
     })
     _sessionEventCallbacks.delete(sessionId)
     _streamingBuffers.delete(sessionId)
+    _sessionEventGuards.delete(sessionId)
   }
 }))

--- a/src/shared/lib/normalize-agent-event.ts
+++ b/src/shared/lib/normalize-agent-event.ts
@@ -4,8 +4,9 @@
  * This module runs in TWO contexts:
  *
  * 1. **Main process** — `emitAgentEvent()` is called by implementers instead of
- *    the raw `sendToRenderer()`. It stamps `eventId`, `sessionSequence`, and
- *    sends the envelope over the canonical `agent:stream` IPC channel.
+ *    the raw `sendToRenderer()`. It stamps `eventId`, `sessionSequence`,
+ *    `runEpoch`, and sends the envelope over the canonical `agent:stream`
+ *    IPC channel.
  *
  * 2. **Preload bridge** — `normalizeAgentEvent()` re-normalizes events coming
  *    from `agent:stream`, ensuring the renderer always sees a uniform
@@ -18,7 +19,6 @@ import type { BrowserWindow } from 'electron'
 import type {
   CanonicalAgentEvent,
   RawAgentEvent,
-  EventEnvelope,
   AgentStatusPayload
 } from '../types/agent-protocol'
 
@@ -26,6 +26,7 @@ import type {
 // Session-scoped sequence counters (main process only)
 // ---------------------------------------------------------------------------
 const sessionSequences = new Map<string, number>()
+const sessionRunEpochs = new Map<string, number>()
 
 function nextSequence(sessionId: string): number {
   const current = sessionSequences.get(sessionId) ?? 0
@@ -37,6 +38,22 @@ function nextSequence(sessionId: string): number {
 /** Reset the sequence counter for a session (e.g. on disconnect). */
 export function resetSessionSequence(sessionId: string): void {
   sessionSequences.delete(sessionId)
+}
+
+function currentRunEpoch(sessionId: string): number {
+  return sessionRunEpochs.get(sessionId) ?? 0
+}
+
+/** Advance the active run epoch for a hive session and return the new value. */
+export function beginSessionRun(sessionId: string): number {
+  const next = currentRunEpoch(sessionId) + 1
+  sessionRunEpochs.set(sessionId, next)
+  return next
+}
+
+/** Read the current run epoch for a hive session. Defaults to 0 before any prompt. */
+export function getCurrentRunEpoch(sessionId: string): number {
+  return currentRunEpoch(sessionId)
 }
 
 // ---------------------------------------------------------------------------
@@ -64,7 +81,7 @@ function generateEventId(): string {
 
 /**
  * Send an agent event to the renderer via the canonical `agent:stream` channel,
- * stamping `eventId` and `sessionSequence` on the envelope.
+ * stamping `eventId`, `sessionSequence`, and `runEpoch` on the envelope.
  *
  * Usage (in implementers):
  * ```ts
@@ -85,7 +102,8 @@ export function emitAgentEvent(
   const envelope: CanonicalAgentEvent = {
     ...event,
     eventId: event.eventId ?? generateEventId(),
-    sessionSequence: event.sessionSequence ?? nextSequence(event.sessionId)
+    sessionSequence: event.sessionSequence ?? nextSequence(event.sessionId),
+    runEpoch: event.runEpoch ?? currentRunEpoch(event.sessionId)
   } as CanonicalAgentEvent
 
   mainWindow.webContents.send('agent:stream', envelope)
@@ -110,8 +128,8 @@ export function emitAgentEvent(
 /**
  * Normalize a raw agent event into the canonical shape:
  *
- * 1. Ensure `eventId` and `sessionSequence` exist (generate if missing for
- *    legacy events that bypassed `emitAgentEvent`).
+ * 1. Ensure `eventId`, `sessionSequence`, and `runEpoch` exist (generate if
+ *    missing for legacy events that bypassed `emitAgentEvent`).
  * 2. For `session.status` events, ensure `statusPayload` is always at the
  *    top level (some implementers only put it in `data.status`).
  * 3. Tag the `sourceChannel` so the renderer can distinguish origin.
@@ -138,6 +156,9 @@ export function normalizeAgentEvent(
   }
   if (event.sessionSequence == null) {
     event.sessionSequence = 0
+  }
+  if (event.runEpoch == null) {
+    event.runEpoch = 0
   }
   event.sourceChannel = sourceChannel
 

--- a/src/shared/types/agent-protocol.ts
+++ b/src/shared/types/agent-protocol.ts
@@ -123,6 +123,8 @@ export interface EventEnvelope {
   eventId: string
   /** Monotonically increasing counter per session, for ordering. */
   sessionSequence: number
+  /** Monotonically increasing run identifier per hive session. */
+  runEpoch: number
   /** Which IPC channel the event arrived on (set by preload normalizer). */
   sourceChannel?: 'agent:stream'
 }

--- a/test/phase-23/agent-event-bridge-run-epoch.test.ts
+++ b/test/phase-23/agent-event-bridge-run-epoch.test.ts
@@ -1,0 +1,308 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { cleanup, renderHook } from '@testing-library/react'
+
+let activeSessionId = 'sess-1'
+let streamCallback: ((event: Record<string, unknown>) => void) | null = null
+
+const mockOnStream = vi.fn((cb: (event: Record<string, unknown>) => void) => {
+  streamCallback = cb
+  return () => {
+    if (streamCallback === cb) {
+      streamCallback = null
+    }
+  }
+})
+
+const mockOnBranchRenamed = vi.fn(() => () => {})
+
+Object.defineProperty(window, 'agentOps', {
+  writable: true,
+  value: {
+    onStream: mockOnStream
+  }
+})
+
+Object.defineProperty(window, 'worktreeOps', {
+  writable: true,
+  value: {
+    onBranchRenamed: mockOnBranchRenamed
+  }
+})
+
+vi.mock('@/stores/useSessionStore', () => ({
+  useSessionStore: {
+    getState: () => ({
+      activeSessionId,
+      getSessionMode: vi.fn(() => 'build'),
+      getPendingPlan: vi.fn(() => null),
+      dequeueFollowUpMessage: vi.fn(() => null),
+      requeueFollowUpMessageFront: vi.fn(),
+      updateSessionName: vi.fn(),
+      sessionsByWorktree: new Map(),
+      sessionsByConnection: new Map()
+    })
+  }
+}))
+
+vi.mock('@/stores/useWorktreeStore', () => ({
+  useWorktreeStore: {
+    getState: () => ({
+      updateWorktreeBranch: vi.fn(),
+      worktreesByProject: new Map()
+    })
+  }
+}))
+
+vi.mock('@/stores/useConnectionStore', () => ({
+  useConnectionStore: {
+    getState: () => ({
+      connections: []
+    })
+  }
+}))
+
+vi.mock('@/stores/useWorktreeStatusStore', () => ({
+  useWorktreeStatusStore: {
+    getState: () => ({
+      setSessionStatus: vi.fn(),
+      clearSessionStatus: vi.fn(),
+      setLastMessageTime: vi.fn(),
+      sessionStatuses: {}
+    })
+  }
+}))
+
+vi.mock('@/stores/useQuestionStore', () => ({
+  useQuestionStore: {
+    getState: () => ({
+      addQuestion: vi.fn(),
+      removeQuestion: vi.fn()
+    })
+  }
+}))
+
+vi.mock('@/stores/usePermissionStore', () => ({
+  usePermissionStore: {
+    getState: () => ({
+      addPermission: vi.fn(),
+      removePermission: vi.fn(),
+      pendingBySession: new Map()
+    })
+  }
+}))
+
+vi.mock('@/stores/useCommandApprovalStore', () => ({
+  useCommandApprovalStore: {
+    getState: () => ({
+      addApproval: vi.fn(),
+      removeApproval: vi.fn(),
+      getApprovals: vi.fn(() => [])
+    })
+  }
+}))
+
+vi.mock('@/stores/useSettingsStore', () => ({
+  useSettingsStore: {
+    getState: () => ({
+      showUsageIndicator: false,
+      commandFilter: { enabled: false, allowlist: [] },
+      openSettings: vi.fn()
+    })
+  }
+}))
+
+vi.mock('@/stores/useContextStore', () => ({
+  useContextStore: {
+    getState: () => ({
+      setSessionContextRefreshing: vi.fn(),
+      setSessionTokens: vi.fn(),
+      addSessionCost: vi.fn(),
+      addSessionCostOnce: vi.fn(),
+      setModelLimit: vi.fn()
+    })
+  }
+}))
+
+vi.mock('@/stores/useRecentStore', () => ({
+  useRecentStore: {
+    getState: () => ({
+      addWorktreeToRecent: vi.fn(),
+      addConnectionToRecent: vi.fn()
+    })
+  }
+}))
+
+vi.mock('@/stores', () => ({
+  useUsageStore: {
+    getState: () => ({
+      fetchUsage: vi.fn(),
+      fetchUsageForProvider: vi.fn()
+    })
+  },
+  resolveUsageProvider: vi.fn(() => 'opencode')
+}))
+
+vi.mock('@/lib/token-utils', () => ({
+  extractTokens: vi.fn(() => null),
+  extractCost: vi.fn(() => 0),
+  extractCostEventKey: vi.fn(() => null),
+  extractModelRef: vi.fn(() => null),
+  extractModelUsage: vi.fn(() => null)
+}))
+
+vi.mock('@/lib/context-usage', () => ({
+  applySessionContextUsage: vi.fn()
+}))
+
+vi.mock('@/lib/permissionUtils', () => ({
+  checkAutoApprove: vi.fn(() => false)
+}))
+
+vi.mock('sonner', () => ({
+  toast: {
+    warning: vi.fn()
+  }
+}))
+
+import { useAgentEventBridge } from '../../src/renderer/src/hooks/useAgentEventBridge'
+import {
+  acceptSessionEvent,
+  clearStreamingBuffer,
+  getSessionEventGuardState,
+  getStreamingBuffer,
+  resetSessionEventGuardsForTests,
+  setStreamingBuffer,
+  useSessionRuntimeStore
+} from '../../src/renderer/src/stores/useSessionRuntimeStore'
+import type { CanonicalAgentEvent } from '../../src/shared/types/agent-protocol'
+
+function makePartEvent(
+  sessionId: string,
+  runEpoch: number,
+  sessionSequence: number,
+  eventId: string
+): CanonicalAgentEvent {
+  return {
+    type: 'message.part.updated',
+    sessionId,
+    runEpoch,
+    sessionSequence,
+    eventId,
+    sourceChannel: 'agent:stream',
+    data: {
+      delta: eventId,
+      part: { type: 'text', text: eventId }
+    }
+  }
+}
+
+describe('session event run guard', () => {
+  beforeEach(() => {
+    resetSessionEventGuardsForTests()
+  })
+
+  test('isolates 5 interleaved sessions by sessionId and runEpoch', () => {
+    const acceptedBySession = new Map<string, string[]>()
+    const events = [
+      makePartEvent('sess-1', 1, 1, 's1-r1-1'),
+      makePartEvent('sess-2', 1, 1, 's2-r1-1'),
+      makePartEvent('sess-3', 2, 4, 's3-r2-4'),
+      makePartEvent('sess-4', 1, 1, 's4-r1-1'),
+      makePartEvent('sess-5', 3, 9, 's5-r3-9'),
+      makePartEvent('sess-1', 1, 2, 's1-r1-2'),
+      makePartEvent('sess-3', 1, 5, 's3-r1-stale'),
+      makePartEvent('sess-2', 1, 1, 's2-r1-dup'),
+      makePartEvent('sess-1', 2, 3, 's1-r2-3'),
+      makePartEvent('sess-1', 1, 99, 's1-r1-late'),
+      makePartEvent('sess-5', 2, 10, 's5-r2-late')
+    ]
+
+    for (const event of events) {
+      const result = acceptSessionEvent(event)
+      if (!result.accepted) continue
+      const bucket = acceptedBySession.get(event.sessionId) ?? []
+      bucket.push(event.eventId)
+      acceptedBySession.set(event.sessionId, bucket)
+    }
+
+    expect(acceptedBySession.get('sess-1')).toEqual(['s1-r1-1', 's1-r1-2', 's1-r2-3'])
+    expect(acceptedBySession.get('sess-2')).toEqual(['s2-r1-1'])
+    expect(acceptedBySession.get('sess-3')).toEqual(['s3-r2-4'])
+    expect(acceptedBySession.get('sess-4')).toEqual(['s4-r1-1'])
+    expect(acceptedBySession.get('sess-5')).toEqual(['s5-r3-9'])
+
+    expect(getSessionEventGuardState('sess-1')).toEqual({
+      activeRunEpoch: 2,
+      lastAppliedSequence: 3
+    })
+    expect(getSessionEventGuardState('sess-3')).toEqual({
+      activeRunEpoch: 2,
+      lastAppliedSequence: 4
+    })
+  })
+})
+
+describe('useAgentEventBridge runEpoch guard', () => {
+  const sessionIds = ['sess-1', 'sess-2', 'sess-3', 'sess-4', 'sess-5'] as const
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    activeSessionId = 'sess-1'
+    streamCallback = null
+    resetSessionEventGuardsForTests()
+
+    for (const sessionId of sessionIds) {
+      clearStreamingBuffer(sessionId)
+      useSessionRuntimeStore.getState().clearSession(sessionId)
+    }
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  test('dispatches only events from the active run for each session and clears stale overlays', () => {
+    const received = new Map<string, string[]>()
+    const unsubscribers = sessionIds.map((sessionId) =>
+      useSessionRuntimeStore.getState().subscribeToSessionEvents(sessionId, (event) => {
+        const bucket = received.get(sessionId) ?? []
+        bucket.push(event.eventId)
+        received.set(sessionId, bucket)
+      })
+    )
+
+    setStreamingBuffer('sess-1', {
+      parts: [{ type: 'text', text: 'old overlay' }],
+      childParts: new Map(),
+      streamingContent: 'old overlay',
+      isStreaming: true
+    })
+
+    renderHook(() => useAgentEventBridge())
+    expect(streamCallback).not.toBeNull()
+
+    streamCallback!(makePartEvent('sess-1', 1, 1, 's1-r1-1'))
+    streamCallback!(makePartEvent('sess-2', 1, 1, 's2-r1-1'))
+    activeSessionId = 'sess-3'
+    streamCallback!(makePartEvent('sess-3', 2, 4, 's3-r2-4'))
+    streamCallback!(makePartEvent('sess-4', 1, 1, 's4-r1-1'))
+    streamCallback!(makePartEvent('sess-5', 3, 9, 's5-r3-9'))
+    streamCallback!(makePartEvent('sess-1', 1, 2, 's1-r1-2'))
+    streamCallback!(makePartEvent('sess-3', 1, 5, 's3-r1-stale'))
+    streamCallback!(makePartEvent('sess-2', 1, 1, 's2-r1-dup'))
+    streamCallback!(makePartEvent('sess-1', 2, 3, 's1-r2-3'))
+    streamCallback!(makePartEvent('sess-1', 1, 99, 's1-r1-late'))
+
+    expect(received.get('sess-1')).toEqual(['s1-r1-1', 's1-r1-2', 's1-r2-3'])
+    expect(received.get('sess-2')).toEqual(['s2-r1-1'])
+    expect(received.get('sess-3')).toEqual(['s3-r2-4'])
+    expect(received.get('sess-4')).toEqual(['s4-r1-1'])
+    expect(received.get('sess-5')).toEqual(['s5-r3-9'])
+
+    expect(getStreamingBuffer('sess-1')).toBeUndefined()
+
+    for (const unsubscribe of unsubscribers) {
+      unsubscribe()
+    }
+  })
+})

--- a/test/phase-23/agent-event-normalization.test.ts
+++ b/test/phase-23/agent-event-normalization.test.ts
@@ -47,6 +47,27 @@ describe('normalizeAgentEvent', () => {
       expect(result.sessionSequence).toBe(42)
     })
 
+    it('sets runEpoch to 0 when missing', () => {
+      const raw = {
+        type: 'session.updated',
+        sessionId: 'sess-1',
+        data: { title: 'hello' }
+      }
+      const result = normalizeAgentEvent(raw, 'agent:stream')
+      expect(result.runEpoch).toBe(0)
+    })
+
+    it('preserves existing runEpoch', () => {
+      const raw = {
+        type: 'session.updated',
+        sessionId: 'sess-1',
+        runEpoch: 7,
+        data: { title: 'hello' }
+      }
+      const result = normalizeAgentEvent(raw, 'agent:stream')
+      expect(result.runEpoch).toBe(7)
+    })
+
     it('tags sourceChannel', () => {
       const raw = {
         type: 'session.updated',
@@ -205,6 +226,8 @@ describe('normalizeAgentEvent', () => {
 // ---------------------------------------------------------------------------
 describe('emitAgentEvent', () => {
   let emitAgentEvent: typeof import('../../src/shared/lib/normalize-agent-event').emitAgentEvent
+  let beginSessionRun: typeof import('../../src/shared/lib/normalize-agent-event').beginSessionRun
+  let getCurrentRunEpoch: typeof import('../../src/shared/lib/normalize-agent-event').getCurrentRunEpoch
   let resetSessionSequence: typeof import('../../src/shared/lib/normalize-agent-event').resetSessionSequence
 
   beforeEach(async () => {
@@ -212,6 +235,8 @@ describe('emitAgentEvent', () => {
     vi.resetModules()
     const mod = await import('../../src/shared/lib/normalize-agent-event')
     emitAgentEvent = mod.emitAgentEvent
+    beginSessionRun = mod.beginSessionRun
+    getCurrentRunEpoch = mod.getCurrentRunEpoch
     resetSessionSequence = mod.resetSessionSequence
   })
 
@@ -244,7 +269,41 @@ describe('emitAgentEvent', () => {
     const event = captured as Record<string, unknown>
     expect(event.eventId).toBeDefined()
     expect(event.sessionSequence).toBe(1)
+    expect(event.runEpoch).toBe(0)
     expect(event.type).toBe('session.updated')
+  })
+
+  it('stamps the current runEpoch after beginSessionRun', () => {
+    let captured: unknown
+    const mockWindow = {
+      isDestroyed: () => false,
+      webContents: {
+        send: (_channel: string, data: unknown) => {
+          captured = data
+        }
+      }
+    }
+
+    expect(getCurrentRunEpoch('sess-1')).toBe(0)
+    expect(beginSessionRun('sess-1')).toBe(1)
+    expect(getCurrentRunEpoch('sess-1')).toBe(1)
+
+    emitAgentEvent(mockWindow as never, {
+      type: 'session.updated',
+      sessionId: 'sess-1',
+      data: { title: 'hello' }
+    })
+
+    const event = captured as Record<string, unknown>
+    expect(event.runEpoch).toBe(1)
+  })
+
+  it('increments runEpoch per session independently', () => {
+    expect(beginSessionRun('sess-1')).toBe(1)
+    expect(beginSessionRun('sess-1')).toBe(2)
+    expect(beginSessionRun('sess-2')).toBe(1)
+    expect(getCurrentRunEpoch('sess-1')).toBe(2)
+    expect(getCurrentRunEpoch('sess-2')).toBe(1)
   })
 
   it('increments sessionSequence per session', () => {


### PR DESCRIPTION
## Summary
- add `runEpoch` to the canonical agent event envelope
- stamp `runEpoch` from the main process at prompt start for Claude Code, Codex, and OpenCode runtimes
- guard renderer-side stream dispatch by `runEpoch` first and `sessionSequence` second
- clear stale streaming overlay when a newer run is accepted

## Testing
- `pnpm vitest run test/phase-23/agent-event-normalization.test.ts test/phase-23/agent-event-bridge-run-epoch.test.ts test/phase-23/use-session-runtime-store.test.ts test/phase-24/mock-agent-integration.test.ts test/phase-21/session-4/claude-prompt-streaming.test.ts`
