### PR TITLE
feat: queue and steer busy session prompts

### DIFF
--- a/src/renderer/src/components/session-hq/ComposerBar.tsx
+++ b/src/renderer/src/components/session-hq/ComposerBar.tsx
@@ -7,17 +7,24 @@
  */
 
 import React, { useRef, useCallback, useState, useEffect, useMemo } from 'react'
-import { ArrowUp, Square, CornerDownLeft } from 'lucide-react'
+import { ArrowUp, Square, CornerDownLeft, ListPlus, Workflow, ChevronDown } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { AttachmentButton } from '../sessions/AttachmentButton'
 import { AttachmentPreview, type Attachment } from '../sessions/AttachmentPreview'
 import { SlashCommandPopover } from '../sessions/SlashCommandPopover'
 import { BUILT_IN_SLASH_COMMANDS } from '../sessions/SessionView'
 import { Button } from '@/components/ui/button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger
+} from '@/components/ui/dropdown-menu'
 import type { SessionLifecycle, InterruptItem } from '@/stores/useSessionRuntimeStore'
 import { isComposingKeyboardEvent } from '@/lib/message-composer-shortcuts'
 import {
   determineComposerActions,
+  getActionLabel,
   type ComposerAction,
   type ComposerActionSet
 } from '@/lib/session-send-actions'
@@ -58,7 +65,24 @@ function SendIcon({ hint }: { hint: ComposerActionSet['iconHint'] }): React.JSX.
   switch (hint) {
     case 'stop':
       return <Square className="h-3.5 w-3.5" />
+    case 'queue':
+      return <ListPlus className="h-4 w-4" />
     case 'reply':
+      return <CornerDownLeft className="h-4 w-4" />
+    default:
+      return <ArrowUp className="h-4 w-4" />
+  }
+}
+
+function ActionMenuIcon({ action }: { action: ComposerAction }): React.JSX.Element {
+  switch (action) {
+    case 'queue':
+      return <ListPlus className="h-4 w-4" />
+    case 'steer':
+      return <Workflow className="h-4 w-4" />
+    case 'stop_and_send':
+      return <Square className="h-3.5 w-3.5" />
+    case 'reply_interrupt':
       return <CornerDownLeft className="h-4 w-4" />
     default:
       return <ArrowUp className="h-4 w-4" />
@@ -132,15 +156,16 @@ export function ComposerBar({
     }).catch(() => {})
     return () => { mounted = false }
   }, [worktreePath, commandsVersion])
+  const canSend = content.trim().length > 0 || attachments.length > 0
   // Derive available actions from the state machine
   const actionSet = determineComposerActions({
     lifecycle,
     hasInterrupt: firstInterrupt != null,
     hasPendingMessages: pendingCount > 0,
+    hasDraftContent: canSend,
     isConnected
   })
 
-  const canSend = content.trim().length > 0 || attachments.length > 0
   const isDisabled = !actionSet.inputEnabled
 
   // Auto-resize textarea
@@ -178,6 +203,21 @@ export function ComposerBar({
     onAction(actionSet.primary, content.trim(), attachments)
     clearInput()
   }, [actionSet.primary, canSend, content, attachments, onAction, clearInput])
+
+  const handleAlternativeAction = useCallback(
+    (action: ComposerAction) => {
+      if (action === 'stop_and_send' && !canSend) {
+        onAction('stop_and_send', '', [])
+        return
+      }
+
+      if (!canSend && action !== 'reply_interrupt') return
+
+      onAction(action, content.trim(), attachments)
+      clearInput()
+    },
+    [attachments, canSend, clearInput, content, onAction]
+  )
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
@@ -245,6 +285,16 @@ export function ComposerBar({
     textareaRef.current?.focus()
   }, [])
 
+  const placeholder = pendingPlan
+    ? 'Provide feedback on the plan...'
+    : firstInterrupt
+      ? 'Type your reply...'
+      : actionSet.primary === 'queue'
+        ? 'Type a follow-up to queue after the current run...'
+        : actionSet.iconHint === 'stop'
+          ? 'Type to stop and send...'
+          : 'Type a message...'
+
   // Determine if button should be enabled
   const buttonEnabled =
     actionSet.primary != null &&
@@ -295,15 +345,7 @@ export function ComposerBar({
           onChange={(e) => handleContentChange(e.target.value)}
           onKeyDown={handleKeyDown}
           onPaste={handlePaste}
-          placeholder={
-            pendingPlan
-              ? 'Provide feedback on the plan...'
-              : firstInterrupt
-                ? 'Type your reply...'
-                : actionSet.iconHint === 'stop'
-                  ? 'Type to stop and send...'
-                  : 'Type a message...'
-          }
+          placeholder={placeholder}
           disabled={isDisabled}
           className={cn(
             'w-full resize-none bg-transparent border-0 outline-none',
@@ -348,6 +390,42 @@ export function ComposerBar({
 
         <div className="flex-1" />
 
+        {actionSet.alternatives.length > 0 && (
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="h-8 rounded-full border border-border/70 px-2.5"
+                disabled={!canSend && actionSet.iconHint !== 'stop'}
+                aria-label="More send actions"
+                data-testid="composer-action-menu-trigger"
+              >
+                <ChevronDown className="h-4 w-4" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent
+              align="end"
+              side="top"
+              className="w-52"
+              data-testid="composer-action-menu"
+            >
+              {actionSet.alternatives.map((action) => (
+                <DropdownMenuItem
+                  key={action}
+                  onSelect={() => handleAlternativeAction(action)}
+                  disabled={!canSend && action !== 'stop_and_send'}
+                  data-testid={`composer-action-${action}`}
+                >
+                  <ActionMenuIcon action={action} />
+                  <span>{getActionLabel(action)}</span>
+                </DropdownMenuItem>
+              ))}
+            </DropdownMenuContent>
+          </DropdownMenu>
+        )}
+
         {/* Send / Stop icon button */}
         <button
           onClick={handleSubmit}
@@ -362,6 +440,7 @@ export function ComposerBar({
           )}
           aria-label={actionSet.primaryLabel}
           title={actionSet.primaryLabel}
+          data-testid="composer-primary-action"
         >
           <SendIcon hint={actionSet.iconHint} />
         </button>

--- a/src/renderer/src/components/session-hq/SessionShell.tsx
+++ b/src/renderer/src/components/session-hq/SessionShell.tsx
@@ -755,8 +755,15 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
                 sessionId,
                 droidSessionId,
                 (sid) => useSessionRuntimeStore.getState().dequeueMessage(sid),
-                (wp, sid, content) => window.agentOps.prompt(wp, sid, content, requestModel),
-                worktreePath
+                async (wp, sid, message) => {
+                  let messageParts: MessagePart[] | undefined
+                  if (message.attachments.length > 0) {
+                    messageParts = await buildMessageParts(message.attachments as Attachment[], message.content)
+                  }
+                  return window.agentOps.prompt(wp, sid, messageParts ?? message.content, requestModel)
+                },
+                worktreePath,
+                (sid, message) => useSessionRuntimeStore.getState().requeueMessageFront(sid, message)
               ).catch((err) => console.error('[SessionShell] drainNextPending failed:', err))
             }
           }

--- a/src/renderer/src/lib/session-send-actions.ts
+++ b/src/renderer/src/lib/session-send-actions.ts
@@ -28,6 +28,7 @@ export interface ComposerInput {
   lifecycle: SessionLifecycle
   hasInterrupt: boolean
   hasPendingMessages: boolean
+  hasDraftContent: boolean
   isConnected: boolean
 }
 
@@ -56,11 +57,13 @@ export interface ComposerActionSet {
  *   1. Not connected → disabled
  *   2. Interrupt pending → reply mode
  *   3. idle / error → send
- *   4. busy / materializing → stop+send (primary), queue / steer (alt)
+ *   4. busy / materializing →
+ *      - empty input: stop+send (primary)
+ *      - draft content: queue (primary), steer / stop+send (alt)
  *   5. retry → queue (primary), stop+send (alt)
  */
 export function determineComposerActions(input: ComposerInput): ComposerActionSet {
-  const { lifecycle, hasInterrupt, hasPendingMessages, isConnected } = input
+  const { lifecycle, hasInterrupt, hasPendingMessages, hasDraftContent, isConnected } = input
 
   // 1. Not connected
   if (!isConnected) {
@@ -98,6 +101,15 @@ export function determineComposerActions(input: ComposerInput): ComposerActionSe
 
     case 'busy':
     case 'materializing':
+      if (hasDraftContent) {
+        return {
+          primary: 'queue',
+          alternatives: ['steer', 'stop_and_send'],
+          inputEnabled: true,
+          primaryLabel: 'Queue',
+          iconHint: 'queue'
+        }
+      }
       return {
         primary: 'stop_and_send',
         alternatives: ['queue', 'steer'],
@@ -252,12 +264,21 @@ export async function drainNextPending(
   prompt: (
     worktreePath: string,
     sessionId: string,
-    content: string
+    message: PendingMessage
   ) => Promise<{ success: boolean; error?: string }>,
-  worktreePath: string
+  worktreePath: string,
+  requeueFront?: (sessionId: string, message: PendingMessage) => void
 ): Promise<boolean> {
   const next = dequeue(storeSessionId)
   if (!next) return false
-  await prompt(worktreePath, agentSessionId, next.content)
+  try {
+    const result = await prompt(worktreePath, agentSessionId, next)
+    if (!result.success) {
+      throw new Error(result.error || 'Failed to drain pending message')
+    }
+  } catch (error) {
+    requeueFront?.(storeSessionId, next)
+    throw error
+  }
   return true
 }

--- a/src/renderer/src/stores/useSessionRuntimeStore.ts
+++ b/src/renderer/src/stores/useSessionRuntimeStore.ts
@@ -679,6 +679,7 @@ interface SessionRuntimeStoreActions {
   // Pending message queue (Phase 5 — composer state machine)
   queueMessage(sessionId: string, message: PendingMessage): void
   dequeueMessage(sessionId: string): PendingMessage | null
+  requeueMessageFront(sessionId: string, message: PendingMessage): void
   getPendingMessages(sessionId: string): PendingMessage[]
   getPendingCount(sessionId: string): number
   clearPendingMessages(sessionId: string): void
@@ -895,6 +896,15 @@ export const useSessionRuntimeStore = create<SessionRuntimeStore>()((set, get) =
       return { pendingMessages: pending }
     })
     return first
+  },
+
+  requeueMessageFront(sessionId, message) {
+    set((state) => {
+      const pending = new Map(state.pendingMessages)
+      const queue = [...(pending.get(sessionId) ?? [])]
+      pending.set(sessionId, [message, ...queue])
+      return { pendingMessages: pending }
+    })
   },
 
   getPendingMessages(sessionId) {

--- a/test/phase-23/composer-bar.test.tsx
+++ b/test/phase-23/composer-bar.test.tsx
@@ -1,0 +1,108 @@
+import React from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { act, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { ComposerBar } from '../../src/renderer/src/components/session-hq/ComposerBar'
+
+;(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+beforeEach(() => {
+  Object.defineProperty(window, 'db', {
+    writable: true,
+    configurable: true,
+    value: {
+      session: {
+        getDraft: vi.fn().mockResolvedValue(null),
+        updateDraft: vi.fn().mockResolvedValue(undefined)
+      }
+    }
+  })
+
+  Object.defineProperty(window, 'agentOps', {
+    writable: true,
+    configurable: true,
+    value: {
+      commands: vi.fn().mockResolvedValue({ success: true, commands: [] })
+    }
+  })
+})
+
+describe('ComposerBar', () => {
+  it('uses queue as the primary action while busy when draft content exists', async () => {
+    const user = userEvent.setup()
+    const onAction = vi.fn()
+
+    render(
+      <ComposerBar
+        sessionId="sess-1"
+        lifecycle="busy"
+        pendingCount={0}
+        firstInterrupt={null}
+        onAction={onAction}
+        isConnected={true}
+      />
+    )
+
+    await user.type(screen.getByRole('textbox'), 'Follow up after this run')
+    await user.click(screen.getByTestId('composer-primary-action'))
+
+    expect(onAction).toHaveBeenCalledWith(
+      'queue',
+      'Follow up after this run',
+      expect.any(Array)
+    )
+  })
+
+  it('shows steer and stop actions in the busy-state action menu', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <ComposerBar
+        sessionId="sess-1"
+        lifecycle="busy"
+        pendingCount={0}
+        firstInterrupt={null}
+        onAction={vi.fn()}
+        isConnected={true}
+      />
+    )
+
+    await user.type(screen.getByRole('textbox'), 'Need to redirect now')
+    await act(async () => {
+      await user.click(screen.getByTestId('composer-action-menu-trigger'))
+    })
+
+    expect(await screen.findByTestId('composer-action-steer')).toBeInTheDocument()
+    expect(screen.getByTestId('composer-action-stop_and_send')).toBeInTheDocument()
+  })
+
+  it('dispatches steer from the busy-state action menu', async () => {
+    const user = userEvent.setup()
+    const onAction = vi.fn()
+
+    render(
+      <ComposerBar
+        sessionId="sess-1"
+        lifecycle="busy"
+        pendingCount={0}
+        firstInterrupt={null}
+        onAction={onAction}
+        isConnected={true}
+      />
+    )
+
+    await user.type(screen.getByRole('textbox'), 'Switch to investigating the failing test')
+    await act(async () => {
+      await user.click(screen.getByTestId('composer-action-menu-trigger'))
+    })
+    await act(async () => {
+      await user.click(await screen.findByTestId('composer-action-steer'))
+    })
+
+    expect(onAction).toHaveBeenCalledWith(
+      'steer',
+      'Switch to investigating the failing test',
+      expect.any(Array)
+    )
+  })
+})

--- a/test/phase-23/session-send-actions.test.ts
+++ b/test/phase-23/session-send-actions.test.ts
@@ -28,6 +28,7 @@ function makeInput(overrides: Partial<ComposerInput> = {}): ComposerInput {
     lifecycle: 'idle',
     hasInterrupt: false,
     hasPendingMessages: false,
+    hasDraftContent: false,
     isConnected: true,
     ...overrides
   }
@@ -137,7 +138,7 @@ describe('determineComposerActions', () => {
   })
 
   describe('busy lifecycle', () => {
-    it('returns stop_and_send with queue and steer alternatives', () => {
+    it('returns stop_and_send with queue and steer alternatives when no draft exists', () => {
       const result = determineComposerActions(makeInput({ lifecycle: 'busy' }))
       expect(result.primary).toBe('stop_and_send')
       expect(result.inputEnabled).toBe(true)
@@ -145,15 +146,34 @@ describe('determineComposerActions', () => {
       expect(result.primaryLabel).toBe('Stop')
       expect(result.alternatives).toEqual(['queue', 'steer'])
     })
+
+    it('returns queue with steer and stop alternatives when draft content exists', () => {
+      const result = determineComposerActions(
+        makeInput({ lifecycle: 'busy', hasDraftContent: true })
+      )
+      expect(result.primary).toBe('queue')
+      expect(result.inputEnabled).toBe(true)
+      expect(result.iconHint).toBe('queue')
+      expect(result.primaryLabel).toBe('Queue')
+      expect(result.alternatives).toEqual(['steer', 'stop_and_send'])
+    })
   })
 
   describe('materializing lifecycle', () => {
-    it('returns stop_and_send (same as busy)', () => {
+    it('returns stop_and_send (same as busy) when input is empty', () => {
       const result = determineComposerActions(
         makeInput({ lifecycle: 'materializing' })
       )
       expect(result.primary).toBe('stop_and_send')
       expect(result.alternatives).toEqual(['queue', 'steer'])
+    })
+
+    it('returns queue when materializing with draft content', () => {
+      const result = determineComposerActions(
+        makeInput({ lifecycle: 'materializing', hasDraftContent: true })
+      )
+      expect(result.primary).toBe('queue')
+      expect(result.alternatives).toEqual(['steer', 'stop_and_send'])
     })
   })
 
@@ -296,7 +316,20 @@ describe('drainNextPending', () => {
     const result = await drainNextPending('sess-1', 'agent-sess-1', dequeue, prompt, '/path')
     expect(result).toBe(true)
     expect(dequeue).toHaveBeenCalledWith('sess-1')
-    expect(prompt).toHaveBeenCalledWith('/path', 'agent-sess-1', 'queued message')
+    expect(prompt).toHaveBeenCalledWith('/path', 'agent-sess-1', pending)
+  })
+
+  it('requeues the message at the front when drain fails', async () => {
+    const pending = createPendingMessage('queued message')
+    const dequeue = vi.fn().mockReturnValue(pending)
+    const prompt = vi.fn().mockRejectedValue(new Error('send failed'))
+    const requeueFront = vi.fn()
+
+    await expect(
+      drainNextPending('sess-1', 'agent-sess-1', dequeue, prompt, '/path', requeueFront)
+    ).rejects.toThrow('send failed')
+
+    expect(requeueFront).toHaveBeenCalledWith('sess-1', pending)
   })
 })
 
@@ -348,6 +381,18 @@ describe('useSessionRuntimeStore pending messages', () => {
     store.queueMessage('sess-1', createPendingMessage('b'))
     store.clearPendingMessages('sess-1')
     expect(useSessionRuntimeStore.getState().getPendingCount('sess-1')).toBe(0)
+  })
+
+  it('requeueMessageFront prepends a failed pending message', () => {
+    const store = useSessionRuntimeStore.getState()
+    store.queueMessage('sess-1', createPendingMessage('second'))
+    const failed = createPendingMessage('first-again')
+    store.requeueMessageFront('sess-1', failed)
+
+    expect(useSessionRuntimeStore.getState().getPendingMessages('sess-1').map((m) => m.content)).toEqual([
+      'first-again',
+      'second'
+    ])
   })
 
   it('clearPendingMessages is no-op for unknown session', () => {
@@ -412,11 +457,11 @@ describe('end-to-end: state machine → execute', () => {
   })
 
   it('busy session: choose queue alternative → message is queued', async () => {
-    const actions = determineComposerActions(makeInput({ lifecycle: 'busy' }))
-    expect(actions.alternatives).toContain('queue')
+    const actions = determineComposerActions(makeInput({ lifecycle: 'busy', hasDraftContent: true }))
+    expect(actions.primary).toBe('queue')
 
     const ctx = makeSendContext()
-    const consumed = await executeSendAction('queue', 'for later', [], ctx)
+    const consumed = await executeSendAction(actions.primary!, 'for later', [], ctx)
     expect(consumed).toBe(true)
     expect(ctx.queueMessage).toHaveBeenCalledTimes(1)
     expect(ctx.prompt).not.toHaveBeenCalled()


### PR DESCRIPTION
## Summary
- make the HQ composer default to queue when the session is busy and the user has draft content
- expose explicit steer and stop-and-send actions from the busy-state action menu
- preserve queued attachments during auto-drain and requeue failed sends at the front

## Testing
- pnpm vitest run test/phase-23/session-send-actions.test.ts test/phase-23/composer-bar.test.tsx