### PR TITLE
refactor: move session shell live overlay into runtime mirror

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,25 @@ All renderer↔main communication goes through the preload layer via typed IPC. 
 4. Main process handler in `src/main/ipc/` processes and returns
 5. Store updates with result, component re-renders
 
+### Session Truth Sources
+
+Session rendering uses three distinct truth layers. Do not add a fourth without
+an explicit design review.
+
+- **Runtime truth** — `useSessionRuntimeStore` plus its module-level mirror
+  registry in `src/renderer/src/stores/useSessionRuntimeStore.ts`. This owns
+  transient agent runtime state: lifecycle, interrupts, pending queue, accepted
+  stream ordering metadata, and live streaming overlay for Session HQ. The
+  global `useAgentEventBridge` hook is the canonical event ingress for this
+  layer.
+- **Durable truth** — SQLite plus `session:getTimeline` in the main process.
+  This owns committed transcript/history. `useSessionStore` is **not** a
+  transcript store; it tracks session records, selection, tabs, and related
+  metadata only.
+- **View truth** — session-scoped UI affordances such as scroll anchors,
+  hover/edit state, and composer draft state. Keep these out of the durable
+  session stores unless they must survive process restart.
+
 ### Shared Types (`src/shared/`)
 
 - **`types/`** — Shared type definitions used across main, preload, and renderer (project, worktree, session, connection, space, git, terminal, etc.). This is the source of truth for cross-process types.

--- a/src/renderer/src/components/session-hq/SessionShell.tsx
+++ b/src/renderer/src/components/session-hq/SessionShell.tsx
@@ -16,7 +16,14 @@
  *   View layer     → component-local state (streaming, etc.)
  */
 
-import React, { useEffect, useState, useCallback, useRef, useMemo } from 'react'
+import React, {
+  useEffect,
+  useState,
+  useCallback,
+  useRef,
+  useMemo,
+  useSyncExternalStore
+} from 'react'
 import { SessionHeader } from './SessionHeader'
 import { AgentTimeline } from './AgentTimeline'
 import type { ThreadStatusRowData } from './ThreadStatusRow'
@@ -40,7 +47,9 @@ import type { CanonicalAgentEvent } from '@shared/types/agent-protocol'
 import type { StreamingPart as SharedStreamingPart } from '@shared/lib/timeline-types'
 import {
   getStreamingBuffer,
-  setStreamingBuffer,
+  getStreamingBufferSnapshot,
+  subscribeToStreamingBuffer,
+  updateStreamingBuffer,
   clearStreamingBuffer
 } from '@/stores/useSessionRuntimeStore'
 import {
@@ -188,6 +197,14 @@ function useSessionRuntime(sessionId: string) {
   const pendingCount = useSessionRuntimeStore((s) => s.getPendingCount(sessionId))
 
   return { lifecycle, interruptQueue, pendingCount }
+}
+
+function useStreamingMirror(sessionId: string) {
+  return useSyncExternalStore(
+    useCallback((cb) => subscribeToStreamingBuffer(sessionId, cb), [sessionId]),
+    useCallback(() => getStreamingBufferSnapshot(sessionId), [sessionId]),
+    useCallback(() => getStreamingBufferSnapshot(sessionId), [sessionId])
+  )
 }
 
 // ---------------------------------------------------------------------------
@@ -338,19 +355,14 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
   const currentProviderId = resolvedModel?.providerID ?? ''
   const skipForkFromMessageConfirm = useSettingsStore((s) => s.skipForkFromMessageConfirm)
 
-  // --- Live streaming state (view-layer) ---
-  // Restore from buffer on mount so switching away mid-stream and back
-  // doesn't lose the in-progress output. The buffer is cleared by the event
-  // bridge when the session goes idle, so its mere presence is a reliable
-  // signal that this session is still mid-turn.
-  const _initBuffer = getStreamingBuffer(sessionId)
-  const [streamingContent, setStreamingContent] = useState(_initBuffer?.streamingContent ?? '')
-  const [isStreaming, setIsStreaming] = useState(_initBuffer?.isStreaming ?? false)
-  const [runStartedAt, setRunStartedAt] = useState<number | null>(_initBuffer?.runStartedAt ?? null)
-  const [compactionState, setCompactionState] = useState<{
-    phase: 'running' | 'completed'
-    timestamp: number
-  } | null>(_initBuffer?.compactionState ?? null)
+  // --- Live streaming mirror (module-level runtime truth) ---
+  const streamingMirror = useStreamingMirror(sessionId)
+  const streamingContent = streamingMirror.streamingContent
+  const isStreaming = streamingMirror.isStreaming
+  const runStartedAt = streamingMirror.runStartedAt ?? null
+  const compactionState = streamingMirror.compactionState ?? null
+  const streamingParts = streamingMirror.parts
+  const childPartsMap = streamingMirror.childParts
   const [droidSessionId, setDroidSessionId] = useState<string | null>(
     sessionRecord?.opencode_session_id ?? null
   )
@@ -363,38 +375,35 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
   const [pendingForkMessageId, setPendingForkMessageId] = useState<string | null>(null)
   const [forkConfirmDismissChecked, setForkConfirmDismissChecked] = useState(false)
 
-  const streamingContentRef = useRef(_initBuffer?.streamingContent ?? '')
+  const syncOptimisticMessagesToMirror = useCallback(() => {
+    updateStreamingBuffer(
+      sessionId,
+      (current) => ({
+        ...current,
+        optimisticMessages: optimisticRef.current.length > 0 ? [...optimisticRef.current] : undefined
+      }),
+      { notify: 'immediate' }
+    )
+  }, [sessionId, optimisticRef])
 
-  // --- Streaming parts for real-time tool rendering ---
-  const [streamingParts, setStreamingParts] = useState<SharedStreamingPart[]>(
-    _initBuffer?.parts ?? []
+  const resetLiveOverlay = useCallback(
+    (nextIsStreaming: boolean) => {
+      updateStreamingBuffer(
+        sessionId,
+        (current) => ({
+          ...current,
+          parts: [],
+          childParts: new Map<string, SharedStreamingPart[]>(),
+          streamingContent: '',
+          isStreaming: nextIsStreaming,
+          runStartedAt: undefined,
+          compactionState: null
+        }),
+        { notify: 'immediate' }
+      )
+    },
+    [sessionId]
   )
-  const streamingPartsRef = useRef<SharedStreamingPart[]>(_initBuffer?.parts ?? [])
-  const rafRef = useRef<number | null>(null)
-
-  // --- Child session parts (sub-agent tool calls, keyed by parent tool_use id) ---
-  const childPartsMapRef = useRef(
-    _initBuffer?.childParts
-      ? new Map(_initBuffer.childParts)
-      : new Map<string, SharedStreamingPart[]>()
-  )
-  const [childPartsMap, setChildPartsMap] = useState<Map<string, SharedStreamingPart[]>>(
-    _initBuffer?.childParts ? new Map(_initBuffer.childParts) : new Map()
-  )
-
-  // Sync streaming state to module-level buffer so it survives tab switches.
-  // Written synchronously on every streaming update; cleared when session goes idle.
-  const flushBuffer = useCallback(() => {
-    setStreamingBuffer(sessionId, {
-      parts: streamingPartsRef.current,
-      childParts: new Map(childPartsMapRef.current),
-      streamingContent: streamingContentRef.current,
-      isStreaming: true,
-      runStartedAt: runStartedAt ?? undefined,
-      compactionState,
-      optimisticMessages: optimisticRef.current.length > 0 ? optimisticRef.current : undefined
-    })
-  }, [sessionId, optimisticRef, runStartedAt, compactionState])
 
   // --- Mission Control task state ---
   const [missionTasks, setMissionTasks] = useState<MissionTask[]>([])
@@ -462,9 +471,16 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
 
   useEffect(() => {
     if (hasDurableCompactionMessage && compactionState?.phase === 'completed') {
-      setCompactionState(null)
+      updateStreamingBuffer(
+        sessionId,
+        (current) => ({
+          ...current,
+          compactionState: null
+        }),
+        { notify: 'immediate' }
+      )
     }
-  }, [hasDurableCompactionMessage, compactionState])
+  }, [hasDurableCompactionMessage, compactionState, sessionId])
 
   // Auto-hide MissionControl after all tasks complete
   useEffect(() => {
@@ -490,63 +506,6 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
     }
   }, [allTasksComplete, isStreaming, missionVisible])
 
-  const immediateFlush = useCallback(() => {
-    setStreamingParts([...streamingPartsRef.current])
-    flushBuffer()
-  }, [flushBuffer])
-
-  const scheduleFlush = useCallback(() => {
-    if (rafRef.current) return
-    rafRef.current = requestAnimationFrame(() => {
-      rafRef.current = null
-      setStreamingParts([...streamingPartsRef.current])
-      flushBuffer()
-    })
-  }, [flushBuffer])
-
-  const upsertToolUse = useCallback(
-    (
-      toolId: string,
-      update: Partial<NonNullable<SharedStreamingPart['toolUse']>> & { name?: string }
-    ) => {
-      const parts = streamingPartsRef.current
-      const existingIndex = parts.findIndex(
-        (p) => p.type === 'tool_use' && p.toolUse?.id === toolId
-      )
-
-      if (existingIndex >= 0) {
-        const existing = parts[existingIndex]
-        streamingPartsRef.current = [
-          ...parts.slice(0, existingIndex),
-          {
-            ...existing,
-            toolUse: { ...existing.toolUse!, ...update }
-          },
-          ...parts.slice(existingIndex + 1)
-        ]
-      } else {
-        streamingPartsRef.current = [
-          ...parts,
-          {
-            type: 'tool_use',
-            toolUse: {
-              id: toolId,
-              name: update.name ?? 'unknown',
-              input: update.input,
-              status: update.status ?? 'running',
-              startTime: update.startTime ?? Date.now(),
-              endTime: update.endTime,
-              output: update.output,
-              error: update.error
-            }
-          }
-        ]
-      }
-      immediateFlush()
-    },
-    [immediateFlush]
-  )
-
   const transitionToolStatus = useCallback(
     (toolUseID: string, status: 'success' | 'error', error?: string) => {
       const mapper = (p: SharedStreamingPart): SharedStreamingPart =>
@@ -554,8 +513,14 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
           ? { ...p, toolUse: { ...p.toolUse!, status, ...(error ? { error } : {}) } }
           : p
 
-      streamingPartsRef.current = streamingPartsRef.current.map(mapper)
-      setStreamingParts([...streamingPartsRef.current])
+      updateStreamingBuffer(
+        sessionId,
+        (current) => ({
+          ...current,
+          parts: current.parts.map(mapper)
+        }),
+        { notify: 'immediate' }
+      )
 
       // Persist the visual status in committed timeline messages too, since
       // the plan card may already have been materialized from durable history.
@@ -571,98 +536,8 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
       })
       timelineMessagesRef.current = updatedMessages
       setMessages(updatedMessages)
-
-      flushBuffer()
     },
-    [flushBuffer, setMessages]
-  )
-
-  /** Route a child-session event into childPartsMap instead of main streaming parts. */
-  const routeChildEvent = useCallback(
-    (childId: string, partData: Record<string, unknown>) => {
-      const part = partData.part as Record<string, unknown> | undefined
-      if (!part) return
-
-      let sp: SharedStreamingPart | null = null
-
-      if (part.type === 'text') {
-        const text = (partData.delta as string) ?? (part.text as string) ?? ''
-        if (text) {
-          // Accumulate text into last text part for this child
-          const existing = childPartsMapRef.current.get(childId)
-          const last = existing?.[existing.length - 1]
-          if (last?.type === 'text') {
-            last.text = (last.text ?? '') + text
-            setChildPartsMap(new Map(childPartsMapRef.current))
-            flushBuffer()
-            return
-          }
-          sp = { type: 'text', text }
-        }
-      } else if (part.type === 'tool') {
-        const toolId = (part.callID as string) || (part.id as string) || `child-tool-${Date.now()}`
-        const toolName = (part.tool as string) || undefined
-        const state = (part.state as Record<string, unknown>) || {}
-        const statusMap: Record<string, 'pending' | 'running' | 'success' | 'error'> = {
-          pending: 'pending',
-          running: 'running',
-          completed: 'success',
-          error: 'error'
-        }
-        const stateTime = state.time as Record<string, number> | undefined
-
-        // Upsert: find existing tool part by id
-        const existing = childPartsMapRef.current.get(childId)
-        if (existing) {
-          const idx = existing.findIndex((p) => p.type === 'tool_use' && p.toolUse?.id === toolId)
-          if (idx >= 0) {
-            existing[idx] = {
-              ...existing[idx],
-              toolUse: {
-                ...existing[idx].toolUse!,
-                ...(toolName ? { name: toolName } : {}),
-                ...(state.input ? { input: state.input as Record<string, unknown> } : {}),
-                status: statusMap[state.status as string] || 'running',
-                startTime: stateTime?.start || existing[idx].toolUse!.startTime,
-                endTime: stateTime?.end,
-                output: state.status === 'completed' ? (state.output as string) : undefined,
-                error: state.status === 'error' ? (state.error as string) : undefined
-              }
-            }
-            setChildPartsMap(new Map(childPartsMapRef.current))
-            flushBuffer()
-            return
-          }
-        }
-
-        sp = {
-          type: 'tool_use',
-          toolUse: {
-            id: toolId,
-            name: toolName ?? 'unknown',
-            input: (state.input as Record<string, unknown>) ?? {},
-            status: statusMap[state.status as string] || 'running',
-            startTime: stateTime?.start || Date.now(),
-            endTime: stateTime?.end,
-            output: state.status === 'completed' ? (state.output as string) : undefined,
-            error: state.status === 'error' ? (state.error as string) : undefined
-          }
-        }
-      }
-      // Reasoning from child sessions: skip (not useful to surface)
-
-      if (sp) {
-        const arr = childPartsMapRef.current.get(childId)
-        if (arr) {
-          arr.push(sp)
-        } else {
-          childPartsMapRef.current.set(childId, [sp])
-        }
-        setChildPartsMap(new Map(childPartsMapRef.current))
-        flushBuffer()
-      }
-    },
-    [flushBuffer]
+    [sessionId, setMessages]
   )
 
   useEffect(() => {
@@ -760,62 +635,12 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
         if (event.type === 'message.part.updated') {
           const partData = event.data
           if (!partData) return
-
-          // Route child-session events (sub-agent tool calls) to the side-channel map
-          const childId = event.childSessionId
-          if (childId) {
-            routeChildEvent(childId, partData as Record<string, unknown>)
-            return
-          }
+          if (event.childSessionId) return
 
           const part = partData.part as Record<string, unknown> | undefined
-
-          // --- Text deltas ---
-          if (part?.type === 'text') {
-            const delta = (partData.delta as string) ?? (part.text as string) ?? ''
-            if (delta) {
-              streamingContentRef.current += delta
-              setStreamingContent(streamingContentRef.current)
-
-              // Also accumulate into streaming parts for AgentTimeline
-              const parts = streamingPartsRef.current
-              const lastText = parts[parts.length - 1]
-              if (lastText?.type === 'text') {
-                streamingPartsRef.current = [
-                  ...parts.slice(0, -1),
-                  { ...lastText, text: (lastText.text ?? '') + delta }
-                ]
-              } else {
-                streamingPartsRef.current = [...parts, { type: 'text', text: delta }]
-              }
-              scheduleFlush()
-            }
-
-            // --- Tool events ---
-          } else if (part?.type === 'tool') {
-            const toolId = (part.callID as string) || (part.id as string) || `tool-${Date.now()}`
+          if (part?.type === 'tool') {
             const toolName = (part.tool as string) || undefined
             const state = (part.state as Record<string, unknown>) || {}
-
-            const statusMap: Record<string, 'pending' | 'running' | 'success' | 'error'> = {
-              pending: 'pending',
-              running: 'running',
-              completed: 'success',
-              error: 'error'
-            }
-
-            const stateTime = state.time as Record<string, number> | undefined
-
-            upsertToolUse(toolId, {
-              ...(toolName ? { name: toolName } : {}),
-              ...(state.input ? { input: state.input as Record<string, unknown> } : {}),
-              status: statusMap[state.status as string] || 'running',
-              startTime: stateTime?.start || Date.now(),
-              endTime: stateTime?.end,
-              output: state.status === 'completed' ? (state.output as string) : undefined,
-              error: state.status === 'error' ? (state.error as string) : undefined
-            })
-            setIsStreaming(true)
 
             // --- Mission Control: detect todo/task tools ---
             const lowerToolName = toolName?.toLowerCase() ?? ''
@@ -868,61 +693,13 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
                 setMissionTasks([...missionTasksRef.current])
               }
             }
-
-            // --- Reasoning deltas ---
-          } else if (part?.type === 'reasoning') {
-            const delta = (partData.delta as string) ?? (part.text as string) ?? ''
-            if (delta) {
-              const parts = streamingPartsRef.current
-              const last = parts[parts.length - 1]
-              if (last?.type === 'reasoning') {
-                streamingPartsRef.current = [
-                  ...parts.slice(0, -1),
-                  { ...last, reasoning: (last.reasoning ?? '') + delta }
-                ]
-              } else {
-                streamingPartsRef.current = [...parts, { type: 'reasoning', reasoning: delta }]
-              }
-              scheduleFlush()
-            }
-            setIsStreaming(true)
-
-            // --- Subtask events ---
-          } else if (part?.type === 'subtask') {
-            streamingPartsRef.current = [
-              ...streamingPartsRef.current,
-              {
-                type: 'subtask',
-                subtask: {
-                  id: (part.id as string) || `subtask-${Date.now()}`,
-                  sessionID: (part.sessionID as string) || '',
-                  prompt: (part.prompt as string) || '',
-                  description: (part.description as string) || '',
-                  agent: (part.agent as string) || 'unknown',
-                  parts: [],
-                  status: 'running'
-                }
-              }
-            ]
-            immediateFlush()
-            setIsStreaming(true)
           }
         }
 
         // Lifecycle events
         if (event.type === 'session.status') {
           const statusType = event.data?.status?.type
-          if (statusType === 'busy') {
-            setIsStreaming(true)
-            setRunStartedAt((current) => current ?? Date.now())
-          } else if (statusType === 'materializing') {
-            setIsStreaming(true)
-            setRunStartedAt((current) => current ?? Date.now())
-          } else if (statusType === 'retry') {
-            setRunStartedAt(null)
-          } else if (statusType === 'idle') {
-            setIsStreaming(false)
-            setRunStartedAt(null)
+          if (statusType === 'idle') {
             void refreshUsageSummary()
             // Refresh timeline to pick up newly committed messages
             refresh().then((msgs) => {
@@ -942,16 +719,10 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
                   }
                 }
               }
+
+              optimisticRef.current = []
+              clearStreamingBuffer(sessionId)
             })
-            // Clear streaming state and buffer on idle
-            streamingContentRef.current = ''
-            setStreamingContent('')
-            streamingPartsRef.current = []
-            setStreamingParts([])
-            childPartsMapRef.current.clear()
-            setChildPartsMap(new Map())
-            optimisticRef.current = []
-            clearStreamingBuffer(sessionId)
 
             // Auto-drain pending message queue
             if (worktreePath && droidSessionId) {
@@ -964,25 +735,6 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
               ).catch((err) => console.error('[SessionShell] drainNextPending failed:', err))
             }
           }
-        }
-
-        // Context compression events
-        if (event.type === 'session.compaction_started') {
-          setCompactionState({
-            phase: 'running',
-            timestamp: Date.now()
-          })
-        }
-
-        if (event.type === 'session.context_compacted') {
-          setCompactionState({
-            phase: 'completed',
-            timestamp: Date.now()
-          })
-        }
-
-        if (event.type === 'session.error') {
-          setRunStartedAt(null)
         }
 
         // Token / cost tracking (active session — global bridge skips the active one)
@@ -1056,10 +808,6 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
     refresh,
     worktreePath,
     droidSessionId,
-    scheduleFlush,
-    upsertToolUse,
-    immediateFlush,
-    routeChildEvent,
     optimisticRef,
     currentProviderId,
     requestModel,
@@ -1082,15 +830,7 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
       }
 
       if (action === 'send' || action === 'stop_and_send' || action === 'steer') {
-        streamingContentRef.current = ''
-        setStreamingContent('')
-        streamingPartsRef.current = []
-        setStreamingParts([])
-        childPartsMapRef.current.clear()
-        setChildPartsMap(new Map())
-        setIsStreaming(true)
-        // Clear stale buffer from previous turn
-        clearStreamingBuffer(sessionId)
+        resetLiveOverlay(true)
       }
 
       // Optimistic insert — show user message immediately in the timeline
@@ -1112,8 +852,7 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
         // Sync ref immediately so MissionControl's streaming callback can find
         // the user message before the next useEffect tick
         timelineMessagesRef.current = [...timelineMessagesRef.current, optimisticMsg]
-        // Flush buffer immediately so the optimistic message survives tab switches
-        flushBuffer()
+        syncOptimisticMessagesToMirror()
       }
 
       try {
@@ -1132,14 +871,21 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
         })
 
         if (!consumed && (action === 'send' || action === 'stop_and_send')) {
-          setIsStreaming(false)
+          resetLiveOverlay(false)
         }
       } catch (err) {
         console.error('[SessionShell] action failed:', err)
-        setIsStreaming(false)
+        resetLiveOverlay(false)
       }
     },
-    [worktreePath, droidSessionId, sessionId, appendOptimistic, flushBuffer, requestModel]
+    [
+      worktreePath,
+      droidSessionId,
+      appendOptimistic,
+      requestModel,
+      resetLiveOverlay,
+      syncOptimisticMessagesToMirror
+    ]
   )
 
   const canEditUserMessage = useCallback(
@@ -1179,17 +925,11 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
       optimisticRef.current = optimisticRef.current.filter(
         (message) => trimmedMessages.some((candidate) => candidate.id === message.id)
       )
+      syncOptimisticMessagesToMirror()
       setEditingMessageId(null)
       setEditingContent('')
 
-      streamingContentRef.current = ''
-      setStreamingContent('')
-      streamingPartsRef.current = []
-      setStreamingParts([])
-      childPartsMapRef.current.clear()
-      setChildPartsMap(new Map())
-      setIsStreaming(true)
-      clearStreamingBuffer(sessionId)
+      resetLiveOverlay(true)
 
       const optimisticMsg: TimelineMessage = {
         id: `optimistic-${Date.now()}`,
@@ -1199,7 +939,7 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
       }
       appendOptimistic(optimisticMsg)
       timelineMessagesRef.current = [...trimmedMessages, optimisticMsg]
-      flushBuffer()
+      syncOptimisticMessagesToMirror()
 
       try {
         const consumed = await executeSendAction('send', contentToSend, [], {
@@ -1211,12 +951,12 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
         })
 
         if (!consumed) {
-          setIsStreaming(false)
+          resetLiveOverlay(false)
         }
       } catch (error) {
         console.error('[SessionShell] edit resend failed:', error)
         toast.error(t('sessionView.toasts.messageError'))
-        setIsStreaming(false)
+        resetLiveOverlay(false)
       }
     },
     [
@@ -1225,10 +965,10 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
       droidSessionId,
       timelineMessages,
       setMessages,
-      sessionId,
       appendOptimistic,
-      flushBuffer,
       requestModel,
+      resetLiveOverlay,
+      syncOptimisticMessagesToMirror,
       t,
       optimisticRef
     ]
@@ -1366,13 +1106,7 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
           ? 'Implement the plan.'
           : buildPlanImplementationPrompt(pendingBeforeAction.planContent)
 
-      streamingContentRef.current = ''
-      setStreamingContent('')
-      streamingPartsRef.current = []
-      setStreamingParts([])
-      childPartsMapRef.current.clear()
-      setChildPartsMap(new Map())
-      setIsStreaming(true)
+      resetLiveOverlay(true)
 
       if (isClaudeCode) {
         // Claude resumes within the same prompt cycle after approval; mark the
@@ -1389,6 +1123,7 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
       }
       appendOptimistic(optimisticMsg)
       timelineMessagesRef.current = [...timelineMessagesRef.current, optimisticMsg]
+      syncOptimisticMessagesToMirror()
 
       await executeSendAction('send', implementPrompt, [], {
         worktreePath,
@@ -1402,7 +1137,7 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
       toast.error(`Plan approve error: ${err instanceof Error ? err.message : String(err)}`)
       useSessionStore.getState().setPendingPlan(sessionId, pendingBeforeAction)
       useWorktreeStatusStore.getState().setSessionStatus(sessionId, 'plan_ready')
-      setIsStreaming(false)
+      resetLiveOverlay(false)
     }
   }, [
     worktreePath,
@@ -1411,6 +1146,8 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
     sessionRecord?.agent_sdk,
     sessionId,
     appendOptimistic,
+    resetLiveOverlay,
+    syncOptimisticMessagesToMirror,
     transitionToolStatus,
     requestModel
   ])

--- a/src/renderer/src/components/session-hq/SessionShell.tsx
+++ b/src/renderer/src/components/session-hq/SessionShell.tsx
@@ -50,7 +50,7 @@ import {
   getStreamingBufferSnapshot,
   subscribeToStreamingBuffer,
   updateStreamingBuffer,
-  clearStreamingBuffer
+  clearStreamingBufferOverlay
 } from '@/stores/useSessionRuntimeStore'
 import {
   executeSendAction,
@@ -702,27 +702,32 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
           if (statusType === 'idle') {
             void refreshUsageSummary()
             // Refresh timeline to pick up newly committed messages
-            refresh().then((msgs) => {
-              // Sync mission tasks from committed timeline (source of truth after idle)
-              if (msgs.length > 0) {
-                const extracted = extractMissionTasks(msgs)
-                if (extracted.length > 0) {
-                  // Don't overwrite if all tasks already completed in memory —
-                  // streaming TaskUpdate events are more authoritative than DB
-                  // snapshots for task status (DB only has original TodoWrite input)
-                  const currentAllComplete =
-                    missionTasksRef.current.length > 0 &&
-                    missionTasksRef.current.every((t) => t.status === 'completed')
-                  if (!currentAllComplete) {
-                    missionTasksRef.current = extracted
-                    setMissionTasks(extracted)
+            void refresh()
+              .then((msgs) => {
+                // Sync mission tasks from committed timeline (source of truth after idle)
+                if (msgs.length > 0) {
+                  const extracted = extractMissionTasks(msgs)
+                  if (extracted.length > 0) {
+                    // Don't overwrite if all tasks already completed in memory —
+                    // streaming TaskUpdate events are more authoritative than DB
+                    // snapshots for task status (DB only has original TodoWrite input)
+                    const currentAllComplete =
+                      missionTasksRef.current.length > 0 &&
+                      missionTasksRef.current.every((t) => t.status === 'completed')
+                    if (!currentAllComplete) {
+                      missionTasksRef.current = extracted
+                      setMissionTasks(extracted)
+                    }
                   }
                 }
-              }
-
-              optimisticRef.current = []
-              clearStreamingBuffer(sessionId)
-            })
+              })
+              .finally(() => {
+                optimisticRef.current = []
+                clearStreamingBufferOverlay(sessionId, {
+                  notify: 'immediate',
+                  preserveCompactionState: true
+                })
+              })
 
             // Auto-drain pending message queue
             if (worktreePath && droidSessionId) {

--- a/src/renderer/src/hooks/useAgentEventBridge.ts
+++ b/src/renderer/src/hooks/useAgentEventBridge.ts
@@ -31,8 +31,9 @@ import { useRecentStore } from '@/stores/useRecentStore'
 import { useUsageStore, resolveUsageProvider } from '@/stores'
 import {
   useSessionRuntimeStore,
-  clearStreamingBuffer,
-  acceptSessionEvent
+  acceptSessionEvent,
+  syncStreamingBufferGuardState,
+  writeEventToStreamingBuffer
 } from '@/stores/useSessionRuntimeStore'
 import {
   extractTokens,
@@ -264,9 +265,11 @@ export function useAgentEventBridge(): void {
             return
           }
 
-          if (guard.advancedRun) {
-            clearStreamingBuffer(sessionId)
-          }
+          syncStreamingBufferGuardState(sessionId, guard.state, {
+            resetOverlay: guard.advancedRun,
+            notify: 'none'
+          })
+          writeEventToStreamingBuffer(sessionId, event, { activeSessionId: activeId })
 
           // Always dispatch to per-session callbacks (SessionView streaming)
           runtime.dispatchToSession(sessionId, event)
@@ -639,11 +642,6 @@ export function useAgentEventBridge(): void {
 
           runtime.setLifecycle(sessionId, 'idle')
           runtime.setRetryInfo(sessionId, null)
-          // Clear streaming buffer — DB is now source of truth for this turn.
-          // Must happen here (not only in SessionShell) because the user may
-          // have switched tabs mid-stream; SessionShell is unmounted and won't
-          // receive the idle event directly.
-          clearStreamingBuffer(sessionId)
 
           // Usage tracking on idle
           if (useSettingsStore.getState().showUsageIndicator) {

--- a/src/renderer/src/stores/useSessionRuntimeStore.ts
+++ b/src/renderer/src/stores/useSessionRuntimeStore.ts
@@ -77,6 +77,9 @@ const _sessionEventCallbacks = new Map<string, Set<EventCallback>>()
 // ---------------------------------------------------------------------------
 
 export interface StreamingBuffer {
+  activeRunEpoch: number
+  lastAppliedSequence: number
+  mirrorVersion: number
   parts: StreamingPart[]
   /** Child session parts keyed by child session id */
   childParts: Map<string, StreamingPart[]>
@@ -92,17 +95,399 @@ export interface StreamingBuffer {
 }
 
 const _streamingBuffers = new Map<string, StreamingBuffer>()
+type StreamingBufferCallback = () => void
+const _streamingBufferCallbacks = new Map<string, Set<StreamingBufferCallback>>()
+const _pendingStreamingBufferFlushes = new Set<string>()
+
+function createStreamingBuffer(overrides?: Partial<StreamingBuffer>): StreamingBuffer {
+  return {
+    activeRunEpoch: 0,
+    lastAppliedSequence: -1,
+    mirrorVersion: 0,
+    parts: [],
+    childParts: new Map(),
+    streamingContent: '',
+    isStreaming: false,
+    runStartedAt: undefined,
+    compactionState: null,
+    optimisticMessages: undefined,
+    ...overrides
+  }
+}
+
+function cloneStreamingBuffer(buffer: StreamingBuffer): StreamingBuffer {
+  return {
+    ...buffer,
+    parts: [...buffer.parts],
+    childParts: new Map(
+      Array.from(buffer.childParts.entries(), ([childId, parts]) => [childId, [...parts]])
+    ),
+    optimisticMessages: buffer.optimisticMessages ? [...buffer.optimisticMessages] : undefined
+  }
+}
+
+function notifyStreamingBufferSubscribers(sessionId: string): void {
+  const callbacks = _streamingBufferCallbacks.get(sessionId)
+  if (!callbacks) return
+  for (const cb of callbacks) {
+    try {
+      cb()
+    } catch (error) {
+      console.error('[SessionRuntimeStore] streaming buffer callback error:', error)
+    }
+  }
+}
+
+function flushStreamingBufferVersion(sessionId: string): void {
+  const current = _streamingBuffers.get(sessionId)
+  if (!current) return
+  _streamingBuffers.set(sessionId, {
+    ...current,
+    mirrorVersion: current.mirrorVersion + 1
+  })
+  notifyStreamingBufferSubscribers(sessionId)
+}
+
+function scheduleStreamingBufferFlush(sessionId: string): void {
+  if (_pendingStreamingBufferFlushes.has(sessionId)) return
+  _pendingStreamingBufferFlushes.add(sessionId)
+  const schedule =
+    typeof requestAnimationFrame === 'function'
+      ? requestAnimationFrame
+      : (cb: FrameRequestCallback) => setTimeout(() => cb(Date.now()), 0)
+
+  schedule(() => {
+    _pendingStreamingBufferFlushes.delete(sessionId)
+    flushStreamingBufferVersion(sessionId)
+  })
+}
+
+function mapPartStatus(
+  value: unknown
+): 'pending' | 'running' | 'success' | 'error' {
+  if (value === 'pending' || value === 'running') return value
+  if (value === 'completed' || value === 'success') return 'success'
+  if (value === 'error') return 'error'
+  return 'running'
+}
 
 export function getStreamingBuffer(sessionId: string): StreamingBuffer | undefined {
-  return _streamingBuffers.get(sessionId)
+  const buffer = _streamingBuffers.get(sessionId)
+  return buffer ? cloneStreamingBuffer(buffer) : undefined
 }
 
 export function setStreamingBuffer(sessionId: string, buffer: StreamingBuffer): void {
-  _streamingBuffers.set(sessionId, buffer)
+  _streamingBuffers.set(sessionId, cloneStreamingBuffer(buffer))
 }
 
 export function clearStreamingBuffer(sessionId: string): void {
   _streamingBuffers.delete(sessionId)
+  _pendingStreamingBufferFlushes.delete(sessionId)
+  notifyStreamingBufferSubscribers(sessionId)
+}
+
+export function subscribeToStreamingBuffer(sessionId: string, cb: StreamingBufferCallback): () => void {
+  let callbackSet = _streamingBufferCallbacks.get(sessionId)
+  if (!callbackSet) {
+    callbackSet = new Set()
+    _streamingBufferCallbacks.set(sessionId, callbackSet)
+  }
+  callbackSet.add(cb)
+  return () => {
+    const setForSession = _streamingBufferCallbacks.get(sessionId)
+    if (!setForSession) return
+    setForSession.delete(cb)
+    if (setForSession.size === 0) {
+      _streamingBufferCallbacks.delete(sessionId)
+    }
+  }
+}
+
+export function getStreamingBufferSnapshot(sessionId: string): StreamingBuffer {
+  return getStreamingBuffer(sessionId) ?? createStreamingBuffer()
+}
+
+export function updateStreamingBuffer(
+  sessionId: string,
+  updater: (current: StreamingBuffer) => StreamingBuffer,
+  options?: { notify?: 'none' | 'frame' | 'immediate' }
+): StreamingBuffer {
+  const current = _streamingBuffers.get(sessionId) ?? createStreamingBuffer()
+  const next = cloneStreamingBuffer(updater(cloneStreamingBuffer(current)))
+  _streamingBuffers.set(sessionId, next)
+
+  const notifyMode = options?.notify ?? 'frame'
+  if (notifyMode === 'immediate') {
+    flushStreamingBufferVersion(sessionId)
+  } else if (notifyMode === 'frame') {
+    scheduleStreamingBufferFlush(sessionId)
+  }
+
+  return getStreamingBufferSnapshot(sessionId)
+}
+
+export function syncStreamingBufferGuardState(
+  sessionId: string,
+  state: SessionEventGuardState,
+  options?: { resetOverlay?: boolean; notify?: 'none' | 'frame' | 'immediate' }
+): StreamingBuffer {
+  return updateStreamingBuffer(
+    sessionId,
+    (current) =>
+      options?.resetOverlay
+        ? createStreamingBuffer({
+            activeRunEpoch: state.activeRunEpoch,
+            lastAppliedSequence: state.lastAppliedSequence,
+            mirrorVersion: current.mirrorVersion,
+            optimisticMessages: current.optimisticMessages
+          })
+        : {
+            ...current,
+            activeRunEpoch: state.activeRunEpoch,
+            lastAppliedSequence: state.lastAppliedSequence
+          },
+    { notify: options?.notify ?? 'none' }
+  )
+}
+
+export function writeEventToStreamingBuffer(
+  sessionId: string,
+  event: CanonicalAgentEvent,
+  options?: { activeSessionId?: string | null }
+): StreamingBuffer {
+  const activeSessionId = options?.activeSessionId ?? null
+
+  return updateStreamingBuffer(
+    sessionId,
+    (current) => {
+      if (event.type === 'message.part.updated') {
+        const partData = event.data as Record<string, unknown> | undefined
+        const part = partData?.part as Record<string, unknown> | undefined
+        if (!part) return current
+
+        if (event.childSessionId) {
+          const nextChildParts = new Map(current.childParts)
+          const existing = [...(nextChildParts.get(event.childSessionId) ?? [])]
+
+          if (part.type === 'text') {
+            const delta = (partData?.delta as string) ?? (part.text as string) ?? ''
+            if (!delta) return current
+            const last = existing[existing.length - 1]
+            if (last?.type === 'text') {
+              existing[existing.length - 1] = { ...last, text: (last.text ?? '') + delta }
+            } else {
+              existing.push({ type: 'text', text: delta })
+            }
+          } else if (part.type === 'tool') {
+            const toolId =
+              (part.callID as string) || (part.id as string) || `child-tool-${Date.now()}`
+            const toolName = (part.tool as string) || 'unknown'
+            const state = (part.state as Record<string, unknown>) || {}
+            const stateTime = state.time as Record<string, number> | undefined
+            const idx = existing.findIndex((p) => p.type === 'tool_use' && p.toolUse?.id === toolId)
+            const toolPart: StreamingPart = {
+              type: 'tool_use',
+              toolUse: {
+                id: toolId,
+                name: toolName,
+                input: (state.input as Record<string, unknown>) ?? {},
+                status: mapPartStatus(state.status),
+                startTime: stateTime?.start || existing[idx]?.toolUse?.startTime || Date.now(),
+                endTime: stateTime?.end,
+                output: state.status === 'completed' ? (state.output as string) : undefined,
+                error: state.status === 'error' ? (state.error as string) : undefined
+              }
+            }
+            if (idx >= 0) {
+              existing[idx] = toolPart
+            } else {
+              existing.push(toolPart)
+            }
+          } else {
+            return current
+          }
+
+          nextChildParts.set(event.childSessionId, existing)
+          return {
+            ...current,
+            childParts: nextChildParts,
+            isStreaming: true
+          }
+        }
+
+        if (part.type === 'text') {
+          const delta = (partData?.delta as string) ?? (part.text as string) ?? ''
+          if (!delta) return current
+
+          const nextParts = [...current.parts]
+          const last = nextParts[nextParts.length - 1]
+          if (last?.type === 'text') {
+            nextParts[nextParts.length - 1] = {
+              ...last,
+              text: (last.text ?? '') + delta
+            }
+          } else {
+            nextParts.push({ type: 'text', text: delta })
+          }
+
+          return {
+            ...current,
+            parts: nextParts,
+            streamingContent: current.streamingContent + delta,
+            isStreaming: true
+          }
+        }
+
+        if (part.type === 'tool') {
+          const toolId = (part.callID as string) || (part.id as string) || `tool-${Date.now()}`
+          const toolName = (part.tool as string) || 'unknown'
+          const state = (part.state as Record<string, unknown>) || {}
+          const stateTime = state.time as Record<string, number> | undefined
+          const nextParts = [...current.parts]
+          const idx = nextParts.findIndex((p) => p.type === 'tool_use' && p.toolUse?.id === toolId)
+          const toolPart: StreamingPart = {
+            type: 'tool_use',
+            toolUse: {
+              id: toolId,
+              name: toolName,
+              input: (state.input as Record<string, unknown>) ?? {},
+              status: mapPartStatus(state.status),
+              startTime: stateTime?.start || nextParts[idx]?.toolUse?.startTime || Date.now(),
+              endTime: stateTime?.end,
+              output: state.status === 'completed' ? (state.output as string) : undefined,
+              error: state.status === 'error' ? (state.error as string) : undefined
+            }
+          }
+
+          if (idx >= 0) {
+            nextParts[idx] = toolPart
+          } else {
+            nextParts.push(toolPart)
+          }
+
+          return {
+            ...current,
+            parts: nextParts,
+            isStreaming: true
+          }
+        }
+
+        if (part.type === 'reasoning') {
+          const delta = (partData?.delta as string) ?? (part.text as string) ?? ''
+          if (!delta) return current
+          const nextParts = [...current.parts]
+          const last = nextParts[nextParts.length - 1]
+          if (last?.type === 'reasoning') {
+            nextParts[nextParts.length - 1] = {
+              ...last,
+              reasoning: (last.reasoning ?? '') + delta
+            }
+          } else {
+            nextParts.push({ type: 'reasoning', reasoning: delta })
+          }
+          return {
+            ...current,
+            parts: nextParts,
+            isStreaming: true
+          }
+        }
+
+        if (part.type === 'subtask') {
+          return {
+            ...current,
+            parts: [
+              ...current.parts,
+              {
+                type: 'subtask',
+                subtask: {
+                  id: (part.id as string) || `subtask-${Date.now()}`,
+                  sessionID: (part.sessionID as string) || '',
+                  prompt: (part.prompt as string) || '',
+                  description: (part.description as string) || '',
+                  agent: (part.agent as string) || 'unknown',
+                  parts: [],
+                  status: 'running'
+                }
+              }
+            ],
+            isStreaming: true
+          }
+        }
+
+        return current
+      }
+
+      if (event.type === 'session.status') {
+        const statusType =
+          (event.statusPayload as { type?: string } | undefined)?.type ??
+          ((event.data as Record<string, unknown> | undefined)?.status as { type?: string } | undefined)
+            ?.type
+
+        if (statusType === 'busy' || statusType === 'materializing') {
+          return {
+            ...current,
+            isStreaming: true,
+            runStartedAt: current.runStartedAt ?? Date.now()
+          }
+        }
+
+        if (statusType === 'retry') {
+          return {
+            ...current,
+            runStartedAt: undefined
+          }
+        }
+
+        if (statusType === 'idle') {
+          if (sessionId !== activeSessionId) {
+            return createStreamingBuffer({
+              activeRunEpoch: current.activeRunEpoch,
+              lastAppliedSequence: current.lastAppliedSequence,
+              mirrorVersion: current.mirrorVersion
+            })
+          }
+
+          return {
+            ...current,
+            isStreaming: false,
+            runStartedAt: undefined
+          }
+        }
+
+        return current
+      }
+
+      if (event.type === 'session.compaction_started') {
+        return {
+          ...current,
+          compactionState: {
+            phase: 'running',
+            timestamp: Date.now()
+          }
+        }
+      }
+
+      if (event.type === 'session.context_compacted') {
+        return {
+          ...current,
+          compactionState: {
+            phase: 'completed',
+            timestamp: Date.now()
+          }
+        }
+      }
+
+      if (event.type === 'session.error') {
+        return {
+          ...current,
+          runStartedAt: undefined
+        }
+      }
+
+      return current
+    },
+    { notify: 'frame' }
+  )
 }
 
 // ---------------------------------------------------------------------------

--- a/src/renderer/src/stores/useSessionRuntimeStore.ts
+++ b/src/renderer/src/stores/useSessionRuntimeStore.ts
@@ -98,6 +98,7 @@ const _streamingBuffers = new Map<string, StreamingBuffer>()
 type StreamingBufferCallback = () => void
 const _streamingBufferCallbacks = new Map<string, Set<StreamingBufferCallback>>()
 const _pendingStreamingBufferFlushes = new Set<string>()
+const _emptyStreamingBufferSnapshots = new Map<string, StreamingBuffer>()
 
 function createStreamingBuffer(overrides?: Partial<StreamingBuffer>): StreamingBuffer {
   return {
@@ -124,6 +125,28 @@ function cloneStreamingBuffer(buffer: StreamingBuffer): StreamingBuffer {
     ),
     optimisticMessages: buffer.optimisticMessages ? [...buffer.optimisticMessages] : undefined
   }
+}
+
+function getEmptyStreamingBufferSnapshot(sessionId: string): StreamingBuffer {
+  const existing = _emptyStreamingBufferSnapshots.get(sessionId)
+  if (existing) return existing
+
+  const next = createStreamingBuffer()
+  _emptyStreamingBufferSnapshots.set(sessionId, next)
+  return next
+}
+
+function resetStreamingBufferOverlayState(
+  current: StreamingBuffer,
+  options?: { preserveOptimisticMessages?: boolean; preserveCompactionState?: boolean }
+): StreamingBuffer {
+  return createStreamingBuffer({
+    activeRunEpoch: current.activeRunEpoch,
+    lastAppliedSequence: current.lastAppliedSequence,
+    mirrorVersion: current.mirrorVersion,
+    optimisticMessages: options?.preserveOptimisticMessages ? current.optimisticMessages : undefined,
+    compactionState: options?.preserveCompactionState ? current.compactionState : null
+  })
 }
 
 function notifyStreamingBufferSubscribers(sessionId: string): void {
@@ -178,12 +201,20 @@ export function getStreamingBuffer(sessionId: string): StreamingBuffer | undefin
 
 export function setStreamingBuffer(sessionId: string, buffer: StreamingBuffer): void {
   _streamingBuffers.set(sessionId, cloneStreamingBuffer(buffer))
+  _emptyStreamingBufferSnapshots.delete(sessionId)
 }
 
 export function clearStreamingBuffer(sessionId: string): void {
   _streamingBuffers.delete(sessionId)
   _pendingStreamingBufferFlushes.delete(sessionId)
   notifyStreamingBufferSubscribers(sessionId)
+}
+
+export function resetStreamingBuffersForTests(): void {
+  _streamingBuffers.clear()
+  _pendingStreamingBufferFlushes.clear()
+  _emptyStreamingBufferSnapshots.clear()
+  _streamingBufferCallbacks.clear()
 }
 
 export function subscribeToStreamingBuffer(sessionId: string, cb: StreamingBufferCallback): () => void {
@@ -204,7 +235,7 @@ export function subscribeToStreamingBuffer(sessionId: string, cb: StreamingBuffe
 }
 
 export function getStreamingBufferSnapshot(sessionId: string): StreamingBuffer {
-  return getStreamingBuffer(sessionId) ?? createStreamingBuffer()
+  return _streamingBuffers.get(sessionId) ?? getEmptyStreamingBufferSnapshot(sessionId)
 }
 
 export function updateStreamingBuffer(
@@ -213,8 +244,14 @@ export function updateStreamingBuffer(
   options?: { notify?: 'none' | 'frame' | 'immediate' }
 ): StreamingBuffer {
   const current = _streamingBuffers.get(sessionId) ?? createStreamingBuffer()
-  const next = cloneStreamingBuffer(updater(cloneStreamingBuffer(current)))
+  const next = updater(current)
+
+  if (next === current) {
+    return getStreamingBufferSnapshot(sessionId)
+  }
+
   _streamingBuffers.set(sessionId, next)
+  _emptyStreamingBufferSnapshots.delete(sessionId)
 
   const notifyMode = options?.notify ?? 'frame'
   if (notifyMode === 'immediate') {
@@ -226,6 +263,30 @@ export function updateStreamingBuffer(
   return getStreamingBufferSnapshot(sessionId)
 }
 
+export function clearStreamingBufferOverlay(
+  sessionId: string,
+  options?: {
+    notify?: 'none' | 'frame' | 'immediate'
+    preserveOptimisticMessages?: boolean
+    preserveCompactionState?: boolean
+  }
+): StreamingBuffer {
+  return updateStreamingBuffer(
+    sessionId,
+    (current) => {
+      if (!_streamingBuffers.has(sessionId)) {
+        return current
+      }
+
+      return resetStreamingBufferOverlayState(current, {
+        preserveOptimisticMessages: options?.preserveOptimisticMessages,
+        preserveCompactionState: options?.preserveCompactionState
+      })
+    },
+    { notify: options?.notify ?? 'immediate' }
+  )
+}
+
 export function syncStreamingBufferGuardState(
   sessionId: string,
   state: SessionEventGuardState,
@@ -235,12 +296,14 @@ export function syncStreamingBufferGuardState(
     sessionId,
     (current) =>
       options?.resetOverlay
-        ? createStreamingBuffer({
+        ? {
+            ...resetStreamingBufferOverlayState(current, {
+              preserveOptimisticMessages: true,
+              preserveCompactionState: true
+            }),
             activeRunEpoch: state.activeRunEpoch,
-            lastAppliedSequence: state.lastAppliedSequence,
-            mirrorVersion: current.mirrorVersion,
-            optimisticMessages: current.optimisticMessages
-          })
+            lastAppliedSequence: state.lastAppliedSequence
+          }
         : {
             ...current,
             activeRunEpoch: state.activeRunEpoch,
@@ -440,10 +503,8 @@ export function writeEventToStreamingBuffer(
 
         if (statusType === 'idle') {
           if (sessionId !== activeSessionId) {
-            return createStreamingBuffer({
-              activeRunEpoch: current.activeRunEpoch,
-              lastAppliedSequence: current.lastAppliedSequence,
-              mirrorVersion: current.mirrorVersion
+            return resetStreamingBufferOverlayState(current, {
+              preserveCompactionState: true
             })
           }
 
@@ -866,6 +927,8 @@ export const useSessionRuntimeStore = create<SessionRuntimeStore>()((set, get) =
     })
     _sessionEventCallbacks.delete(sessionId)
     _streamingBuffers.delete(sessionId)
+    _emptyStreamingBufferSnapshots.delete(sessionId)
+    _pendingStreamingBufferFlushes.delete(sessionId)
     _sessionEventGuards.delete(sessionId)
   }
 }))

--- a/test/phase-23/agent-event-bridge-run-epoch.test.ts
+++ b/test/phase-23/agent-event-bridge-run-epoch.test.ts
@@ -170,6 +170,7 @@ import {
   clearStreamingBuffer,
   getSessionEventGuardState,
   getStreamingBuffer,
+  resetStreamingBuffersForTests,
   resetSessionEventGuardsForTests,
   setStreamingBuffer,
   useSessionRuntimeStore
@@ -249,6 +250,7 @@ describe('useAgentEventBridge runEpoch guard', () => {
     vi.clearAllMocks()
     activeSessionId = 'sess-1'
     streamCallback = null
+    resetStreamingBuffersForTests()
     resetSessionEventGuardsForTests()
 
     for (const sessionId of sessionIds) {

--- a/test/phase-23/agent-event-bridge-run-epoch.test.ts
+++ b/test/phase-23/agent-event-bridge-run-epoch.test.ts
@@ -272,6 +272,9 @@ describe('useAgentEventBridge runEpoch guard', () => {
     )
 
     setStreamingBuffer('sess-1', {
+      activeRunEpoch: 0,
+      lastAppliedSequence: -1,
+      mirrorVersion: 0,
       parts: [{ type: 'text', text: 'old overlay' }],
       childParts: new Map(),
       streamingContent: 'old overlay',
@@ -299,7 +302,12 @@ describe('useAgentEventBridge runEpoch guard', () => {
     expect(received.get('sess-4')).toEqual(['s4-r1-1'])
     expect(received.get('sess-5')).toEqual(['s5-r3-9'])
 
-    expect(getStreamingBuffer('sess-1')).toBeUndefined()
+    expect(getStreamingBuffer('sess-1')).toMatchObject({
+      activeRunEpoch: 2,
+      lastAppliedSequence: 3,
+      streamingContent: 's1-r2-3',
+      isStreaming: true
+    })
 
     for (const unsubscribe of unsubscribers) {
       unsubscribe()

--- a/test/phase-23/session-shell-thread-status-source.test.ts
+++ b/test/phase-23/session-shell-thread-status-source.test.ts
@@ -4,19 +4,27 @@ describe('SessionShell thread status flow (source verification)', () => {
   test('stores running and compaction state in the streaming buffer', async () => {
     const fs = await import('fs')
     const path = await import('path')
-    const source = fs.readFileSync(
+    const shellSource = fs.readFileSync(
       path.resolve(
         __dirname,
         '../../src/renderer/src/components/session-hq/SessionShell.tsx'
       ),
       'utf-8'
     )
+    const runtimeSource = fs.readFileSync(
+      path.resolve(
+        __dirname,
+        '../../src/renderer/src/stores/useSessionRuntimeStore.ts'
+      ),
+      'utf-8'
+    )
 
-    expect(source).toContain('runStartedAt')
-    expect(source).toContain('compactionState')
-    expect(source).toContain('setRunStartedAt((current) => current ?? Date.now())')
-    expect(source).toContain("phase: 'running'")
-    expect(source).toContain("phase: 'completed'")
+    expect(shellSource).toContain('runStartedAt')
+    expect(shellSource).toContain('compactionState')
+    expect(shellSource).toContain('const streamingMirror = useStreamingMirror(sessionId)')
+    expect(runtimeSource).toContain('updateStreamingBuffer(')
+    expect(runtimeSource).toContain("phase: 'running'")
+    expect(runtimeSource).toContain("phase: 'completed'")
   })
 
   test('passes ephemeral thread status rows into AgentTimeline', async () => {

--- a/test/phase-23/session-shell-thread-status-source.test.ts
+++ b/test/phase-23/session-shell-thread-status-source.test.ts
@@ -43,6 +43,23 @@ describe('SessionShell thread status flow (source verification)', () => {
     expect(source).toContain('hasDurableCompactionMessage')
   })
 
+  test('clears active overlays in finally while preserving compaction chips', async () => {
+    const fs = await import('fs')
+    const path = await import('path')
+    const source = fs.readFileSync(
+      path.resolve(
+        __dirname,
+        '../../src/renderer/src/components/session-hq/SessionShell.tsx'
+      ),
+      'utf-8'
+    )
+
+    expect(source).toContain('void refresh()')
+    expect(source).toContain('.finally(() => {')
+    expect(source).toContain('clearStreamingBufferOverlay(sessionId, {')
+    expect(source).toContain('preserveCompactionState: true')
+  })
+
   test('wires new UI user-message edit and fork flows into AgentTimeline', async () => {
     const fs = await import('fs')
     const path = await import('path')

--- a/test/phase-23/use-session-runtime-store.test.ts
+++ b/test/phase-23/use-session-runtime-store.test.ts
@@ -1,15 +1,21 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import {
+  clearStreamingBuffer,
+  clearStreamingBufferOverlay,
   getStreamingBufferSnapshot,
+  getStreamingBuffer,
+  resetStreamingBuffersForTests,
   subscribeToStreamingBuffer,
   syncStreamingBufferGuardState,
   updateStreamingBuffer,
+  writeEventToStreamingBuffer,
   useSessionRuntimeStore
 } from '../../src/renderer/src/stores/useSessionRuntimeStore'
 import type { CanonicalAgentEvent } from '../../src/shared/types/agent-protocol'
 
 // Reset store state between tests
 beforeEach(() => {
+  resetStreamingBuffersForTests()
   const state = useSessionRuntimeStore.getState()
   // Clear all sessions
   for (const sessionId of state.sessions.keys()) {
@@ -276,6 +282,61 @@ describe('useSessionRuntimeStore', () => {
   })
 
   describe('streaming mirror registry', () => {
+    it('returns a cached empty snapshot until the session mirror changes', () => {
+      const first = getStreamingBufferSnapshot('sess-empty')
+      const second = getStreamingBufferSnapshot('sess-empty')
+
+      expect(second).toBe(first)
+
+      updateStreamingBuffer(
+        'sess-empty',
+        (current) => ({
+          ...current,
+          streamingContent: 'hello',
+          parts: [{ type: 'text', text: 'hello' }],
+          isStreaming: true
+        }),
+        { notify: 'none' }
+      )
+
+      const afterWrite = getStreamingBufferSnapshot('sess-empty')
+      expect(afterWrite).not.toBe(first)
+      expect(getStreamingBufferSnapshot('sess-empty')).toBe(afterWrite)
+
+      clearStreamingBuffer('sess-empty')
+
+      const afterClear = getStreamingBufferSnapshot('sess-empty')
+      expect(afterClear).not.toBe(afterWrite)
+      expect(getStreamingBufferSnapshot('sess-empty')).toBe(afterClear)
+    })
+
+    it('stores updater results without deep-cloning the returned arrays and maps again', () => {
+      const parts = [{ type: 'text', text: 'hello' }] as const
+      const childParts = new Map<string, Array<{ type: 'text'; text: string }>>([
+        ['child-1', [{ type: 'text', text: 'child text' }]]
+      ])
+
+      updateStreamingBuffer(
+        'sess-refs',
+        (current) => ({
+          ...current,
+          parts: parts as unknown as typeof current.parts,
+          childParts: childParts as unknown as typeof current.childParts,
+          streamingContent: 'hello',
+          isStreaming: true
+        }),
+        { notify: 'none' }
+      )
+
+      const snapshot = getStreamingBufferSnapshot('sess-refs')
+      expect(snapshot.parts).toBe(parts)
+      expect(snapshot.childParts).toBe(childParts)
+
+      const detached = getStreamingBuffer('sess-refs')
+      expect(detached?.parts).not.toBe(parts)
+      expect(detached?.childParts).not.toBe(childParts)
+    })
+
     it('stores live overlay outside Zustand state and notifies immediate subscribers', () => {
       let callbackCount = 0
       const unsubscribe = subscribeToStreamingBuffer('sess-1', () => {
@@ -299,6 +360,22 @@ describe('useSessionRuntimeStore', () => {
       expect(snapshot.isStreaming).toBe(true)
       expect(snapshot.mirrorVersion).toBe(1)
       expect(callbackCount).toBe(1)
+
+      unsubscribe()
+    })
+
+    it('does not notify or bump mirrorVersion when an updater returns the current snapshot', () => {
+      let callbackCount = 0
+      const unsubscribe = subscribeToStreamingBuffer('sess-noop', () => {
+        callbackCount += 1
+      })
+
+      const before = getStreamingBufferSnapshot('sess-noop')
+      const after = updateStreamingBuffer('sess-noop', (current) => current, { notify: 'immediate' })
+
+      expect(after).toBe(before)
+      expect(getStreamingBufferSnapshot('sess-noop')).toBe(before)
+      expect(callbackCount).toBe(0)
 
       unsubscribe()
     })
@@ -352,6 +429,10 @@ describe('useSessionRuntimeStore', () => {
           streamingContent: 'old run text',
           parts: [{ type: 'text', text: 'old run text' }],
           isStreaming: true,
+          compactionState: {
+            phase: 'completed',
+            timestamp: 123
+          },
           optimisticMessages: [
             {
               id: 'optimistic-1',
@@ -376,6 +457,10 @@ describe('useSessionRuntimeStore', () => {
       expect(snapshot.streamingContent).toBe('')
       expect(snapshot.parts).toEqual([])
       expect(snapshot.isStreaming).toBe(false)
+      expect(snapshot.compactionState).toEqual({
+        phase: 'completed',
+        timestamp: 123
+      })
       expect(snapshot.optimisticMessages).toEqual([
         {
           id: 'optimistic-1',
@@ -384,6 +469,106 @@ describe('useSessionRuntimeStore', () => {
           timestamp: '2026-04-19T00:00:00.000Z'
         }
       ])
+    })
+
+    it('clears overlay on background idle while preserving compaction state', () => {
+      updateStreamingBuffer(
+        'sess-idle',
+        (current) => ({
+          ...current,
+          activeRunEpoch: 4,
+          lastAppliedSequence: 18,
+          streamingContent: 'background reply',
+          parts: [{ type: 'text', text: 'background reply' }],
+          isStreaming: true,
+          compactionState: {
+            phase: 'running',
+            timestamp: 456
+          },
+          optimisticMessages: [
+            {
+              id: 'optimistic-1',
+              role: 'user',
+              content: 'queued',
+              timestamp: '2026-04-19T00:00:00.000Z'
+            }
+          ]
+        }),
+        { notify: 'none' }
+      )
+
+      writeEventToStreamingBuffer(
+        'sess-idle',
+        {
+          type: 'session.status',
+          sessionId: 'sess-idle',
+          runEpoch: 4,
+          sessionSequence: 19,
+          eventId: 'idle-1',
+          sourceChannel: 'agent:stream',
+          data: {
+            status: {
+              type: 'idle'
+            }
+          }
+        } as CanonicalAgentEvent,
+        { activeSessionId: 'other-session' }
+      )
+
+      const snapshot = getStreamingBufferSnapshot('sess-idle')
+      expect(snapshot.activeRunEpoch).toBe(4)
+      expect(snapshot.lastAppliedSequence).toBe(18)
+      expect(snapshot.streamingContent).toBe('')
+      expect(snapshot.parts).toEqual([])
+      expect(snapshot.isStreaming).toBe(false)
+      expect(snapshot.optimisticMessages).toBeUndefined()
+      expect(snapshot.compactionState).toEqual({
+        phase: 'running',
+        timestamp: 456
+      })
+    })
+
+    it('clears active overlays without deleting guard state or compaction chips', () => {
+      updateStreamingBuffer(
+        'sess-active',
+        (current) => ({
+          ...current,
+          activeRunEpoch: 7,
+          lastAppliedSequence: 22,
+          streamingContent: 'done',
+          parts: [{ type: 'text', text: 'done' }],
+          isStreaming: true,
+          compactionState: {
+            phase: 'completed',
+            timestamp: 789
+          },
+          optimisticMessages: [
+            {
+              id: 'optimistic-1',
+              role: 'user',
+              content: 'hello',
+              timestamp: '2026-04-19T00:00:00.000Z'
+            }
+          ]
+        }),
+        { notify: 'none' }
+      )
+
+      clearStreamingBufferOverlay('sess-active', {
+        notify: 'immediate',
+        preserveCompactionState: true
+      })
+
+      const snapshot = getStreamingBufferSnapshot('sess-active')
+      expect(snapshot.activeRunEpoch).toBe(7)
+      expect(snapshot.lastAppliedSequence).toBe(22)
+      expect(snapshot.streamingContent).toBe('')
+      expect(snapshot.parts).toEqual([])
+      expect(snapshot.optimisticMessages).toBeUndefined()
+      expect(snapshot.compactionState).toEqual({
+        phase: 'completed',
+        timestamp: 789
+      })
     })
   })
 

--- a/test/phase-23/use-session-runtime-store.test.ts
+++ b/test/phase-23/use-session-runtime-store.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { useSessionRuntimeStore } from '../../src/renderer/src/stores/useSessionRuntimeStore'
+import {
+  getStreamingBufferSnapshot,
+  subscribeToStreamingBuffer,
+  syncStreamingBufferGuardState,
+  updateStreamingBuffer,
+  useSessionRuntimeStore
+} from '../../src/renderer/src/stores/useSessionRuntimeStore'
 import type { CanonicalAgentEvent } from '../../src/shared/types/agent-protocol'
 
 // Reset store state between tests
@@ -266,6 +272,118 @@ describe('useSessionRuntimeStore', () => {
       store.removeInterrupt('sess-1', 'q-1')
       // The internal map entry should be deleted when queue is empty
       expect(useSessionRuntimeStore.getState().interruptQueues.has('sess-1')).toBe(false)
+    })
+  })
+
+  describe('streaming mirror registry', () => {
+    it('stores live overlay outside Zustand state and notifies immediate subscribers', () => {
+      let callbackCount = 0
+      const unsubscribe = subscribeToStreamingBuffer('sess-1', () => {
+        callbackCount += 1
+      })
+
+      updateStreamingBuffer(
+        'sess-1',
+        (current) => ({
+          ...current,
+          streamingContent: 'hello',
+          parts: [{ type: 'text', text: 'hello' }],
+          isStreaming: true
+        }),
+        { notify: 'immediate' }
+      )
+
+      const snapshot = getStreamingBufferSnapshot('sess-1')
+      expect(snapshot.streamingContent).toBe('hello')
+      expect(snapshot.parts).toEqual([{ type: 'text', text: 'hello' }])
+      expect(snapshot.isStreaming).toBe(true)
+      expect(snapshot.mirrorVersion).toBe(1)
+      expect(callbackCount).toBe(1)
+
+      unsubscribe()
+    })
+
+    it('coalesces multiple frame writes into a single mirrorVersion tick', () => {
+      vi.useFakeTimers()
+      const originalRaf = globalThis.requestAnimationFrame
+      globalThis.requestAnimationFrame = ((cb: FrameRequestCallback) =>
+        setTimeout(() => cb(Date.now()), 0)) as typeof requestAnimationFrame
+
+      let callbackCount = 0
+      const unsubscribe = subscribeToStreamingBuffer('sess-2', () => {
+        callbackCount += 1
+      })
+
+      updateStreamingBuffer(
+        'sess-2',
+        (current) => ({
+          ...current,
+          streamingContent: 'a'
+        }),
+        { notify: 'frame' }
+      )
+      updateStreamingBuffer(
+        'sess-2',
+        (current) => ({
+          ...current,
+          streamingContent: `${current.streamingContent}b`
+        }),
+        { notify: 'frame' }
+      )
+
+      expect(callbackCount).toBe(0)
+      vi.runAllTimers()
+
+      const snapshot = getStreamingBufferSnapshot('sess-2')
+      expect(snapshot.streamingContent).toBe('ab')
+      expect(snapshot.mirrorVersion).toBe(1)
+      expect(callbackCount).toBe(1)
+
+      unsubscribe()
+      globalThis.requestAnimationFrame = originalRaf
+      vi.useRealTimers()
+    })
+
+    it('resets only the live overlay when a newer run is accepted', () => {
+      updateStreamingBuffer(
+        'sess-3',
+        (current) => ({
+          ...current,
+          streamingContent: 'old run text',
+          parts: [{ type: 'text', text: 'old run text' }],
+          isStreaming: true,
+          optimisticMessages: [
+            {
+              id: 'optimistic-1',
+              role: 'user',
+              content: 'please continue',
+              timestamp: '2026-04-19T00:00:00.000Z'
+            }
+          ]
+        }),
+        { notify: 'none' }
+      )
+
+      syncStreamingBufferGuardState(
+        'sess-3',
+        { activeRunEpoch: 2, lastAppliedSequence: 8 },
+        { resetOverlay: true, notify: 'immediate' }
+      )
+
+      const snapshot = getStreamingBufferSnapshot('sess-3')
+      expect(snapshot.activeRunEpoch).toBe(2)
+      expect(snapshot.lastAppliedSequence).toBe(8)
+      expect(snapshot.streamingContent).toBe('')
+      expect(snapshot.parts).toEqual([])
+      expect(snapshot.isStreaming).toBe(false)
+      expect(snapshot.optimisticMessages).toEqual([
+        {
+          id: 'optimistic-1',
+          role: 'user',
+          content: 'please continue',
+          timestamp: '2026-04-19T00:00:00.000Z'
+        }
+      ])
     })
   })
 


### PR DESCRIPTION
## Summary
- move Session HQ live overlay state out of `SessionShell` local state and into the runtime mirror registry
- have `useAgentEventBridge` write accepted stream events into the mirror so background sessions keep their live overlay while the view is unmounted
- keep `useSessionStore` and `useWorktreeStatusStore` structure unchanged
- document runtime vs durable vs view truth sources in `CLAUDE.md`

## Testing
- `pnpm vitest run test/phase-24/mock-agent-integration.test.ts test/phase-21/session-4/claude-prompt-streaming.test.ts test/phase-23/agent-event-normalization.test.ts test/phase-23/agent-event-bridge-run-epoch.test.ts test/phase-23/use-session-runtime-store.test.ts test/phase-23/session-shell-thread-status-source.test.ts test/phase-23/session-shell-plan-implement-source.test.ts`
- `pnpm exec eslint src/renderer/src/stores/useSessionRuntimeStore.ts src/renderer/src/hooks/useAgentEventBridge.ts src/renderer/src/components/session-hq/SessionShell.tsx test/phase-23/use-session-runtime-store.test.ts test/phase-23/agent-event-bridge-run-epoch.test.ts test/phase-23/session-shell-thread-status-source.test.ts`

## Notes
- This PR is intentionally based on #22 so the review only covers PR2's mirror-registry work.
