### PR TITLE
feat: restore HQ smart scroll across session switches

### DIFF
--- a/src/renderer/src/components/session-hq/AgentTimeline.tsx
+++ b/src/renderer/src/components/session-hq/AgentTimeline.tsx
@@ -10,7 +10,7 @@
  *   streamingContent (live)    → inline streaming text at bottom
  */
 
-import React, { useRef, useEffect, useMemo } from 'react'
+import React, { useMemo } from 'react'
 import { cn } from '@/lib/utils'
 import { formatMessageTime } from '@/lib/format-time'
 import type { TimelineMessage, StreamingPart, ToolUseInfo } from '@shared/lib/timeline-types'
@@ -579,6 +579,12 @@ export interface AgentTimelineProps {
   onSaveUserMessageEdit?: (messageId: string) => void | Promise<void>
   onCancelUserMessageEdit?: () => void
   forkingMessageId?: string | null
+  scrollContainerRef?: React.RefObject<HTMLDivElement | null>
+  onScroll?: () => void
+  onWheel?: () => void
+  onPointerDown?: () => void
+  onPointerUp?: () => void
+  onPointerCancel?: () => void
 }
 
 export function AgentTimeline({
@@ -602,30 +608,14 @@ export function AgentTimeline({
   onEditingContentChange,
   onSaveUserMessageEdit,
   onCancelUserMessageEdit,
-  forkingMessageId
+  forkingMessageId,
+  scrollContainerRef,
+  onScroll,
+  onWheel,
+  onPointerDown,
+  onPointerUp,
+  onPointerCancel
 }: AgentTimelineProps): React.JSX.Element {
-  const scrollRef = useRef<HTMLDivElement>(null)
-
-  // Auto-scroll to bottom when new content arrives
-  const prevMessageCountRef = useRef(0)
-  useEffect(() => {
-    const el = scrollRef.current
-    if (!el) return
-    const messageCount = timelineMessages.length
-    const hasNewMessages = messageCount > prevMessageCountRef.current
-    prevMessageCountRef.current = messageCount
-
-    if (hasNewMessages || isStreaming) {
-      // Only auto-scroll if user is near the bottom
-      const isNearBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 150
-      if (isNearBottom || hasNewMessages) {
-        requestAnimationFrame(() => {
-          el.scrollTop = el.scrollHeight
-        })
-      }
-    }
-  }, [timelineMessages.length, streamingContent, streamingParts, isStreaming])
-
   // Flatten messages into timeline nodes
   const nodes = useMemo(() => {
     return timelineMessages.flatMap((msg) => messageToNodes(msg))
@@ -758,8 +748,14 @@ export function AgentTimeline({
 
   return (
     <div
-      ref={scrollRef}
+      ref={scrollContainerRef}
       className="flex-1 overflow-y-auto"
+      onScroll={onScroll}
+      onWheel={onWheel}
+      onPointerDown={onPointerDown}
+      onPointerUp={onPointerUp}
+      onPointerCancel={onPointerCancel}
+      data-testid="hq-agent-timeline-scroll"
     >
       <div className="w-[85%] ml-[5%] py-6 pb-[14.5rem]">
         {/* Timeline nodes */}

--- a/src/renderer/src/components/session-hq/ComposerBar.tsx
+++ b/src/renderer/src/components/session-hq/ComposerBar.tsx
@@ -47,6 +47,7 @@ export interface ComposerBarProps {
   worktreePath?: string | null
   /** Bumped when session.commands_available fires — triggers re-fetch of SDK commands */
   commandsVersion?: number
+  containerRef?: React.RefObject<HTMLDivElement | null>
 }
 
 // ---------------------------------------------------------------------------
@@ -80,7 +81,8 @@ export function ComposerBar({
   onToggleMode,
   pendingPlan,
   worktreePath,
-  commandsVersion = 0
+  commandsVersion = 0,
+  containerRef
 }: ComposerBarProps): React.JSX.Element {
   const textareaRef = useRef<HTMLTextAreaElement>(null)
   const [content, setContent] = useState('')
@@ -250,6 +252,7 @@ export function ComposerBar({
 
   return (
     <div
+      ref={containerRef}
       className={cn(
         'absolute bottom-16 z-20',
         'w-[85%] ml-[5%]',

--- a/src/renderer/src/components/session-hq/SessionShell.tsx
+++ b/src/renderer/src/components/session-hq/SessionShell.tsx
@@ -32,6 +32,7 @@ import { InterruptDock } from './InterruptDock'
 import { ComposerBar } from './ComposerBar'
 import { ForkFromMessageConfirmDialog } from './ForkFromMessageConfirmDialog'
 import { PlanReadyImplementFab } from '../sessions/PlanReadyImplementFab'
+import { ScrollToBottomFab } from '../sessions/ScrollToBottomFab'
 import { useSessionRuntimeStore } from '@/stores/useSessionRuntimeStore'
 import { useSessionStore } from '@/stores/useSessionStore'
 import { useWorktreeStore } from '@/stores'
@@ -73,6 +74,7 @@ import {
   restoreMessageModePrefix
 } from '@/lib/message-actions'
 import { useI18n } from '@/i18n/useI18n'
+import { useSessionSmartScroll } from '@/hooks/useSessionSmartScroll'
 import { toast } from 'sonner'
 
 // ---------------------------------------------------------------------------
@@ -362,10 +364,13 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
   const runStartedAt = streamingMirror.runStartedAt ?? null
   const compactionState = streamingMirror.compactionState ?? null
   const streamingParts = streamingMirror.parts
+  const mirrorVersion = streamingMirror.mirrorVersion
   const childPartsMap = streamingMirror.childParts
   const [droidSessionId, setDroidSessionId] = useState<string | null>(
     sessionRecord?.opencode_session_id ?? null
   )
+  const timelineBottomAreaRef = useRef<HTMLDivElement>(null)
+  const composerBarRef = useRef<HTMLDivElement>(null)
 
   // Incremented when session.commands_available fires — triggers ComposerBar re-fetch
   const [commandsVersion, setCommandsVersion] = useState(0)
@@ -468,6 +473,21 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
 
     return rows
   }, [compactionState, hasDurableCompactionMessage, lifecycle, runStartedAt, sessionId])
+
+  const smartScroll = useSessionSmartScroll({
+    sessionId,
+    ready: !loading,
+    contentVersion: timelineMessages.length + ephemeralStatusRows.length,
+    mirrorVersion,
+    isStreaming,
+    bottomAreaRef: timelineBottomAreaRef,
+    composerRef: composerBarRef
+  })
+
+  const scrollFabBottomOffset = useMemo(
+    () => Math.max(smartScroll.scrollFabBottomOffset, pendingPlan ? 152 : 16),
+    [pendingPlan, smartScroll.scrollFabBottomOffset]
+  )
 
   useEffect(() => {
     if (hasDurableCompactionMessage && compactionState?.phase === 'completed') {
@@ -1229,13 +1249,28 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
           onForkUserMessage={handleForkUserMessage}
           onCopyUserMessage={() => {}}
           forkingMessageId={forkingMessageId}
+          scrollContainerRef={smartScroll.scrollContainerRef}
+          onScroll={smartScroll.handleScroll}
+          onWheel={smartScroll.handleScrollWheel}
+          onPointerDown={smartScroll.handleScrollPointerDown}
+          onPointerUp={smartScroll.handleScrollPointerUp}
+          onPointerCancel={smartScroll.handleScrollPointerCancel}
         />
 
-        <InterruptDock
-          sessionId={sessionId}
-          interrupt={currentInterrupt}
-          worktreePath={worktreePath}
+        <ScrollToBottomFab
+          onClick={smartScroll.handleScrollToBottomClick}
+          visible={smartScroll.showScrollFab}
+          count={smartScroll.scrollFabCount}
+          style={{ bottom: `${scrollFabBottomOffset}px` }}
         />
+
+        <div ref={timelineBottomAreaRef}>
+          <InterruptDock
+            sessionId={sessionId}
+            interrupt={currentInterrupt}
+            worktreePath={worktreePath}
+          />
+        </div>
 
         <PlanReadyImplementFab
           onImplement={handlePlanImplement}
@@ -1245,6 +1280,7 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
         />
 
         <ComposerBar
+          containerRef={composerBarRef}
           sessionId={sessionId}
           lifecycle={lifecycle}
           pendingCount={pendingCount}

--- a/src/renderer/src/components/sessions/ScrollToBottomFab.tsx
+++ b/src/renderer/src/components/sessions/ScrollToBottomFab.tsx
@@ -6,21 +6,28 @@ interface ScrollToBottomFabProps {
   onClick: () => void
   visible: boolean
   bottomClass?: string
+  count?: number
+  style?: React.CSSProperties
 }
 
 export function ScrollToBottomFab({
   onClick,
   visible,
-  bottomClass = 'bottom-4'
+  bottomClass = 'bottom-4',
+  count,
+  style
 }: ScrollToBottomFabProps): React.JSX.Element {
   const { t } = useI18n()
+  const showCount = typeof count === 'number' && count > 0
+
   return (
     <button
       onClick={onClick}
+      style={style}
       className={cn(
         'absolute right-4 z-10',
         bottomClass,
-        'h-8 w-8 rounded-full',
+        showCount ? 'h-8 min-w-[3.25rem] gap-1.5 rounded-full px-2.5' : 'h-8 w-8 rounded-full',
         'bg-muted/80 backdrop-blur-sm border border-border',
         'flex items-center justify-center',
         'shadow-md hover:bg-muted transition-all duration-200',
@@ -30,7 +37,12 @@ export function ScrollToBottomFab({
       aria-label={t('scrollToBottomFab.ariaLabel')}
       data-testid="scroll-to-bottom-fab"
     >
-      <ArrowDown className="h-4 w-4" />
+      <ArrowDown className="h-4 w-4 shrink-0" />
+      {showCount && (
+        <span className="text-[11px] font-medium leading-none" data-testid="scroll-to-bottom-fab-count">
+          {count}
+        </span>
+      )}
     </button>
   )
 }

--- a/src/renderer/src/hooks/useSessionSmartScroll.ts
+++ b/src/renderer/src/hooks/useSessionSmartScroll.ts
@@ -1,0 +1,406 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import {
+  getSessionViewState,
+  updateSessionViewState,
+  type SessionViewState
+} from '@/lib/session-view-registry'
+
+const NEAR_BOTTOM_THRESHOLD = 80
+const BOTTOM_AREA_COMPENSATE_THRESHOLD = 96
+const DEFAULT_SCROLL_FAB_OFFSET = 16
+
+interface UseSessionSmartScrollOptions {
+  sessionId: string
+  ready: boolean
+  contentVersion: number
+  mirrorVersion: number
+  isStreaming: boolean
+  bottomAreaRef?: React.RefObject<HTMLElement | null>
+  composerRef?: React.RefObject<HTMLElement | null>
+}
+
+interface UseSessionSmartScrollResult {
+  scrollContainerRef: React.RefObject<HTMLDivElement | null>
+  showScrollFab: boolean
+  scrollFabCount: number
+  scrollFabBottomOffset: number
+  handleScroll: () => void
+  handleScrollWheel: () => void
+  handleScrollPointerDown: () => void
+  handleScrollPointerUp: () => void
+  handleScrollPointerCancel: () => void
+  handleScrollToBottomClick: () => void
+}
+
+function getDistanceFromBottom(element: HTMLDivElement): number {
+  return element.scrollHeight - element.scrollTop - element.clientHeight
+}
+
+function scrollElementTo(element: HTMLDivElement, top: number, behavior: ScrollBehavior): void {
+  if (typeof element.scrollTo === 'function') {
+    try {
+      element.scrollTo({ top, behavior })
+      return
+    } catch {
+      // Fall back to direct assignment for test environments and older runtimes.
+    }
+  }
+
+  element.scrollTop = top
+}
+
+export function useSessionSmartScroll({
+  sessionId,
+  ready,
+  contentVersion,
+  mirrorVersion,
+  isStreaming,
+  bottomAreaRef,
+  composerRef
+}: UseSessionSmartScrollOptions): UseSessionSmartScrollResult {
+  const scrollContainerRef = useRef<HTMLDivElement>(null)
+  const programmaticScrollResetRef = useRef<number | null>(null)
+  const bottomAreaScrollRafRef = useRef<number | null>(null)
+  const isProgrammaticScrollRef = useRef(false)
+  const manualScrollIntentRef = useRef(false)
+  const pointerDownInScrollerRef = useRef(false)
+  const lastScrollTopRef = useRef(0)
+  const hasRestoredInitialAnchorRef = useRef(false)
+  const latestMirrorVersionRef = useRef(mirrorVersion)
+  const [dockHeight, setDockHeight] = useState(0)
+  const [composerHeight, setComposerHeight] = useState(0)
+  const [viewState, setViewState] = useState<SessionViewState>(() =>
+    getSessionViewState(sessionId, mirrorVersion)
+  )
+  const viewStateRef = useRef(viewState)
+
+  const writeViewState = useCallback(
+    (
+      updater: (current: SessionViewState) => Partial<SessionViewState>,
+      options?: { syncState?: boolean }
+    ): SessionViewState => {
+      const next = updateSessionViewState(sessionId, updater, mirrorVersion)
+      viewStateRef.current = next
+      if (options?.syncState ?? true) {
+        setViewState(next)
+      }
+      return next
+    },
+    [mirrorVersion, sessionId]
+  )
+
+  const persistCurrentAnchor = useCallback(
+    (options?: { syncState?: boolean; forceStickyBottom?: boolean; markSeen?: boolean }) => {
+      const element = scrollContainerRef.current
+      const current = viewStateRef.current
+
+      if (!element) {
+        if (options?.syncState) {
+          setViewState(current)
+        }
+        return current
+      }
+
+      const stickyBottom =
+        options?.forceStickyBottom ?? getDistanceFromBottom(element) < NEAR_BOTTOM_THRESHOLD
+      const shouldMarkSeen = options?.markSeen ?? stickyBottom
+
+      const next = writeViewState(
+        () => ({
+          scrollTop: element.scrollTop,
+          stickyBottom,
+          manualScrollLocked: stickyBottom ? false : true,
+          lastSeenVersion: shouldMarkSeen ? mirrorVersion : current.lastSeenVersion
+        }),
+        { syncState: options?.syncState ?? false }
+      )
+
+      lastScrollTopRef.current = element.scrollTop
+      return next
+    },
+    [mirrorVersion, writeViewState]
+  )
+
+  const markProgrammaticScroll = useCallback(() => {
+    isProgrammaticScrollRef.current = true
+    if (programmaticScrollResetRef.current !== null) {
+      cancelAnimationFrame(programmaticScrollResetRef.current)
+    }
+    programmaticScrollResetRef.current = requestAnimationFrame(() => {
+      programmaticScrollResetRef.current = requestAnimationFrame(() => {
+        isProgrammaticScrollRef.current = false
+        programmaticScrollResetRef.current = null
+      })
+    })
+  }, [])
+
+  const resetInteractionState = useCallback(() => {
+    if (programmaticScrollResetRef.current !== null) {
+      cancelAnimationFrame(programmaticScrollResetRef.current)
+      programmaticScrollResetRef.current = null
+    }
+    isProgrammaticScrollRef.current = false
+    manualScrollIntentRef.current = false
+    pointerDownInScrollerRef.current = false
+
+    const element = scrollContainerRef.current
+    if (element) {
+      lastScrollTopRef.current = element.scrollTop
+    }
+  }, [])
+
+  const scrollToBottom = useCallback(
+    (behavior: ScrollBehavior = isStreaming ? 'instant' : 'smooth') => {
+      const element = scrollContainerRef.current
+      if (!element) return
+
+      markProgrammaticScroll()
+      scrollElementTo(element, element.scrollHeight, behavior)
+
+      const current = viewStateRef.current
+      const shouldSyncState =
+        !current.stickyBottom ||
+        current.manualScrollLocked ||
+        current.lastSeenVersion !== mirrorVersion
+
+      persistCurrentAnchor({
+        syncState: shouldSyncState,
+        forceStickyBottom: true,
+        markSeen: true
+      })
+    },
+    [isStreaming, markProgrammaticScroll, mirrorVersion, persistCurrentAnchor]
+  )
+
+  const restoreScrollAnchor = useCallback(() => {
+    if (hasRestoredInitialAnchorRef.current || !ready) return
+
+    const element = scrollContainerRef.current
+    if (!element) return
+
+    const current = viewStateRef.current
+    hasRestoredInitialAnchorRef.current = true
+
+    requestAnimationFrame(() => {
+      if (current.stickyBottom) {
+        scrollToBottom('instant')
+        return
+      }
+
+      markProgrammaticScroll()
+      scrollElementTo(element, current.scrollTop, 'instant')
+      persistCurrentAnchor({
+        syncState: false,
+        forceStickyBottom: false,
+        markSeen: false
+      })
+    })
+  }, [markProgrammaticScroll, persistCurrentAnchor, ready, scrollToBottom])
+
+  const handleScroll = useCallback(() => {
+    const element = scrollContainerRef.current
+    if (!element) return
+
+    const currentScrollTop = element.scrollTop
+    lastScrollTopRef.current = currentScrollTop
+
+    const current = {
+      ...viewStateRef.current,
+      scrollTop: currentScrollTop
+    }
+    viewStateRef.current = current
+
+    const distanceFromBottom = getDistanceFromBottom(element)
+    const isNearBottom = distanceFromBottom < NEAR_BOTTOM_THRESHOLD
+    const hasManualIntent = manualScrollIntentRef.current || pointerDownInScrollerRef.current
+
+    if (isProgrammaticScrollRef.current) {
+      manualScrollIntentRef.current = false
+      return
+    }
+
+    if (isNearBottom && hasManualIntent) {
+      writeViewState(() => ({
+        scrollTop: currentScrollTop,
+        stickyBottom: true,
+        manualScrollLocked: false,
+        lastSeenVersion: mirrorVersion
+      }))
+      manualScrollIntentRef.current = false
+      return
+    }
+
+    if (!hasManualIntent) {
+      return
+    }
+
+    writeViewState(
+      () => ({
+        scrollTop: currentScrollTop,
+        stickyBottom: false,
+        manualScrollLocked: true,
+        lastSeenVersion: current.lastSeenVersion
+      }),
+      { syncState: current.stickyBottom || !current.manualScrollLocked }
+    )
+    manualScrollIntentRef.current = false
+  }, [mirrorVersion, writeViewState])
+
+  const handleScrollToBottomClick = useCallback(() => {
+    resetInteractionState()
+    scrollToBottom('smooth')
+  }, [resetInteractionState, scrollToBottom])
+
+  const handleScrollWheel = useCallback(() => {
+    manualScrollIntentRef.current = true
+  }, [])
+
+  const handleScrollPointerDown = useCallback(() => {
+    pointerDownInScrollerRef.current = true
+  }, [])
+
+  const handleScrollPointerUp = useCallback(() => {
+    pointerDownInScrollerRef.current = false
+    manualScrollIntentRef.current = false
+  }, [])
+
+  const handleScrollPointerCancel = useCallback(() => {
+    pointerDownInScrollerRef.current = false
+    manualScrollIntentRef.current = false
+  }, [])
+
+  useEffect(() => {
+    latestMirrorVersionRef.current = mirrorVersion
+  }, [mirrorVersion])
+
+  useEffect(() => {
+    const next = getSessionViewState(sessionId, latestMirrorVersionRef.current)
+    viewStateRef.current = next
+    setViewState(next)
+    hasRestoredInitialAnchorRef.current = false
+    resetInteractionState()
+  }, [resetInteractionState, sessionId])
+
+  useEffect(() => {
+    const current = viewStateRef.current
+
+    if (mirrorVersion < current.lastSeenVersion) {
+      writeViewState(() => ({
+        ...current,
+        lastSeenVersion: mirrorVersion
+      }))
+      return
+    }
+
+    if (current.stickyBottom && mirrorVersion > current.lastSeenVersion) {
+      writeViewState(() => ({
+        ...current,
+        lastSeenVersion: mirrorVersion
+      }))
+    }
+  }, [mirrorVersion, writeViewState])
+
+  useEffect(() => {
+    restoreScrollAnchor()
+  }, [contentVersion, ready, restoreScrollAnchor])
+
+  useEffect(() => {
+    if (!ready || !hasRestoredInitialAnchorRef.current || !viewStateRef.current.stickyBottom) {
+      return
+    }
+    scrollToBottom()
+  }, [contentVersion, mirrorVersion, ready, scrollToBottom])
+
+  useEffect(() => {
+    const dockElement = bottomAreaRef?.current
+    const composerElement = composerRef?.current
+    setDockHeight(dockElement?.getBoundingClientRect().height ?? 0)
+    setComposerHeight(composerElement?.getBoundingClientRect().height ?? 0)
+
+    if (typeof ResizeObserver === 'undefined') return
+
+    const observers: ResizeObserver[] = []
+    const handleResize = () => {
+      const scrollElement = scrollContainerRef.current
+      if (!scrollElement) return
+
+      const distanceFromBottom = getDistanceFromBottom(scrollElement)
+      const shouldCompensate =
+        viewStateRef.current.stickyBottom || distanceFromBottom < BOTTOM_AREA_COMPENSATE_THRESHOLD
+
+      if (!shouldCompensate) return
+
+      if (bottomAreaScrollRafRef.current !== null) {
+        cancelAnimationFrame(bottomAreaScrollRafRef.current)
+      }
+
+      bottomAreaScrollRafRef.current = requestAnimationFrame(() => {
+        bottomAreaScrollRafRef.current = null
+        resetInteractionState()
+        scrollToBottom('instant')
+      })
+    }
+
+    const observedTargets: Array<readonly [HTMLElement | null | undefined, (height: number) => void]> = [
+      [dockElement, setDockHeight],
+      [composerElement, setComposerHeight]
+    ]
+
+    for (const [target, updateHeight] of observedTargets) {
+      if (!target) continue
+      const observer = new ResizeObserver((entries) => {
+        const nextHeight =
+          entries[0]?.contentRect.height ?? target.getBoundingClientRect().height ?? 0
+        updateHeight(nextHeight)
+        handleResize()
+      })
+      observer.observe(target)
+      observers.push(observer)
+    }
+
+    return () => {
+      for (const observer of observers) {
+        observer.disconnect()
+      }
+      if (bottomAreaScrollRafRef.current !== null) {
+        cancelAnimationFrame(bottomAreaScrollRafRef.current)
+        bottomAreaScrollRafRef.current = null
+      }
+    }
+  }, [bottomAreaRef, composerRef, resetInteractionState, scrollToBottom, sessionId])
+
+  useEffect(() => {
+    return () => {
+      persistCurrentAnchor({
+        syncState: false
+      })
+      resetInteractionState()
+      if (bottomAreaScrollRafRef.current !== null) {
+        cancelAnimationFrame(bottomAreaScrollRafRef.current)
+        bottomAreaScrollRafRef.current = null
+      }
+    }
+  }, [persistCurrentAnchor, resetInteractionState])
+
+  const scrollFabCount = Math.max(0, mirrorVersion - viewState.lastSeenVersion)
+  const showScrollFab = !viewState.stickyBottom && scrollFabCount > 0
+
+  const scrollFabBottomOffset = useMemo(() => {
+    const dockOffset = dockHeight > 0 ? dockHeight + 16 : DEFAULT_SCROLL_FAB_OFFSET
+    const composerOffset = composerHeight > 0 ? composerHeight + 32 : DEFAULT_SCROLL_FAB_OFFSET
+    return Math.max(DEFAULT_SCROLL_FAB_OFFSET, dockOffset, composerOffset)
+  }, [composerHeight, dockHeight])
+
+  return {
+    scrollContainerRef,
+    showScrollFab,
+    scrollFabCount,
+    scrollFabBottomOffset,
+    handleScroll,
+    handleScrollWheel,
+    handleScrollPointerDown,
+    handleScrollPointerUp,
+    handleScrollPointerCancel,
+    handleScrollToBottomClick
+  }
+}

--- a/src/renderer/src/lib/session-view-registry.ts
+++ b/src/renderer/src/lib/session-view-registry.ts
@@ -6,6 +6,7 @@ export interface SessionViewState {
 }
 
 const STORAGE_KEY = 'xuanpu:session-view-registry'
+const PERSIST_DEBOUNCE_MS = 250
 
 const DEFAULT_SESSION_VIEW_STATE: SessionViewState = {
   scrollTop: 0,
@@ -16,6 +17,8 @@ const DEFAULT_SESSION_VIEW_STATE: SessionViewState = {
 
 const _sessionViewRegistry = new Map<string, SessionViewState>()
 let _didLoadFromStorage = false
+let _persistTimeoutHandle: ReturnType<typeof setTimeout> | null = null
+let _persistIdleHandle: number | null = null
 
 function normalizeSessionViewState(
   state?: Partial<SessionViewState>,
@@ -57,17 +60,66 @@ function normalizeSessionViewState(
   }
 }
 
-function persistRegistry(): void {
-  if (typeof window === 'undefined' || typeof window.sessionStorage?.setItem !== 'function') {
+function cancelScheduledPersist(): void {
+  if (_persistTimeoutHandle !== null) {
+    clearTimeout(_persistTimeoutHandle)
+    _persistTimeoutHandle = null
+  }
+
+  if (
+    _persistIdleHandle !== null &&
+    typeof globalThis.cancelIdleCallback === 'function'
+  ) {
+    globalThis.cancelIdleCallback(_persistIdleHandle)
+    _persistIdleHandle = null
+  }
+}
+
+function flushPersistRegistry(): void {
+  _persistTimeoutHandle = null
+  _persistIdleHandle = null
+
+  if (typeof window === 'undefined') {
+    return
+  }
+
+  const sessionStorage = window.sessionStorage
+  if (
+    typeof sessionStorage?.setItem !== 'function' ||
+    typeof sessionStorage?.removeItem !== 'function'
+  ) {
     return
   }
 
   try {
+    if (_sessionViewRegistry.size === 0) {
+      sessionStorage.removeItem(STORAGE_KEY)
+      return
+    }
+
     const payload = Object.fromEntries(_sessionViewRegistry)
-    window.sessionStorage.setItem(STORAGE_KEY, JSON.stringify(payload))
+    sessionStorage.setItem(STORAGE_KEY, JSON.stringify(payload))
   } catch {
     // Non-fatal: the in-memory registry still preserves session anchors.
   }
+}
+
+function persistRegistry(): void {
+  cancelScheduledPersist()
+
+  if (typeof globalThis.requestIdleCallback === 'function') {
+    _persistIdleHandle = globalThis.requestIdleCallback(
+      () => {
+        flushPersistRegistry()
+      },
+      { timeout: PERSIST_DEBOUNCE_MS }
+    )
+    return
+  }
+
+  _persistTimeoutHandle = setTimeout(() => {
+    flushPersistRegistry()
+  }, PERSIST_DEBOUNCE_MS)
 }
 
 function ensureRegistryLoaded(): void {
@@ -133,7 +185,17 @@ export function updateSessionViewState(
   return setSessionViewState(sessionId, updater(current), maxSeenVersion)
 }
 
+export function removeSessionViewState(sessionId: string): void {
+  ensureRegistryLoaded()
+
+  if (!_sessionViewRegistry.has(sessionId)) return
+
+  _sessionViewRegistry.delete(sessionId)
+  persistRegistry()
+}
+
 export function resetSessionViewRegistryForTests(): void {
+  cancelScheduledPersist()
   _sessionViewRegistry.clear()
   _didLoadFromStorage = false
 

--- a/src/renderer/src/lib/session-view-registry.ts
+++ b/src/renderer/src/lib/session-view-registry.ts
@@ -1,0 +1,143 @@
+export interface SessionViewState {
+  scrollTop: number
+  stickyBottom: boolean
+  manualScrollLocked: boolean
+  lastSeenVersion: number
+}
+
+const STORAGE_KEY = 'xuanpu:session-view-registry'
+
+const DEFAULT_SESSION_VIEW_STATE: SessionViewState = {
+  scrollTop: 0,
+  stickyBottom: true,
+  manualScrollLocked: false,
+  lastSeenVersion: 0
+}
+
+const _sessionViewRegistry = new Map<string, SessionViewState>()
+let _didLoadFromStorage = false
+
+function normalizeSessionViewState(
+  state?: Partial<SessionViewState>,
+  maxSeenVersion = Number.POSITIVE_INFINITY
+): SessionViewState {
+  const scrollTop =
+    typeof state?.scrollTop === 'number' && Number.isFinite(state.scrollTop)
+      ? Math.max(0, state.scrollTop)
+      : DEFAULT_SESSION_VIEW_STATE.scrollTop
+
+  const stickyBottom =
+    typeof state?.stickyBottom === 'boolean'
+      ? state.stickyBottom
+      : DEFAULT_SESSION_VIEW_STATE.stickyBottom
+
+  const boundedMaxSeenVersion = Number.isFinite(maxSeenVersion)
+    ? Math.max(0, maxSeenVersion)
+    : Number.POSITIVE_INFINITY
+
+  const rawLastSeenVersion =
+    typeof state?.lastSeenVersion === 'number' && Number.isFinite(state.lastSeenVersion)
+      ? Math.max(0, state.lastSeenVersion)
+      : DEFAULT_SESSION_VIEW_STATE.lastSeenVersion
+
+  const lastSeenVersion = Math.min(rawLastSeenVersion, boundedMaxSeenVersion)
+
+  const manualScrollLocked =
+    stickyBottom
+      ? false
+      : typeof state?.manualScrollLocked === 'boolean'
+        ? state.manualScrollLocked
+        : DEFAULT_SESSION_VIEW_STATE.manualScrollLocked
+
+  return {
+    scrollTop,
+    stickyBottom,
+    manualScrollLocked,
+    lastSeenVersion
+  }
+}
+
+function persistRegistry(): void {
+  if (typeof window === 'undefined' || typeof window.sessionStorage?.setItem !== 'function') {
+    return
+  }
+
+  try {
+    const payload = Object.fromEntries(_sessionViewRegistry)
+    window.sessionStorage.setItem(STORAGE_KEY, JSON.stringify(payload))
+  } catch {
+    // Non-fatal: the in-memory registry still preserves session anchors.
+  }
+}
+
+function ensureRegistryLoaded(): void {
+  if (_didLoadFromStorage) return
+  _didLoadFromStorage = true
+
+  if (typeof window === 'undefined' || typeof window.sessionStorage?.getItem !== 'function') {
+    return
+  }
+
+  try {
+    const raw = window.sessionStorage.getItem(STORAGE_KEY)
+    if (!raw) return
+
+    const parsed = JSON.parse(raw) as Record<string, Partial<SessionViewState>>
+    for (const [sessionId, state] of Object.entries(parsed)) {
+      _sessionViewRegistry.set(sessionId, normalizeSessionViewState(state))
+    }
+  } catch {
+    _sessionViewRegistry.clear()
+  }
+}
+
+export function getSessionViewState(
+  sessionId: string,
+  maxSeenVersion = Number.POSITIVE_INFINITY
+): SessionViewState {
+  ensureRegistryLoaded()
+
+  const current = normalizeSessionViewState(_sessionViewRegistry.get(sessionId), maxSeenVersion)
+  _sessionViewRegistry.set(sessionId, current)
+  return { ...current }
+}
+
+export function setSessionViewState(
+  sessionId: string,
+  nextState: Partial<SessionViewState>,
+  maxSeenVersion = Number.POSITIVE_INFINITY
+): SessionViewState {
+  ensureRegistryLoaded()
+
+  const current = getSessionViewState(sessionId, maxSeenVersion)
+  const next = normalizeSessionViewState(
+    {
+      ...current,
+      ...nextState
+    },
+    maxSeenVersion
+  )
+  _sessionViewRegistry.set(sessionId, next)
+  persistRegistry()
+  return { ...next }
+}
+
+export function updateSessionViewState(
+  sessionId: string,
+  updater: (current: SessionViewState) => Partial<SessionViewState>,
+  maxSeenVersion = Number.POSITIVE_INFINITY
+): SessionViewState {
+  ensureRegistryLoaded()
+
+  const current = getSessionViewState(sessionId, maxSeenVersion)
+  return setSessionViewState(sessionId, updater(current), maxSeenVersion)
+}
+
+export function resetSessionViewRegistryForTests(): void {
+  _sessionViewRegistry.clear()
+  _didLoadFromStorage = false
+
+  if (typeof window !== 'undefined' && typeof window.sessionStorage?.removeItem === 'function') {
+    window.sessionStorage.removeItem(STORAGE_KEY)
+  }
+}

--- a/src/renderer/src/stores/useSessionStore.ts
+++ b/src/renderer/src/stores/useSessionStore.ts
@@ -4,6 +4,7 @@ import type { SelectedModel } from './useSettingsStore'
 import { useSettingsStore } from './useSettingsStore'
 import { useGitStore } from './useGitStore'
 import { useWorktreeStore } from './useWorktreeStore'
+import { removeSessionViewState } from '@/lib/session-view-registry'
 import { translate } from '@/i18n/useI18n'
 import { DEFAULT_LOCALE } from '@/i18n/messages'
 
@@ -544,6 +545,8 @@ export const useSessionStore = create<SessionState>()(
               break
             }
           }
+
+          removeSessionViewState(sessionId)
 
           return { success: true }
         } catch (error) {
@@ -1126,7 +1129,10 @@ export const useSessionStore = create<SessionState>()(
         if (index === -1) return
         const toClose = tabOrder.slice(index + 1)
         for (const sessionId of toClose) {
-          await get().closeSession(sessionId)
+          const result = await get().closeSession(sessionId)
+          if (result.success) {
+            removeSessionViewState(sessionId)
+          }
         }
       },
 

--- a/test/phase-19/session-7/tab-context-store.test.ts
+++ b/test/phase-19/session-7/tab-context-store.test.ts
@@ -1,6 +1,10 @@
 import { describe, test, expect, beforeEach, vi } from 'vitest'
 import { useFileViewerStore } from '../../../src/renderer/src/stores/useFileViewerStore'
 import { useSessionStore } from '../../../src/renderer/src/stores/useSessionStore'
+import {
+  resetSessionViewRegistryForTests,
+  setSessionViewState
+} from '../../../src/renderer/src/lib/session-view-registry'
 
 /**
  * Session 7: Tab Context Menus — Store Actions
@@ -31,6 +35,9 @@ describe('Session 7: Tab Context Store Actions', () => {
     const worktreeId = 'wt-1'
 
     beforeEach(() => {
+      vi.useRealTimers()
+      resetSessionViewRegistryForTests()
+      window.sessionStorage.clear()
       // Reset store with 3 sessions in tab order
       useSessionStore.setState({
         sessionsByWorktree: new Map([
@@ -172,6 +179,42 @@ describe('Session 7: Tab Context Store Actions', () => {
       // Only s3 should be closed, s1 and s2 remain
       expect(tabOrder).toEqual(['s1', 's2'])
       expect(sessions.map((s) => s.id)).toEqual(['s1', 's2'])
+    })
+
+    test('closeSessionsToRight clears removed sessions from the persisted view registry', async () => {
+      vi.useFakeTimers()
+
+      setSessionViewState('s1', {
+        scrollTop: 10,
+        stickyBottom: true,
+        manualScrollLocked: false,
+        lastSeenVersion: 1
+      })
+      setSessionViewState('s2', {
+        scrollTop: 20,
+        stickyBottom: false,
+        manualScrollLocked: true,
+        lastSeenVersion: 2
+      })
+      setSessionViewState('s3', {
+        scrollTop: 30,
+        stickyBottom: false,
+        manualScrollLocked: true,
+        lastSeenVersion: 3
+      })
+      vi.runAllTimers()
+
+      await useSessionStore.getState().closeSessionsToRight(worktreeId, 's1')
+      vi.runAllTimers()
+
+      expect(JSON.parse(window.sessionStorage.getItem('xuanpu:session-view-registry') ?? '{}')).toEqual({
+        s1: {
+          scrollTop: 10,
+          stickyBottom: true,
+          manualScrollLocked: false,
+          lastSeenVersion: 1
+        }
+      })
     })
 
     test('closeSessionsToRight with last tab is a no-op', async () => {

--- a/test/phase-23/session-shell-thread-status-source.test.ts
+++ b/test/phase-23/session-shell-thread-status-source.test.ts
@@ -82,4 +82,23 @@ describe('SessionShell thread status flow (source verification)', () => {
     expect(source).toContain('onForkUserMessage={handleForkUserMessage}')
     expect(source).toContain('forkingMessageId={forkingMessageId}')
   })
+
+  test('routes HQ smart scroll through the shared session view registry hook', async () => {
+    const fs = await import('fs')
+    const path = await import('path')
+    const source = fs.readFileSync(
+      path.resolve(
+        __dirname,
+        '../../src/renderer/src/components/session-hq/SessionShell.tsx'
+      ),
+      'utf-8'
+    )
+
+    expect(source).toContain("import { ScrollToBottomFab } from '../sessions/ScrollToBottomFab'")
+    expect(source).toContain("import { useSessionSmartScroll } from '@/hooks/useSessionSmartScroll'")
+    expect(source).toContain('const smartScroll = useSessionSmartScroll({')
+    expect(source).toContain('count={smartScroll.scrollFabCount}')
+    expect(source).toContain('scrollContainerRef={smartScroll.scrollContainerRef}')
+    expect(source).toContain('containerRef={composerBarRef}')
+  })
 })

--- a/test/phase-23/session-view-registry.test.ts
+++ b/test/phase-23/session-view-registry.test.ts
@@ -1,6 +1,7 @@
-import { beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   getSessionViewState,
+  removeSessionViewState,
   setSessionViewState,
   updateSessionViewState,
   resetSessionViewRegistryForTests
@@ -8,8 +9,13 @@ import {
 
 describe('session-view-registry', () => {
   beforeEach(() => {
+    vi.useFakeTimers()
     resetSessionViewRegistryForTests()
     window.sessionStorage.clear()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
   })
 
   it('returns the default anchor state for unseen sessions', () => {
@@ -34,6 +40,8 @@ describe('session-view-registry', () => {
       scrollTop: 256
     }))
 
+    vi.runAllTimers()
+
     expect(getSessionViewState('session-a')).toEqual({
       scrollTop: 256,
       stickyBottom: false,
@@ -53,12 +61,78 @@ describe('session-view-registry', () => {
     })
   })
 
+  it('removes deleted sessions from the registry and persisted storage', () => {
+    setSessionViewState('session-a', {
+      scrollTop: 128,
+      stickyBottom: false,
+      manualScrollLocked: true,
+      lastSeenVersion: 5
+    })
+    setSessionViewState('session-b', {
+      scrollTop: 64,
+      stickyBottom: true,
+      manualScrollLocked: false,
+      lastSeenVersion: 2
+    })
+    vi.runAllTimers()
+
+    removeSessionViewState('session-a')
+    vi.runAllTimers()
+
+    expect(JSON.parse(window.sessionStorage.getItem('xuanpu:session-view-registry') ?? '{}')).toEqual({
+      'session-b': {
+        scrollTop: 64,
+        stickyBottom: true,
+        manualScrollLocked: false,
+        lastSeenVersion: 2
+      }
+    })
+  })
+
+  it('debounces storage persistence across rapid updates', () => {
+    const setItemSpy = vi.spyOn(Storage.prototype, 'setItem')
+
+    setSessionViewState('session-a', {
+      scrollTop: 10,
+      stickyBottom: false,
+      manualScrollLocked: true,
+      lastSeenVersion: 1
+    })
+    updateSessionViewState('session-a', (current) => ({
+      ...current,
+      scrollTop: 20
+    }))
+    updateSessionViewState('session-a', (current) => ({
+      ...current,
+      scrollTop: 30
+    }))
+
+    expect(setItemSpy).not.toHaveBeenCalled()
+
+    vi.advanceTimersByTime(249)
+    expect(setItemSpy).not.toHaveBeenCalled()
+
+    vi.advanceTimersByTime(1)
+    expect(setItemSpy).toHaveBeenCalledTimes(1)
+    expect(JSON.parse(window.sessionStorage.getItem('xuanpu:session-view-registry') ?? '{}')).toMatchObject({
+      'session-a': {
+        scrollTop: 30,
+        stickyBottom: false,
+        manualScrollLocked: true,
+        lastSeenVersion: 1
+      }
+    })
+
+    setItemSpy.mockRestore()
+  })
+
   it('clamps lastSeenVersion when the mirror version rewinds', () => {
     setSessionViewState('session-a', {
       stickyBottom: false,
       manualScrollLocked: true,
       lastSeenVersion: 9
     })
+    vi.runAllTimers()
 
     expect(getSessionViewState('session-a', 3)).toEqual({
       scrollTop: 0,

--- a/test/phase-23/session-view-registry.test.ts
+++ b/test/phase-23/session-view-registry.test.ts
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import {
+  getSessionViewState,
+  setSessionViewState,
+  updateSessionViewState,
+  resetSessionViewRegistryForTests
+} from '../../src/renderer/src/lib/session-view-registry'
+
+describe('session-view-registry', () => {
+  beforeEach(() => {
+    resetSessionViewRegistryForTests()
+    window.sessionStorage.clear()
+  })
+
+  it('returns the default anchor state for unseen sessions', () => {
+    expect(getSessionViewState('session-a')).toEqual({
+      scrollTop: 0,
+      stickyBottom: true,
+      manualScrollLocked: false,
+      lastSeenVersion: 0
+    })
+  })
+
+  it('merges partial updates and persists them to sessionStorage', () => {
+    setSessionViewState('session-a', {
+      scrollTop: 128,
+      stickyBottom: false,
+      manualScrollLocked: true,
+      lastSeenVersion: 5
+    })
+
+    updateSessionViewState('session-a', (current) => ({
+      ...current,
+      scrollTop: 256
+    }))
+
+    expect(getSessionViewState('session-a')).toEqual({
+      scrollTop: 256,
+      stickyBottom: false,
+      manualScrollLocked: true,
+      lastSeenVersion: 5
+    })
+
+    const persisted = window.sessionStorage.getItem('xuanpu:session-view-registry')
+    expect(persisted).not.toBeNull()
+    expect(JSON.parse(persisted ?? '{}')).toMatchObject({
+      'session-a': {
+        scrollTop: 256,
+        stickyBottom: false,
+        manualScrollLocked: true,
+        lastSeenVersion: 5
+      }
+    })
+  })
+
+  it('clamps lastSeenVersion when the mirror version rewinds', () => {
+    setSessionViewState('session-a', {
+      stickyBottom: false,
+      manualScrollLocked: true,
+      lastSeenVersion: 9
+    })
+
+    expect(getSessionViewState('session-a', 3)).toEqual({
+      scrollTop: 0,
+      stickyBottom: false,
+      manualScrollLocked: true,
+      lastSeenVersion: 3
+    })
+  })
+})

--- a/test/phase-23/use-session-smart-scroll.test.tsx
+++ b/test/phase-23/use-session-smart-scroll.test.tsx
@@ -1,0 +1,362 @@
+import React, { useRef } from 'react'
+import { act, fireEvent, render, screen } from '@testing-library/react'
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest'
+import { useSessionSmartScroll } from '../../src/renderer/src/hooks/useSessionSmartScroll'
+import {
+  getSessionViewState,
+  setSessionViewState,
+  resetSessionViewRegistryForTests
+} from '../../src/renderer/src/lib/session-view-registry'
+
+class MockResizeObserver {
+  callback: ResizeObserverCallback
+  target: Element | null = null
+
+  constructor(callback: ResizeObserverCallback) {
+    this.callback = callback
+    resizeObservers.push(this)
+  }
+
+  observe = vi.fn((target: Element) => {
+    this.target = target
+  })
+
+  unobserve = vi.fn()
+  disconnect = vi.fn()
+
+  trigger(height: number) {
+    if (!this.target) return
+
+    this.callback(
+      [
+        {
+          target: this.target,
+          contentRect: {
+            height,
+            width: 0,
+            x: 0,
+            y: 0,
+            top: 0,
+            left: 0,
+            right: 0,
+            bottom: height,
+            toJSON: () => ({})
+          }
+        }
+      ] as unknown as ResizeObserverEntry[],
+      this as unknown as ResizeObserver
+    )
+  }
+}
+
+const resizeObservers: MockResizeObserver[] = []
+const originalResizeObserver = globalThis.ResizeObserver
+
+interface HarnessProps {
+  sessionId: string
+  mirrorVersion: number
+  contentVersion: number
+  ready: boolean
+  isStreaming?: boolean
+}
+
+function SmartScrollHarness({
+  sessionId,
+  mirrorVersion,
+  contentVersion,
+  ready,
+  isStreaming = true
+}: HarnessProps): React.JSX.Element {
+  const bottomAreaRef = useRef<HTMLDivElement>(null)
+  const composerRef = useRef<HTMLDivElement>(null)
+  const smartScroll = useSessionSmartScroll({
+    sessionId,
+    ready,
+    contentVersion,
+    mirrorVersion,
+    isStreaming,
+    bottomAreaRef,
+    composerRef
+  })
+
+  return (
+    <div>
+      <div
+        ref={smartScroll.scrollContainerRef}
+        onScroll={smartScroll.handleScroll}
+        onWheel={smartScroll.handleScrollWheel}
+        onPointerDown={smartScroll.handleScrollPointerDown}
+        onPointerUp={smartScroll.handleScrollPointerUp}
+        onPointerCancel={smartScroll.handleScrollPointerCancel}
+        data-testid="smart-scroll-scroller"
+      >
+        <div style={{ height: 1600 }} />
+      </div>
+      <div ref={bottomAreaRef} data-testid="smart-scroll-bottom-area" />
+      <div ref={composerRef} data-testid="smart-scroll-composer" />
+      <button onClick={smartScroll.handleScrollToBottomClick} data-testid="smart-scroll-fab-button">
+        Jump
+      </button>
+      <div data-testid="smart-scroll-fab-visible">
+        {smartScroll.showScrollFab ? 'yes' : 'no'}
+      </div>
+      <div data-testid="smart-scroll-fab-count">{smartScroll.scrollFabCount}</div>
+      <div data-testid="smart-scroll-fab-offset">{smartScroll.scrollFabBottomOffset}</div>
+    </div>
+  )
+}
+
+function attachScrollMetrics(element: HTMLElement, values: {
+  scrollTop: { current: number }
+  scrollHeight: { current: number }
+  clientHeight: number
+}) {
+  Object.defineProperty(element, 'scrollTop', {
+    configurable: true,
+    get: () => values.scrollTop.current,
+    set: (value: number) => {
+      values.scrollTop.current = value
+    }
+  })
+  Object.defineProperty(element, 'scrollHeight', {
+    configurable: true,
+    get: () => values.scrollHeight.current
+  })
+  Object.defineProperty(element, 'clientHeight', {
+    configurable: true,
+    get: () => values.clientHeight
+  })
+}
+
+function attachHeight(element: HTMLElement, height: number) {
+  Object.defineProperty(element, 'getBoundingClientRect', {
+    configurable: true,
+    value: () => ({
+      width: 0,
+      height,
+      top: 0,
+      left: 0,
+      right: 0,
+      bottom: height,
+      x: 0,
+      y: 0,
+      toJSON: () => ({})
+    })
+  })
+}
+
+function getObserverFor(target: Element): MockResizeObserver {
+  const observer = resizeObservers.find((item) => item.target === target)
+  if (!observer) {
+    throw new Error('ResizeObserver target not found')
+  }
+  return observer
+}
+
+describe('useSessionSmartScroll', () => {
+  beforeEach(() => {
+    resetSessionViewRegistryForTests()
+    window.sessionStorage.clear()
+    resizeObservers.length = 0
+    globalThis.ResizeObserver = MockResizeObserver as unknown as typeof ResizeObserver
+  })
+
+  afterEach(() => {
+    if (originalResizeObserver) {
+      globalThis.ResizeObserver = originalResizeObserver
+    } else {
+      // @ts-expect-error test cleanup for optional browser global
+      delete globalThis.ResizeObserver
+    }
+  })
+
+  it('restores a saved non-bottom anchor when the session remounts', () => {
+    setSessionViewState('session-a', {
+      scrollTop: 240,
+      stickyBottom: false,
+      manualScrollLocked: true,
+      lastSeenVersion: 2
+    })
+
+    const { rerender } = render(
+      <SmartScrollHarness
+        sessionId="session-a"
+        mirrorVersion={2}
+        contentVersion={1}
+        ready={false}
+      />
+    )
+
+    const scroller = screen.getByTestId('smart-scroll-scroller')
+    const scrollTop = { current: 0 }
+    const scrollHeight = { current: 1200 }
+    attachScrollMetrics(scroller, { scrollTop, scrollHeight, clientHeight: 400 })
+
+    rerender(
+      <SmartScrollHarness
+        sessionId="session-a"
+        mirrorVersion={2}
+        contentVersion={1}
+        ready={true}
+      />
+    )
+
+    expect(scrollTop.current).toBe(240)
+    expect(getSessionViewState('session-a')).toMatchObject({
+      scrollTop: 240,
+      stickyBottom: false,
+      manualScrollLocked: true,
+      lastSeenVersion: 2
+    })
+  })
+
+  it('keeps sticky-bottom sessions anchored and marks the latest mirror version as seen', () => {
+    setSessionViewState('session-a', {
+      stickyBottom: true,
+      manualScrollLocked: false,
+      lastSeenVersion: 1
+    })
+
+    const { rerender } = render(
+      <SmartScrollHarness
+        sessionId="session-a"
+        mirrorVersion={4}
+        contentVersion={1}
+        ready={false}
+      />
+    )
+
+    const scroller = screen.getByTestId('smart-scroll-scroller')
+    const scrollTop = { current: 0 }
+    const scrollHeight = { current: 1200 }
+    attachScrollMetrics(scroller, { scrollTop, scrollHeight, clientHeight: 400 })
+
+    rerender(
+      <SmartScrollHarness
+        sessionId="session-a"
+        mirrorVersion={4}
+        contentVersion={1}
+        ready={true}
+      />
+    )
+
+    expect(scrollTop.current).toBe(1200)
+    expect(getSessionViewState('session-a')).toMatchObject({
+      stickyBottom: true,
+      manualScrollLocked: false,
+      lastSeenVersion: 4
+    })
+    expect(screen.getByTestId('smart-scroll-fab-visible')).toHaveTextContent('no')
+  })
+
+  it('shows unread FAB count while manually locked and clears it after jumping to bottom', () => {
+    const { rerender } = render(
+      <SmartScrollHarness
+        sessionId="session-a"
+        mirrorVersion={1}
+        contentVersion={1}
+        ready={false}
+      />
+    )
+
+    const scroller = screen.getByTestId('smart-scroll-scroller')
+    const scrollTop = { current: 0 }
+    const scrollHeight = { current: 1200 }
+    attachScrollMetrics(scroller, { scrollTop, scrollHeight, clientHeight: 400 })
+
+    rerender(
+      <SmartScrollHarness
+        sessionId="session-a"
+        mirrorVersion={1}
+        contentVersion={1}
+        ready={true}
+      />
+    )
+
+    scrollTop.current = 200
+    fireEvent.wheel(scroller)
+    fireEvent.scroll(scroller)
+
+    rerender(
+      <SmartScrollHarness
+        sessionId="session-a"
+        mirrorVersion={4}
+        contentVersion={2}
+        ready={true}
+      />
+    )
+
+    expect(screen.getByTestId('smart-scroll-fab-visible')).toHaveTextContent('yes')
+    expect(screen.getByTestId('smart-scroll-fab-count')).toHaveTextContent('3')
+    expect(getSessionViewState('session-a')).toMatchObject({
+      stickyBottom: false,
+      manualScrollLocked: true,
+      lastSeenVersion: 1
+    })
+
+    fireEvent.click(screen.getByTestId('smart-scroll-fab-button'))
+
+    expect(scrollTop.current).toBe(1200)
+    expect(screen.getByTestId('smart-scroll-fab-visible')).toHaveTextContent('no')
+    expect(getSessionViewState('session-a')).toMatchObject({
+      stickyBottom: true,
+      manualScrollLocked: false,
+      lastSeenVersion: 4
+    })
+  })
+
+  it('compensates bottom-area height changes when already anchored near the bottom', () => {
+    const { rerender } = render(
+      <SmartScrollHarness
+        sessionId="session-a"
+        mirrorVersion={2}
+        contentVersion={1}
+        ready={false}
+      />
+    )
+
+    const scroller = screen.getByTestId('smart-scroll-scroller')
+    const bottomArea = screen.getByTestId('smart-scroll-bottom-area')
+    const composer = screen.getByTestId('smart-scroll-composer')
+    const scrollTop = { current: 0 }
+    const scrollHeight = { current: 1200 }
+    attachScrollMetrics(scroller, { scrollTop, scrollHeight, clientHeight: 400 })
+    attachHeight(bottomArea, 96)
+    attachHeight(composer, 80)
+
+    rerender(
+      <SmartScrollHarness
+        sessionId="session-a"
+        mirrorVersion={2}
+        contentVersion={1}
+        ready={true}
+      />
+    )
+
+    scrollHeight.current = 1440
+    act(() => {
+      getObserverFor(composer).trigger(120)
+    })
+
+    expect(scrollTop.current).toBe(1440)
+    expect(Number(screen.getByTestId('smart-scroll-fab-offset').textContent)).toBeGreaterThanOrEqual(152)
+  })
+
+  it('keeps the v1 smart-scroll guard structure in the shared hook source', async () => {
+    const fs = await import('fs')
+    const path = await import('path')
+    const source = fs.readFileSync(
+      path.resolve(
+        __dirname,
+        '../../src/renderer/src/hooks/useSessionSmartScroll.ts'
+      ),
+      'utf-8'
+    )
+
+    expect(source).toContain('isProgrammaticScrollRef')
+    expect(source).toContain('manualScrollIntentRef')
+    expect(source).toContain('pointerDownInScrollerRef')
+    expect(source).toContain("scrollToBottom('instant')")
+    expect(source).toContain('BOTTOM_AREA_COMPENSATE_THRESHOLD')
+  })
+})

--- a/test/phase-8/session-5/scroll-fab.test.tsx
+++ b/test/phase-8/session-5/scroll-fab.test.tsx
@@ -106,6 +106,15 @@ describe('Session 5: ScrollToBottomFab', () => {
       expect(button.className).toContain('rounded-full')
       expect(button.className).toContain('shadow-md')
     })
+
+    test('renders unread count as a pill when count is provided', () => {
+      const onClick = vi.fn()
+      render(<ScrollToBottomFab onClick={onClick} visible={true} count={12} />)
+
+      const button = screen.getByTestId('scroll-to-bottom-fab')
+      expect(button.className).toContain('min-w-[3.25rem]')
+      expect(screen.getByTestId('scroll-to-bottom-fab-count')).toHaveTextContent('12')
+    })
   })
 
   describe('FAB integration in SessionView', () => {
@@ -212,7 +221,7 @@ describe('Session 5: ScrollToBottomFab', () => {
       expect(source).toContain('export function ScrollToBottomFab')
 
       // Accessibility
-      expect(source).toContain('aria-label="Scroll to bottom"')
+      expect(source).toContain("aria-label={t('scrollToBottomFab.ariaLabel')}")
       expect(source).toContain('data-testid="scroll-to-bottom-fab"')
 
       // Conditional classes
@@ -221,6 +230,7 @@ describe('Session 5: ScrollToBottomFab', () => {
       expect(source).toContain('pointer-events-none')
       expect(source).toContain('translate-y-0')
       expect(source).toContain('translate-y-2')
+      expect(source).toContain('scroll-to-bottom-fab-count')
     })
   })
 })

--- a/test/session-7/session-tabs.test.ts
+++ b/test/session-7/session-tabs.test.ts
@@ -5,6 +5,10 @@ import { useSessionStore } from '../../src/renderer/src/stores/useSessionStore'
 import { useWorktreeStore } from '../../src/renderer/src/stores/useWorktreeStore'
 import { useProjectStore } from '../../src/renderer/src/stores/useProjectStore'
 import { useGitStore } from '../../src/renderer/src/stores/useGitStore'
+import {
+  resetSessionViewRegistryForTests,
+  setSessionViewState
+} from '../../src/renderer/src/lib/session-view-registry'
 
 // Mock session data
 const mockSession1 = {
@@ -88,6 +92,8 @@ const mockDbWorktree = {
 // Setup window.db mock
 beforeEach(() => {
   vi.clearAllMocks()
+  resetSessionViewRegistryForTests()
+  window.sessionStorage.clear()
 
   // Reset stores to initial state
   useSessionStore.setState({
@@ -135,6 +141,7 @@ beforeEach(() => {
 afterEach(() => {
   cleanup()
   vi.clearAllMocks()
+  vi.useRealTimers()
 })
 
 describe('Session 7: Session Tabs', () => {
@@ -216,6 +223,47 @@ describe('Session 7: Session Tabs', () => {
       expect(sessions![0].id).toBe('session-2')
       // Should select next session after closing
       expect(state.activeSessionId).toBe('session-2')
+    })
+
+    test('closeSession removes the session view anchor from sessionStorage', async () => {
+      vi.useFakeTimers()
+
+      useSessionStore.setState({
+        sessionsByWorktree: new Map([['worktree-1', [mockSession1, mockSession2]]]),
+        tabOrderByWorktree: new Map([['worktree-1', ['session-1', 'session-2']]]),
+        activeSessionId: 'session-1',
+        activeWorktreeId: 'worktree-1'
+      })
+
+      setSessionViewState('session-1', {
+        scrollTop: 128,
+        stickyBottom: false,
+        manualScrollLocked: true,
+        lastSeenVersion: 3
+      })
+      setSessionViewState('session-2', {
+        scrollTop: 64,
+        stickyBottom: true,
+        manualScrollLocked: false,
+        lastSeenVersion: 1
+      })
+      vi.runAllTimers()
+
+      mockDbSession.update.mockResolvedValue({ ...mockSession1, status: 'completed' })
+
+      await act(async () => {
+        await useSessionStore.getState().closeSession('session-1')
+      })
+      vi.runAllTimers()
+
+      expect(JSON.parse(window.sessionStorage.getItem('xuanpu:session-view-registry') ?? '{}')).toEqual({
+        'session-2': {
+          scrollTop: 64,
+          stickyBottom: true,
+          manualScrollLocked: false,
+          lastSeenVersion: 1
+        }
+      })
     })
 
     test('closeSession resets PR creating state for that session only', async () => {


### PR DESCRIPTION
## Summary
- add a session-scoped view registry backed by a module map + sessionStorage for scroll anchors and last-seen mirror versions
- migrate HQ smart scroll to a shared hook that preserves v1 programmatic/manual scroll guards and bottom-area resize compensation
- drive the HQ scroll-to-bottom FAB from mirrorVersion deltas instead of runtime unread state, with targeted regression coverage

## Testing
- pnpm vitest run test/phase-24/mock-agent-integration.test.ts test/phase-21/session-4/claude-prompt-streaming.test.ts test/phase-23/agent-event-normalization.test.ts test/phase-23/agent-event-bridge-run-epoch.test.ts test/phase-23/use-session-runtime-store.test.ts test/phase-23/session-shell-thread-status-source.test.ts test/phase-23/session-shell-plan-implement-source.test.ts test/phase-23/session-view-registry.test.ts test/phase-23/use-session-smart-scroll.test.tsx test/phase-23/agent-timeline-connector.test.tsx test/phase-23/agent-timeline-user-actions.test.tsx test/phase-8/session-5/scroll-fab.test.tsx
- pnpm exec eslint src/renderer/src/lib/session-view-registry.ts src/renderer/src/hooks/useSessionSmartScroll.ts src/renderer/src/components/session-hq/AgentTimeline.tsx src/renderer/src/components/session-hq/SessionShell.tsx src/renderer/src/components/session-hq/ComposerBar.tsx src/renderer/src/components/sessions/ScrollToBottomFab.tsx test/phase-23/session-view-registry.test.ts test/phase-23/use-session-smart-scroll.test.tsx test/phase-23/session-shell-thread-status-source.test.ts test/phase-8/session-5/scroll-fab.test.tsx