### PR TITLE
feat(phase-21.5): agent tool events — full-delegation users get hot_files + Current Focus

### DIFF
--- a/docs/prd/phase-21.5-agent-tool-events-v2.md
+++ b/docs/prd/phase-21.5-agent-tool-events-v2.md
@@ -1,0 +1,377 @@
+# Phase 21.5 — Agent Tool Events（修订版）
+
+> For: Amp / 下一位接手 Phase 21 扩展的开发者
+> Author: slicenferqin（2026-04-22 初版 / 2026-04-22 修订）
+> Priority: **release-blocker for 1.4.0**
+> 前版：`phase-21.5-agent-tool-events.md`（已过时，本文件替代）
+
+---
+
+## 0 本文档相对初版的修订
+
+本修订基于内部评审（对照 Phase 24C 评审标准：VISION §6 / 反过度设计 / 诚实优于优雅）。5 项必改 + 2 项 nice-to-have 已落地。
+
+| # | 变更 | 章节 |
+|---|---|---|
+| 1 | Glob / Grep **不**归到 `agent.file_read`，另列 `agent.file_search` 类型，**不进** `hot_files` 排序 | §2, §4, §6 |
+| 2 | `operation` union 砍成单值 `'edit'`（V1 不区分 create/delete） | §2 |
+| 3 | 所有 agent 事件 `payload` 内**必须携带** `toolUseId`（V1 即使 `relatedEventId` 仍为 `null`，也为未来 Outcome Loop 保留 join key） | §2, §4 |
+| 4 | `stdoutHead / stderrTail` **默认不采集**，加独立 toggle `field.agent_bash_capture_output`（默认 OFF） | §2, §5 |
+| 5 | 工时 / schema 影响面写实：**约 8 处 TS 类型 / 测试同步**，工时 **1.5 工作日** 而非"半天到一天" | §5, §8 |
+| 6 | Sub-agent / Task tool nested events：**V1 跳过**（`parent_tool_use_id` 非 null 时不 emit） | §2, §4 |
+| 7 | Future-proof note：若未来加 "agent 改文件后自动 focus" UX，需要 dedupe by path within 5s window | §9 |
+
+---
+
+## 1 背景
+
+Phase 21 采集了 7 类 P0 事件，但**全部是"人的行为"**（file.selection / terminal.command 等）。
+
+真实使用分布下，玄圃用户分两类：
+
+- **IDE 辅助型**：人看代码、选代码、跑命令，AI 偶尔帮忙 —— Phase 21 覆盖良好
+- **全委托型**：所有编辑 / 执行 / 读取都由 Agent 完成，人只发 prompt —— Phase 21 事件近乎零
+
+作者实测数据：45 条事件里 24 条 session.message，只有 3 条 terminal.command / 2 条 file.selection（都是手动做验证才产生的）。日常使用下全委托用户的：
+
+- `hot_files` 永远空（Phase 24C `checkpoint-generator.ts` `rankHotFiles` 依赖 file.focus / file.open / file.selection）
+- Field Context 的 `## Current Focus` 永远空
+- Episodic Memory 只能统计"发了几条 prompt"
+
+**Phase 21.5 的目标：补采 Agent 侧事件，让全委托用户也能享受 Phase 22 / 24C 的记忆与 checkpoint 能力。**
+
+---
+
+## 2 范围（MVP）
+
+4 类事件（修订：原 3 类分裂为 4 类，因 Glob/Grep 与 Read 的语义截然不同——前者是搜索模式，无具体文件路径，不应进入 `hot_files` 排序）：
+
+| 类型 | 触发时机 | payload 关键字段 |
+|---|---|---|
+| `agent.file_read` | Read / NotebookRead / file_read 工具返回成功 | `toolUseId`、`path`（相对 worktree 根）、`bytes?`、`toolName` |
+| `agent.file_write` | Edit / Write / NotebookEdit / MultiEdit / apply_patch 工具返回成功 | `toolUseId`、`path`、`operation: 'edit'`（V1 单值）、`toolName` |
+| `agent.file_search` | Glob / Grep 工具返回成功 | `toolUseId`、`pattern`、`matchCount?`、`toolName` |
+| `agent.bash_exec` | Bash / exec_command 返回（含超时/失败） | `toolUseId`、`command`（slice 512）、`exitCode?`、`durationMs?`、可选 `stdoutHead?`（1KB）、可选 `stderrTail?`（1KB） |
+
+### 为什么 `agent.file_search` 独立
+
+Glob 的 `input.pattern` 是 `**/*.ts` 这种字符串，不是具体路径。初版把它塞进 `agent.file_read` 的 `path` 字段，下游 `rankHotFiles` 会调 `statSync('**/*.ts')` 必然失败，等于无效事件——但更危险的是如果 ranker 日后没做 stat 过滤，glob 字符串会进入 `hot_files` 列表污染 checkpoint 显示。
+
+独立后：
+- `agent.file_search` **不进** `hot_files` 排序，也不派生 `Current Focus`
+- 它只为 Episodic Memory 做 "agent 搜了些什么" 的语义帮助（未来可选）
+- 保留 `matchCount` 为将来判断"搜索是否高效"提供数据
+
+### 为什么 `operation` V1 只有 `'edit'`
+
+初版 union 是 `'create' | 'edit' | 'delete'`，但代码只在 `toolName === 'Write'` 时设 `'create'`，其他全是 `'edit'`。`'delete'` 永远是 dead code。真正准确区分 create/edit 需要 file-existed-before 检测，那是 Outcome Loop 的工作，不是 V1 的工作。
+
+**V1 约定**：`operation` 固定 `'edit'`。未来 Outcome Loop 引入时再细分，到时候 `'edit'` → `'create' | 'edit'` 是向下兼容的 union 扩展。
+
+### 为什么每个 payload 都必须带 `toolUseId`
+
+- Claude Code: `block.id`（tool_use 的 id）
+- Codex: `item.id`
+- OpenCode: SDK part id
+
+同一 tool_use 的 read+write、或 bash 触发测试后的 stdoutHead 与后续 session.message，都有天然因果。`relatedEventId` V1 保持 `null`（不做强耦合），但 `toolUseId` 作为最低成本 join key 写进 payload。未来 Outcome Loop 要做 "把 test_pass 归因到 bash 命令" 时，从 payload 查 `toolUseId` 比反查 `relatedEventId` 便宜。
+
+### 为什么 sub-agent nested events 跳过
+
+Claude Code 的 Task tool 会启动子 agent，子 agent 自己用 Read/Write/Bash。如果 nested 工具也 emit，会污染主 session 的 `hot_files`（子任务的 Read 文件被误当主会话的热文件）。
+
+**V1 策略**：检测 tool 调用的 `parent_tool_use_id`（或等价字段），**非 null 时完全跳过 emit**。"我看见的 session 是顶层那个"——符合用户心智。
+
+未来若真需要 sub-session 观测，另开一个 `session.sub_agent_summary` 事件类型（汇总不逐条）。
+
+### 显式不做（留给后续）
+
+- `agent.thinking` / `agent.plan_update`（噪声高，价值低）
+- WebFetch / WebSearch（不是本地 workbench 事件，属于外部世界观测）
+- Subagent 递归逐条采集（见上条，V1 跳过）
+- Per-tool 独立类型（保持 4 类，靠 `toolName` 字段细分）
+
+---
+
+## 3 接入点（已代码核对）
+
+### 3.1 Claude Code runtime
+
+`src/main/services/claude-code-implementer.ts`
+
+- **第 3195 行** `if (blockType === 'tool_use')` —— 工具调用开始时 draft 入 map
+- **第 1046–1067 行** —— `tool_result` 合并回 `tool_use` part 时是**完成时刻**
+
+→ 在 1046 行循环后，当 `toolPart` 的 `tool_result` 有了 `exitCode`（Bash）或 `output`（Read/Edit），调 `emitAgentToolEvent`。`toolUse.name` 即 tool 名（Read / Edit / Write / Bash / Glob / Grep / ...），按名字分流到 4 类 field event。
+
+**sub-agent 过滤**：检查 `tool_use_id` 的 `parent_tool_use_id`（Claude Code SDK 在 Task tool 启动子会话时会填这个字段），非 null 直接 return。
+
+### 3.2 Codex runtime
+
+`src/main/services/codex-event-mapper.ts`
+
+- **第 511–524 行** `item_started` case —— tool 开始
+- 对应的 completion 在同文件中查 `exec_command_output_delta` / `exec_command_end`
+
+→ Codex 的 `exec_command_end` 带 `exit_code`，直接 emit `agent.bash_exec`。Read/Edit 类工具 Codex 通过 `apply_patch` / `file_read` 统一调 —— 具体 event name 请查 `codex-event-mapper.ts` 里的 `item.toolName` 白名单。
+
+### 3.3 OpenCode runtime
+
+`src/main/services/opencode-service.ts` —— SDK 回调里查 `tool_use` 类 part，完成后 emit。（OpenCode transcript 结构与 Claude Code 类似，可复用同样的 part-walker 模式。）
+
+### 3.4 三个 adapter 现实
+
+评审指出"三种 SDK 结构都不同"——**helper 只做归一化 + emit，每个 adapter 自己写 5–10 行形状转换**才是诚实的工作量（见 §8 工时）。
+
+---
+
+## 4 emit 骨架
+
+```ts
+// src/main/field/emit-agent-tool.ts (新文件)
+import { emitFieldEvent } from './emit'
+import path from 'node:path'
+
+export interface AgentToolObservation {
+  worktreeId: string
+  projectId: string | null
+  sessionId: string | null
+  worktreePath: string
+  toolName: string
+  toolUseId: string
+  parentToolUseId?: string | null   // sub-agent 过滤
+  input: Record<string, unknown>
+  output?: {
+    text?: string
+    error?: string
+    exitCode?: number
+    durationMs?: number
+    matchCount?: number             // Glob/Grep only
+  }
+}
+
+const READ_TOOLS = new Set(['Read', 'NotebookRead', 'file_read'])
+const WRITE_TOOLS = new Set(['Edit', 'Write', 'MultiEdit', 'NotebookEdit', 'apply_patch'])
+const SEARCH_TOOLS = new Set(['Glob', 'Grep'])
+const BASH_TOOLS = new Set(['Bash', 'exec_command'])
+
+export function emitAgentToolEvent(obs: AgentToolObservation): void {
+  // Sub-agent: skip nested tool uses entirely (V1)
+  if (obs.parentToolUseId) return
+
+  const { toolName, input, output, worktreePath, toolUseId } = obs
+  const base = {
+    worktreeId: obs.worktreeId,
+    projectId: obs.projectId,
+    sessionId: obs.sessionId,
+    relatedEventId: null as string | null
+  }
+
+  if (BASH_TOOLS.has(toolName)) {
+    const captureOutput = isBashOutputCaptureEnabled()
+    emitFieldEvent({
+      type: 'agent.bash_exec',
+      ...base,
+      payload: {
+        toolUseId,
+        toolName,
+        command: String(input.command ?? '').slice(0, 512),
+        exitCode: output?.exitCode ?? null,
+        durationMs: output?.durationMs ?? null,
+        stdoutHead: captureOutput ? (output?.text?.slice(0, 1024) ?? null) : null,
+        stderrTail: captureOutput ? (output?.error?.slice(-1024) ?? null) : null
+      }
+    })
+    return
+  }
+
+  if (SEARCH_TOOLS.has(toolName)) {
+    emitFieldEvent({
+      type: 'agent.file_search',
+      ...base,
+      payload: {
+        toolUseId,
+        toolName,
+        pattern: String(input.pattern ?? input.path ?? '').slice(0, 512),
+        matchCount: output?.matchCount ?? null
+      }
+    })
+    return
+  }
+
+  const rawPath = (input.file_path ?? input.path ?? '') as string
+  if (!rawPath) return
+  // Guard: if caller accidentally passed a glob into a read/write tool
+  // (should not happen with white-lists above), bail rather than pollute
+  if (rawPath.includes('*') || rawPath.includes('?')) return
+  const relPath = path.isAbsolute(rawPath) ? path.relative(worktreePath, rawPath) : rawPath
+
+  if (READ_TOOLS.has(toolName)) {
+    emitFieldEvent({
+      type: 'agent.file_read',
+      ...base,
+      payload: {
+        toolUseId,
+        toolName,
+        path: relPath,
+        bytes: output?.text?.length ?? null
+      }
+    })
+  } else if (WRITE_TOOLS.has(toolName)) {
+    emitFieldEvent({
+      type: 'agent.file_write',
+      ...base,
+      payload: {
+        toolUseId,
+        toolName,
+        path: relPath,
+        operation: 'edit' // V1: single value; future Outcome Loop may refine
+      }
+    })
+  }
+  // Unknown tool names: no-op (safer than miscategorizing)
+}
+```
+
+### Bash output capture toggle
+
+```ts
+// src/main/field/privacy.ts (add-on)
+const KEY_BASH_CAPTURE = 'field.agent_bash_capture_output'
+export function isBashOutputCaptureEnabled(): boolean {
+  // Default: OFF. Bash output can contain secrets (API keys, env dumps).
+  return getSetting(KEY_BASH_CAPTURE) === 'true'
+}
+```
+
+UI: Settings → Privacy → "Capture Bash stdout/stderr for agent analysis"（默认 unchecked）。
+
+---
+
+## 5 Schema & Types
+
+**物理 schema**：**无 migration**（`field_events.payload_json` 是弹性列）。
+
+**逻辑 schema**：`FieldEventType` 是 discriminated union，新增 4 个 variant 意味着下游消费者都要同步。**实测影响面约 8 处**：
+
+1. `src/shared/types/field-event.ts` —— union 加 4 个 variant + payload interface
+2. `src/main/field/privacy.ts` —— `SENSITIVE_TYPES` 白名单 + 新增 `isBashOutputCaptureEnabled`
+3. `src/main/field/checkpoint-generator.ts` —— `rankHotFiles` switch 加分支（见 §6）
+4. `src/main/field/context-builder.ts` —— `deriveFocus` 加 agent.file_write / agent.file_read 分支
+5. `src/main/field/context-formatter.ts` —— `summarizeEvent` switch 加 4 个 case
+6. `src/main/field/emit.ts` —— dispatcher 可能需要识别新类型的 log 等级
+7. `scripts/dump-field-events.ts` —— `formatRow` switch 加 4 个 case
+8. `test/phase-21/field-events/sink.test.ts` 等 —— 硬编码事件枚举的测试断言
+
+Phase 24C 的 `episodic-schema.test.ts` 已经用了 `toBeGreaterThanOrEqual(18)` 模式，其他硬编码处照此处理。
+
+---
+
+## 6 下游消费
+
+### 6.1 `rankHotFiles`（Phase 24C checkpoint-generator.ts）
+
+```ts
+// 加在现有 switch 里
+} else if (ev.type === 'agent.file_write') {
+  bump((ev.payload as { path?: string }).path, 3)  // 写权重最高
+} else if (ev.type === 'agent.file_read') {
+  bump((ev.payload as { path?: string }).path, 1)
+}
+// agent.file_search / agent.bash_exec 不进 hot_files 排序
+```
+
+对 `editCount` 统计也要加 `agent.file_write.path` 到 touchedFiles set。
+
+### 6.2 `deriveFocus`（context-builder.ts）
+
+Current Focus 优先级链（新→旧覆盖原则的反向）：
+1. 最近的 `file.focus` / `file.open`（人的行为，最高优先级）
+2. 最近的 `agent.file_write`（agent 正在编辑）
+3. 最近的 `agent.file_read`（agent 正在观察）
+
+**修改理由**：全委托用户无 `file.focus`，但 agent 正在编辑 `src/auth.ts` 时，下次 prompt 的 Current Focus 应该能看到 `src/auth.ts`。
+
+### 6.3 Episodic Memory（非本期改动）
+
+`Most-Touched Files` 天然按 `file_events × type` 聚合，加入新类型后自动生效，不需要单独改 episodic compactor。
+
+---
+
+## 7 验收（真实场景）
+
+1. 清理 DB：
+   ```bash
+   sqlite3 ~/.xuanpu/xuanpu.db "DELETE FROM field_events WHERE type LIKE 'agent.%';"
+   ```
+2. 装新包，开一个会话，让 Agent 做一个小任务（例如 "给 README 加一行"）
+3. SQL 核对事件类型都进来了：
+   ```bash
+   sqlite3 ~/.xuanpu/xuanpu.db \
+     "SELECT type, COUNT(*) FROM field_events WHERE type LIKE 'agent.%' GROUP BY type;"
+   ```
+   应看到 `agent.file_read` / `agent.file_write` / `agent.file_search` / `agent.bash_exec` 四类都有计数（除非任务恰好没用到某类）
+4. SQL 核对 payload 有 `toolUseId`：
+   ```bash
+   sqlite3 ~/.xuanpu/xuanpu.db \
+     "SELECT json_extract(payload_json, '$.toolUseId') FROM field_events WHERE type = 'agent.file_write' LIMIT 3;"
+   ```
+   每行非 null
+5. SQL 核对 `agent.bash_exec` **默认不含 stdoutHead**：
+   ```bash
+   sqlite3 ~/.xuanpu/xuanpu.db \
+     "SELECT json_extract(payload_json, '$.stdoutHead') FROM field_events WHERE type = 'agent.bash_exec' LIMIT 3;"
+   ```
+   应为 null（除非用户已打开 capture toggle）
+6. SQL 核对 `agent.file_search` 的 `pattern` **不等于**文件路径：
+   ```bash
+   sqlite3 ~/.xuanpu/xuanpu.db \
+     "SELECT json_extract(payload_json, '$.pattern') FROM field_events WHERE type = 'agent.file_search' LIMIT 3;"
+   ```
+   看到 glob 字符串（`**/*.ts` 等），不是文件路径
+7. 下次发 prompt → Field Context Debug 的 Last Injection 里 `## Current Focus` 段有 Agent 刚读/改的文件
+8. checkpoint: abort 当前会话 → 重连 → "Resumed from previous session" 块里 `Hot files` 非空且**只包含真实文件路径**（无 glob 模式）
+9. Sub-agent 场景：启动 Task tool 子会话 → 检查 nested 工具调用的事件**没有**进入 `field_events`
+
+---
+
+## 8 时间预算（修订）
+
+| 项 | 预估 |
+|---|---|
+| 3 runtime adapter 接入（各有形状差异） | 1.0 天 |
+| 类型 + 8 处下游 TS 类型 / 测试同步 | 0.25 天 |
+| `rankHotFiles` / `deriveFocus` / `summarizeEvent` 消费改动 | 0.25 天 |
+| Bash output capture privacy toggle + Settings UI + 测试 | 0.25 天 |
+| Phase 21.5 专属测试（schema + emit + dedupe + sub-agent skip） | 0.25 天 |
+| **总计** | **~1.5–2 工作日** |
+
+初版 "半天到一天" 严重低估了 3 个 adapter 形状差异 + 下游同步成本。
+
+---
+
+## 9 非目标 & Future-proof 注记
+
+- ❌ Phase 22B.2 Haiku episodic（独立 PR）
+- ❌ Phase 22C.2 semantic memory auto-update（独立 PR）
+- ❌ Redaction / PII filter（未来再加，现阶段依赖 `field_collection` toggle + 默认关闭 bash output capture）
+- ❌ Sub-agent nested 工具逐条观测（V1 跳过，未来 `session.sub_agent_summary` 聚合事件）
+- ❌ `operation: 'create' | 'delete'` 细分（留给 Outcome Loop）
+
+### Future-proof 注记
+
+- **如果未来加 "agent 改文件后自动 focus 那个文件" UX**（现在没有）：`agent.file_write` 和 `file.focus` 会对同一 path 双 emit。需要在 `rankHotFiles` 加 dedupe：按 `(path, 5s window)` 合并为单次事件。
+- **如果 Outcome Loop 引入**：从 `agent.bash_exec.payload.toolUseId` 反查同 tool_use 的 stdout / 后续 session.message 情感，即可做归因。现在保留 `toolUseId` 就是为了那一天。
+
+---
+
+## 10 修订记录
+
+| 日期 | 修订人 | 内容 |
+|---|---|---|
+| 2026-04-22 | slicenferqin | 初版 |
+| 2026-04-22 | slicenferqin | 评审落地 5 项必改 + 2 项 nice-to-have（见 §0） |
+
+---
+
+Phase 21.5 完成后，1.4.0 才具备对**全委托 AI 用户**的完整价值，届时发布。

--- a/scripts/dump-field-events.ts
+++ b/scripts/dump-field-events.ts
@@ -251,6 +251,31 @@ function formatRow(row: Row): string {
       const attach = (p?.attachmentCount ?? 0) > 0 ? ` [+${p?.attachmentCount} attached]` : ''
       return `- ${time} [session.message] ${sdk} "${truncate(p?.text ?? '', 200)}"${attach}`
     }
+    case 'agent.file_read': {
+      const p = payload as { path?: string; toolName?: string; bytes?: number | null }
+      const bytes = typeof p?.bytes === 'number' ? ` (${p.bytes}B)` : ''
+      return `- ${time} [agent.file_read:${p?.toolName ?? '?'}] \`${p?.path ?? ''}\`${bytes}`
+    }
+    case 'agent.file_write': {
+      const p = payload as { path?: string; toolName?: string; operation?: string }
+      return `- ${time} [agent.file_write:${p?.toolName ?? '?'}] \`${p?.path ?? ''}\` (${p?.operation ?? 'edit'})`
+    }
+    case 'agent.file_search': {
+      const p = payload as { pattern?: string; toolName?: string; matchCount?: number | null }
+      const mc = typeof p?.matchCount === 'number' ? ` → ${p.matchCount} matches` : ''
+      return `- ${time} [agent.file_search:${p?.toolName ?? '?'}] \`${p?.pattern ?? ''}\`${mc}`
+    }
+    case 'agent.bash_exec': {
+      const p = payload as {
+        command?: string
+        toolName?: string
+        exitCode?: number | null
+        durationMs?: number | null
+      }
+      const exit = p?.exitCode != null ? ` exit=${p.exitCode}` : ''
+      const dur = p?.durationMs != null ? ` ${p.durationMs}ms` : ''
+      return `- ${time} [agent.bash_exec:${p?.toolName ?? '?'}]${exit}${dur} \`${truncate(p?.command ?? '', 120)}\``
+    }
     default:
       return `- ${time} [${row.type}] ${truncate(row.payload_json, 200)}`
   }

--- a/src/main/field/checkpoint-generator.ts
+++ b/src/main/field/checkpoint-generator.ts
@@ -115,11 +115,20 @@ export function rankHotFiles(
   }
 
   for (const ev of events) {
-    // file.edit (P1, not yet implemented) would score 3; currently absent.
+    // Human-action events (Phase 21)
     if (ev.type === 'file.focus' || ev.type === 'file.open') {
       bump((ev.payload as { path?: string }).path, 1)
     } else if (ev.type === 'file.selection') {
       bump((ev.payload as { path?: string }).path, 2)
+    }
+    // Agent tool events (Phase 21.5). agent.file_write is the strongest
+    // signal — the agent just changed the file — and agent.file_read a
+    // weaker one. agent.file_search (glob/regex patterns) and
+    // agent.bash_exec do NOT point to a specific file and are excluded.
+    else if (ev.type === 'agent.file_write') {
+      bump((ev.payload as { path?: string }).path, 3)
+    } else if (ev.type === 'agent.file_read') {
+      bump((ev.payload as { path?: string }).path, 1)
     }
     // terminal.command cwd inside worktree is a weak signal; skipped
     // because it doesn't point to a specific file.
@@ -343,17 +352,22 @@ export async function generateCheckpoint(
   // Goals
   const { currentGoal, nextAction } = deriveGoals(events)
 
-  // Stats for summary. file.edit is P1 (not implemented); as a proxy, count
-  // distinct files with any focus/selection activity — matches "files touched".
+  // Stats for summary. Count distinct files touched (by either human focus
+  // events from Phase 21 or agent file_write/file_read from Phase 21.5).
   const touchedFiles = new Set<string>()
   for (const ev of events) {
     if (ev.type === 'file.focus' || ev.type === 'file.selection' || ev.type === 'file.open') {
       const p = (ev.payload as { path?: string }).path
       if (p) touchedFiles.add(p)
+    } else if (ev.type === 'agent.file_write' || ev.type === 'agent.file_read') {
+      const p = (ev.payload as { path?: string }).path
+      if (p) touchedFiles.add(p)
     }
   }
   const editCount = touchedFiles.size
-  const commandCount = events.filter((e) => e.type === 'terminal.command').length
+  const commandCount = events.filter(
+    (e) => e.type === 'terminal.command' || e.type === 'agent.bash_exec'
+  ).length
   const firstTs = events[0]?.timestamp ?? now
   const durationMinutes = Math.max(0, Math.round((now - firstTs) / 60_000))
 

--- a/src/main/field/context-builder.ts
+++ b/src/main/field/context-builder.ts
@@ -185,6 +185,10 @@ function deriveFocus(events: StoredFieldEvent[]): FocusResult {
   let focusFileSourceId: string | null = null
   let focusSelectionSourceId: string | null = null
 
+  // Track agent fallbacks separately so they only fire when no human signal exists.
+  let agentWriteFallback: { path: string; sourceId: string } | null = null
+  let agentReadFallback: { path: string; sourceId: string } | null = null
+
   // Events are ASC order. Walking forward and overwriting gives us "last wins".
   for (const e of events) {
     if (e.type === 'file.open' || e.type === 'file.focus') {
@@ -217,6 +221,16 @@ function deriveFocus(events: StoredFieldEvent[]): FocusResult {
         }
         focusSelectionSourceId = e.id
       }
+    } else if (e.type === 'agent.file_write') {
+      const p = e.payload as { path?: string }
+      if (typeof p?.path === 'string') {
+        agentWriteFallback = { path: p.path, sourceId: e.id }
+      }
+    } else if (e.type === 'agent.file_read') {
+      const p = e.payload as { path?: string }
+      if (typeof p?.path === 'string') {
+        agentReadFallback = { path: p.path, sourceId: e.id }
+      }
     }
   }
 
@@ -227,6 +241,17 @@ function deriveFocus(events: StoredFieldEvent[]): FocusResult {
     // Don't overwrite focusFileSourceId — the original file.focus/open event
     // is still the source of the "file" facet; the selection event is its own
     // source. Both end up in promotedIds.
+  }
+
+  // Phase 21.5: if no human focus exists, fall back to agent activity.
+  // Priority within agent: write > read (write means the agent just changed
+  // the file; read means it just looked at it).
+  if (!focusFile) {
+    const fallback = agentWriteFallback ?? agentReadFallback
+    if (fallback) {
+      focusFile = { path: fallback.path, name: basename(fallback.path) }
+      focusFileSourceId = fallback.sourceId
+    }
   }
 
   return { focusFile, focusSelection, focusFileSourceId, focusSelectionSourceId }
@@ -332,6 +357,24 @@ function summarizeEvent(e: StoredFieldEvent): FieldContextActivityEntry {
       const sdk = p?.agentSdk ? `(${p.agentSdk}) ` : ''
       const text = p?.text ? truncate(p.text, 80) : ''
       return { ...base, summary: `${sdk}message: "${text}"` }
+    }
+    case 'agent.file_read': {
+      const p = e.payload as { path?: string; toolName?: string }
+      return { ...base, summary: `agent read \`${p?.path ?? ''}\`` }
+    }
+    case 'agent.file_write': {
+      const p = e.payload as { path?: string; toolName?: string }
+      return { ...base, summary: `agent edited \`${p?.path ?? ''}\`` }
+    }
+    case 'agent.file_search': {
+      const p = e.payload as { pattern?: string; matchCount?: number | null }
+      const mc = typeof p?.matchCount === 'number' ? ` → ${p.matchCount} matches` : ''
+      return { ...base, summary: `agent searched \`${p?.pattern ?? ''}\`${mc}` }
+    }
+    case 'agent.bash_exec': {
+      const p = e.payload as { command?: string; exitCode?: number | null }
+      const exit = p?.exitCode != null ? ` (exit ${p.exitCode})` : ''
+      return { ...base, summary: `agent ran \`${(p?.command ?? '').slice(0, 80)}\`${exit}` }
     }
     default:
       return { ...base, summary: type }

--- a/src/main/field/emit-agent-tool.ts
+++ b/src/main/field/emit-agent-tool.ts
@@ -1,0 +1,217 @@
+/**
+ * Agent tool-event emit helper — Phase 21.5.
+ *
+ * Bridges runtime adapter observations (Claude Code / Codex / OpenCode) into
+ * the unified field_events stream. Each adapter is responsible for
+ * normalizing its own SDK-specific payload shape into `AgentToolObservation`;
+ * this module owns:
+ *   - sub-agent skip (V1: parent_tool_use_id non-null → no-op)
+ *   - tool-name → event-type routing (4 categories)
+ *   - glob pattern guard (never let "** /*.ts" leak into a path field)
+ *   - bash output privacy gate (`isBashOutputCaptureEnabled`)
+ *
+ * Failure mode: silent. Caller must not rely on emission for correctness.
+ *
+ * See docs/prd/phase-21.5-agent-tool-events-v2.md
+ */
+import path from 'node:path'
+import { emitFieldEvent } from './emit'
+import { isBashOutputCaptureEnabled } from './privacy'
+
+/** Tools that read a single concrete file. */
+const READ_TOOLS: ReadonlySet<string> = new Set([
+  'Read',
+  'NotebookRead',
+  'file_read'
+])
+
+/** Tools that mutate a single concrete file. */
+const WRITE_TOOLS: ReadonlySet<string> = new Set([
+  'Edit',
+  'Write',
+  'MultiEdit',
+  'NotebookEdit',
+  'apply_patch'
+])
+
+/** Tools that search by pattern (no concrete file). */
+const SEARCH_TOOLS: ReadonlySet<string> = new Set(['Glob', 'Grep'])
+
+/** Tools that execute shell commands. */
+const BASH_TOOLS: ReadonlySet<string> = new Set(['Bash', 'exec_command'])
+
+const COMMAND_MAX = 512
+const PATTERN_MAX = 512
+const STDOUT_MAX = 1024
+const STDERR_MAX = 1024
+
+export interface AgentToolObservation {
+  /** Worktree the agent is acting in. */
+  worktreeId: string | null
+  projectId: string | null
+  /** Hive sessions.id (preferred) or runtime session id — caller resolves. */
+  sessionId: string | null
+  /** Worktree absolute path; used to resolve absolute file paths to relative. */
+  worktreePath: string
+
+  /** SDK tool name (Read / Edit / Bash / Glob / ...). */
+  toolName: string
+  /** SDK tool-use id (Claude block.id / Codex item.id / OpenCode part id). */
+  toolUseId: string
+  /**
+   * If this tool call was made BY a sub-agent (e.g. Claude Code Task tool),
+   * the parent tool_use id. V1: non-null → emit is skipped entirely.
+   */
+  parentToolUseId?: string | null
+
+  /** Raw input dict from the SDK tool call (file_path / pattern / command). */
+  input: Record<string, unknown>
+
+  /** Optional output observations — fields populated when known. */
+  output?: {
+    /** Tool output text (truncated downstream by category-specific limit). */
+    text?: string
+    /** Stderr (Bash only). */
+    error?: string
+    /** Exit code (Bash only). */
+    exitCode?: number
+    /** Wall-clock duration in ms (Bash only, when measured). */
+    durationMs?: number
+    /** Match count (Glob/Grep only, when reported by SDK). */
+    matchCount?: number
+  }
+}
+
+/**
+ * Emit a normalized agent tool event into the field_events stream.
+ *
+ * Returns the emitted event id, or `null` when the call was skipped
+ * (sub-agent, unknown tool, missing required field, glob-string guard).
+ *
+ * Never throws.
+ */
+export function emitAgentToolEvent(obs: AgentToolObservation): string | null {
+  // V1: skip nested sub-agent tool calls entirely. The user's mental model is
+  // "the session I'm watching" → only outermost tool_use ids count.
+  if (obs.parentToolUseId) return null
+
+  const { toolName, input, output, worktreePath, toolUseId } = obs
+  if (!toolUseId) return null
+  if (!toolName) return null
+
+  const baseEnvelope = {
+    worktreeId: obs.worktreeId,
+    projectId: obs.projectId,
+    sessionId: obs.sessionId,
+    relatedEventId: null as string | null
+  }
+
+  // ─── Bash ────────────────────────────────────────────────────────────────
+  if (BASH_TOOLS.has(toolName)) {
+    const captureOutput = isBashOutputCaptureEnabled()
+    return emitFieldEvent({
+      type: 'agent.bash_exec',
+      ...baseEnvelope,
+      payload: {
+        toolUseId,
+        toolName,
+        command: stringField(input.command, COMMAND_MAX),
+        exitCode: numberOrNull(output?.exitCode),
+        durationMs: numberOrNull(output?.durationMs),
+        stdoutHead: captureOutput ? sliceHead(output?.text, STDOUT_MAX) : null,
+        stderrTail: captureOutput ? sliceTail(output?.error, STDERR_MAX) : null
+      }
+    })
+  }
+
+  // ─── Search (Glob / Grep) ────────────────────────────────────────────────
+  if (SEARCH_TOOLS.has(toolName)) {
+    const pattern = stringField(input.pattern ?? input.path, PATTERN_MAX)
+    if (!pattern) return null
+    return emitFieldEvent({
+      type: 'agent.file_search',
+      ...baseEnvelope,
+      payload: {
+        toolUseId,
+        toolName,
+        pattern,
+        matchCount: numberOrNull(output?.matchCount)
+      }
+    })
+  }
+
+  // ─── Read / Write (single concrete file) ─────────────────────────────────
+  const isRead = READ_TOOLS.has(toolName)
+  const isWrite = WRITE_TOOLS.has(toolName)
+  if (!isRead && !isWrite) {
+    // Unknown tool name — safer to no-op than to miscategorize.
+    return null
+  }
+
+  const rawPath = (input.file_path ?? input.path ?? '') as unknown
+  if (typeof rawPath !== 'string' || rawPath.length === 0) return null
+
+  // Guard: if a search tool's pattern accidentally reaches here (or a
+  // future tool sends a glob in `path`), bail rather than letting the
+  // pattern pollute hot_files / Current Focus.
+  if (rawPath.includes('*') || rawPath.includes('?')) return null
+
+  const relPath = path.isAbsolute(rawPath)
+    ? path.relative(worktreePath, rawPath)
+    : rawPath
+
+  if (isRead) {
+    return emitFieldEvent({
+      type: 'agent.file_read',
+      ...baseEnvelope,
+      payload: {
+        toolUseId,
+        toolName,
+        path: relPath,
+        bytes: typeof output?.text === 'string' ? output.text.length : null
+      }
+    })
+  }
+
+  // isWrite
+  return emitFieldEvent({
+    type: 'agent.file_write',
+    ...baseEnvelope,
+    payload: {
+      toolUseId,
+      toolName,
+      path: relPath,
+      operation: 'edit'
+    }
+  })
+}
+
+// ─── Helpers ───────────────────────────────────────────────────────────────
+
+function stringField(v: unknown, max: number): string {
+  if (typeof v !== 'string') return ''
+  return v.length > max ? v.slice(0, max) : v
+}
+
+function numberOrNull(v: unknown): number | null {
+  return typeof v === 'number' && Number.isFinite(v) ? v : null
+}
+
+function sliceHead(v: unknown, max: number): string | null {
+  if (typeof v !== 'string' || v.length === 0) return null
+  return v.length > max ? v.slice(0, max) : v
+}
+
+function sliceTail(v: unknown, max: number): string | null {
+  if (typeof v !== 'string' || v.length === 0) return null
+  return v.length > max ? v.slice(-max) : v
+}
+
+// ─── Test-only re-exports ──────────────────────────────────────────────────
+
+export const __TEST_TOOL_SETS = {
+  READ_TOOLS,
+  WRITE_TOOLS,
+  SEARCH_TOOLS,
+  BASH_TOOLS
+}

--- a/src/main/field/emit.ts
+++ b/src/main/field/emit.ts
@@ -37,7 +37,12 @@ const SENSITIVE_TYPES: ReadonlySet<FieldEventType> = new Set<FieldEventType>([
   'file.selection',
   'terminal.command',
   'terminal.output',
-  'session.message'
+  'session.message',
+  // Phase 21.5 — agent tool events are also gated by field_collection_enabled
+  'agent.file_read',
+  'agent.file_write',
+  'agent.file_search',
+  'agent.bash_exec'
 ])
 
 /**

--- a/src/main/field/privacy.ts
+++ b/src/main/field/privacy.ts
@@ -59,10 +59,39 @@ export function setMemoryInjectionEnabledCache(value: boolean): void {
 export const MEMORY_INJECTION_SETTING_KEY = INJECTION_SETTING_KEY
 
 // ---------------------------------------------------------------------------
+// agent_bash_capture_output (Phase 21.5)
+//
+// Bash output (stdout/stderr) captured from agent tool_use observations is
+// frequently sensitive: API keys, env dumps, error stacks with tokens.
+//
+// Default OFF. Opt-in via Settings → Privacy → "Capture Bash stdout/stderr
+// for agent analysis". The command itself is still captured regardless of
+// this flag (the user can already see it in the sidebar).
+// ---------------------------------------------------------------------------
+
+const BASH_CAPTURE_SETTING_KEY = 'agent_bash_capture_output'
+let bashCaptureCached: boolean | null = null
+
+export function isBashOutputCaptureEnabled(): boolean {
+  if (bashCaptureCached !== null) return bashCaptureCached
+  const value = getDatabase().getSetting(BASH_CAPTURE_SETTING_KEY)
+  // Default OFF: unset or literally 'false' → false. Must be 'true' to enable.
+  bashCaptureCached = value === 'true'
+  return bashCaptureCached
+}
+
+export function setBashOutputCaptureEnabledCache(value: boolean): void {
+  bashCaptureCached = value
+}
+
+export const BASH_OUTPUT_CAPTURE_SETTING_KEY = BASH_CAPTURE_SETTING_KEY
+
+// ---------------------------------------------------------------------------
 // Test helpers
 // ---------------------------------------------------------------------------
 
 export function invalidatePrivacyCache(): void {
   collectionCached = null
   injectionCached = null
+  bashCaptureCached = null
 }

--- a/src/main/ipc/database-handlers.ts
+++ b/src/main/ipc/database-handlers.ts
@@ -5,8 +5,10 @@ import { telemetryService } from '../services/telemetry-service'
 import {
   setFieldCollectionEnabledCache,
   setMemoryInjectionEnabledCache,
+  setBashOutputCaptureEnabledCache,
   FIELD_COLLECTION_SETTING_KEY,
-  MEMORY_INJECTION_SETTING_KEY
+  MEMORY_INJECTION_SETTING_KEY,
+  BASH_OUTPUT_CAPTURE_SETTING_KEY
 } from '../field/privacy'
 import type {
   ProjectCreate,
@@ -40,6 +42,11 @@ export function registerDatabaseHandlers(): void {
     if (key === MEMORY_INJECTION_SETTING_KEY) {
       setMemoryInjectionEnabledCache(value !== 'false')
     }
+    // Phase 21.5: same pattern for agent bash output capture toggle.
+    // Default OFF — must be literally 'true' to enable.
+    if (key === BASH_OUTPUT_CAPTURE_SETTING_KEY) {
+      setBashOutputCaptureEnabledCache(value === 'true')
+    }
     return true
   })
 
@@ -52,6 +59,10 @@ export function registerDatabaseHandlers(): void {
     // Phase 22C.1: same.
     if (key === MEMORY_INJECTION_SETTING_KEY) {
       setMemoryInjectionEnabledCache(true)
+    }
+    // Phase 21.5: delete reverts bash output capture to default OFF.
+    if (key === BASH_OUTPUT_CAPTURE_SETTING_KEY) {
+      setBashOutputCaptureEnabledCache(false)
     }
     return true
   })

--- a/src/main/services/claude-code-implementer.ts
+++ b/src/main/services/claude-code-implementer.ts
@@ -1068,6 +1068,17 @@ export class ClaudeCodeImplementer implements AgentSdkImplementer, AgentRuntimeA
                       isError: !!tr.is_error,
                       hasOutput: !!output
                     })
+
+                    // Phase 21.5: emit agent.* field event when a tool_use
+                    // completes. Wrapped in try/catch — instrumentation
+                    // failure must never break the merge.
+                    try {
+                      this.emitAgentToolField(session, tu, tr, output)
+                    } catch (err) {
+                      log.debug('Phase 21.5 emit failed; continuing', {
+                        error: err instanceof Error ? err.message : String(err)
+                      })
+                    }
                   }
                 }
               }
@@ -4082,5 +4093,54 @@ export class ClaudeCodeImplementer implements AgentSdkImplementer, AgentRuntimeA
         }
       }
     }
+  }
+
+  /**
+   * Phase 21.5: emit an agent.* field event when a tool_use → tool_result
+   * cycle completes. The shape of `tu` (toolUse) is the merged in-flight
+   * draft: `{ id, name, input, output, error, status, startTime, ... }`.
+   *
+   * Sub-agent calls are already filtered upstream (isSubagentMessage check
+   * in the tool_result merge block).
+   */
+  private emitAgentToolField(
+    session: ClaudeSessionState,
+    tu: Record<string, unknown>,
+    tr: { tool_use_id?: string; is_error?: boolean },
+    output: string | undefined
+  ): void {
+    if (!this.dbService) return
+    const worktreeRow = this.dbService.getWorktreeByPath(session.worktreePath)
+    if (!worktreeRow) return
+
+    const toolName = (tu.name as string) ?? 'unknown'
+    const toolUseId = (tu.id as string) ?? tr.tool_use_id ?? ''
+    const input = (tu.input as Record<string, unknown> | undefined) ?? {}
+    const startTime = (tu.startTime as number | undefined) ?? null
+    const durationMs = startTime ? Date.now() - startTime : undefined
+
+    // Lazy import to keep the module-level dep graph small.
+    void import('../field/emit-agent-tool').then(({ emitAgentToolEvent }) => {
+      emitAgentToolEvent({
+        worktreeId: worktreeRow.id,
+        projectId: worktreeRow.project_id ?? null,
+        sessionId: session.hiveSessionId,
+        worktreePath: session.worktreePath,
+        toolName,
+        toolUseId,
+        // Sub-agent already filtered at the message level; stays null.
+        parentToolUseId: null,
+        input,
+        output: {
+          text: tr.is_error ? undefined : output,
+          error: tr.is_error ? output : undefined,
+          // TODO Phase 21.5+: parse structured exit_code from Bash
+          // tool_result when the SDK exposes it. For now we use is_error
+          // as a 0/1 signal.
+          exitCode: tr.is_error ? 1 : undefined,
+          durationMs
+        }
+      })
+    })
   }
 }

--- a/src/main/services/codex-implementer.ts
+++ b/src/main/services/codex-implementer.ts
@@ -207,6 +207,19 @@ export class CodexImplementer implements AgentSdkImplementer, AgentRuntimeAdapte
     const targetSession = this.findSessionByThreadId(event.threadId)
     if (targetSession) {
       this.persistActivity(targetSession, event)
+
+      // Phase 21.5: emit agent.* field events when a tool item completes.
+      // Wrapped in try/catch — instrumentation failure must never affect
+      // the main event flow.
+      if (event.kind === 'notification' && event.method === 'item/completed') {
+        try {
+          this.emitAgentToolField(targetSession, event)
+        } catch (err) {
+          log.debug('Phase 21.5 emit failed; continuing', {
+            error: err instanceof Error ? err.message : String(err)
+          })
+        }
+      }
     }
 
     // Clean up stale pending entries when a session closes
@@ -2388,5 +2401,69 @@ export class CodexImplementer implements AgentSdkImplementer, AgentRuntimeAdapte
         return a.order - b.order
       })
       .map((entry) => entry.message)
+  }
+
+  /**
+   * Phase 21.5: emit an agent.* field event when a Codex tool item completes.
+   * Called from handleManagerEvent on `item/completed` notifications.
+   *
+   * Codex tool lifecycle items are `commandExecution` (Bash) and `fileChange`
+   * (apply_patch); anything else is ignored by `isToolLifecycleItem`.
+   */
+  private emitAgentToolField(
+    session: CodexSessionState,
+    event: CodexManagerEvent
+  ): void {
+    if (!this.dbService) return
+
+    const payload = asObject(event.payload)
+    const item = asObject(payload?.item)
+    if (!item) return
+
+    const itemType = asString(item?.type)?.toLowerCase()
+    // Only emit for the tool lifecycle itemTypes Codex uses. Non-tool items
+    // (agentMessage / reasoning / plan) are ignored.
+    if (itemType !== 'commandexecution' && itemType !== 'filechange') return
+
+    const toolName =
+      asString(item?.toolName) ??
+      asString(item?.name) ??
+      // Fall back to a canonical name derived from the itemType so the
+      // router in emit-agent-tool.ts knows how to categorize it.
+      (itemType === 'commandexecution' ? 'exec_command' : 'apply_patch')
+
+    const toolUseId =
+      asString(item?.id) ?? asString(event.itemId) ?? asString(payload?.itemId) ?? ''
+    if (!toolUseId) return
+
+    const input = (item?.input as Record<string, unknown> | undefined) ?? {}
+    const status = asString(item?.status)
+    const isError = status === 'failed'
+    const outputText = asString(item?.output) ?? asString(item?.aggregatedOutput) ?? undefined
+    const exitCode = asNumber(item?.exitCode) ?? (isError ? 1 : undefined)
+    const durationMs = asNumber(item?.durationMs) ?? undefined
+
+    const worktreeRow = this.dbService.getWorktreeByPath(session.worktreePath)
+    if (!worktreeRow) return
+
+    void import('../field/emit-agent-tool').then(({ emitAgentToolEvent }) => {
+      emitAgentToolEvent({
+        worktreeId: worktreeRow.id,
+        projectId: worktreeRow.project_id ?? null,
+        sessionId: session.hiveSessionId,
+        worktreePath: session.worktreePath,
+        toolName,
+        toolUseId,
+        // Codex does not surface sub-agent nesting today; V1 stays null.
+        parentToolUseId: null,
+        input,
+        output: {
+          text: isError ? undefined : outputText,
+          error: isError ? outputText : undefined,
+          exitCode,
+          durationMs
+        }
+      })
+    })
   }
 }

--- a/src/main/services/opencode-service.ts
+++ b/src/main/services/opencode-service.ts
@@ -1289,6 +1289,20 @@ class OpenCodeService implements AgentSdkImplementer, AgentRuntimeAdapter {
     }
 
     emitAgentEvent(this.mainWindow, streamEvent)
+
+    // Phase 21.5: emit agent.* field event when a tool part completes.
+    // OpenCode streams tool parts via `message.part.updated`; we only emit
+    // when state.status transitions to a terminal state (completed/error).
+    // Sub-agent / child-session tool calls are skipped entirely (V1).
+    if (eventType === 'message.part.updated' && !isChildEvent) {
+      try {
+        this.maybeEmitAgentToolField(hiveSessionId, event)
+      } catch (err) {
+        log.debug('Phase 21.5 emit failed; continuing', {
+          error: err instanceof Error ? err.message : String(err)
+        })
+      }
+    }
   }
 
   /**
@@ -1530,6 +1544,72 @@ class OpenCodeService implements AgentSdkImplementer, AgentRuntimeAdapter {
   async cleanup(): Promise<void> {
     log.info('Cleaning up OpenCode instance')
     this.shutdownServer()
+  }
+
+  /**
+   * Phase 21.5: emit an agent.* field event when an OpenCode tool part
+   * reaches a terminal state (completed/error).
+   *
+   * OpenCode streams tool parts via `message.part.updated` events. A tool
+   * part carries `{ type: 'tool', callID, tool, state: { status, input,
+   * output, error, time } }`. Non-tool parts (text/reasoning) are ignored.
+   *
+   * Only terminal statuses trigger emission — mid-stream updates would
+   * produce duplicate events for the same tool_use_id.
+   */
+  private maybeEmitAgentToolField(
+    hiveSessionId: string,
+    event: {
+      properties?: {
+        part?: Record<string, unknown>
+      }
+    }
+  ): void {
+    const part = event.properties?.part
+    if (!part || part.type !== 'tool') return
+
+    const state = (part.state as Record<string, unknown> | undefined) ?? {}
+    const status = state.status as string | undefined
+    // Only emit on terminal transitions — avoids double-counting the stream
+    // of 'running' updates OpenCode sends as input_json_delta arrives.
+    if (status !== 'completed' && status !== 'error') return
+
+    const toolUseId = (part.callID as string) || (part.id as string) || ''
+    if (!toolUseId) return
+
+    const toolName = (part.tool as string) || 'unknown'
+    const input = (state.input as Record<string, unknown> | undefined) ?? {}
+    const outputText = state.output as string | undefined
+    const errorText = state.error as string | undefined
+    const stateTime = state.time as Record<string, number> | undefined
+    const durationMs =
+      stateTime?.start && stateTime?.end ? stateTime.end - stateTime.start : undefined
+
+    const db = getDatabase()
+    const hiveSession = db.getSession(hiveSessionId)
+    if (!hiveSession?.worktree_id) return
+    const worktreeRow = db.getWorktree(hiveSession.worktree_id)
+    if (!worktreeRow) return
+
+    void import('../field/emit-agent-tool').then(({ emitAgentToolEvent }) => {
+      emitAgentToolEvent({
+        worktreeId: worktreeRow.id,
+        projectId: worktreeRow.project_id ?? null,
+        sessionId: hiveSessionId,
+        worktreePath: worktreeRow.path,
+        toolName,
+        toolUseId,
+        // Child/subagent events are filtered at the caller (`!isChildEvent`).
+        parentToolUseId: null,
+        input,
+        output: {
+          text: status === 'error' ? undefined : outputText,
+          error: status === 'error' ? errorText ?? outputText : undefined,
+          exitCode: status === 'error' ? 1 : undefined,
+          durationMs
+        }
+      })
+    })
   }
 }
 

--- a/src/renderer/src/components/settings/SettingsPrivacy.tsx
+++ b/src/renderer/src/components/settings/SettingsPrivacy.tsx
@@ -7,6 +7,7 @@ import { toast } from 'sonner'
 
 const FIELD_COLLECTION_SETTING_KEY = 'field_collection_enabled'
 const MEMORY_INJECTION_SETTING_KEY = 'include_memory_in_prompts'
+const BASH_OUTPUT_CAPTURE_SETTING_KEY = 'agent_bash_capture_output'
 
 interface ToggleProps {
   label: string
@@ -47,6 +48,7 @@ export function SettingsPrivacy(): React.JSX.Element {
   const [analyticsEnabled, setAnalyticsEnabled] = useState(true)
   const [fieldCollectionEnabled, setFieldCollectionEnabled] = useState(true)
   const [memoryInjectionEnabled, setMemoryInjectionEnabled] = useState(true)
+  const [bashOutputCaptureEnabled, setBashOutputCaptureEnabled] = useState(false)
   const [loaded, setLoaded] = useState(false)
   const [platform, setPlatform] = useState<string | null>(null)
   const [fdaStatus, setFdaStatus] = useState<{ supported: boolean; granted: boolean } | null>(null)
@@ -57,12 +59,16 @@ export function SettingsPrivacy(): React.JSX.Element {
     void Promise.all([
       window.analyticsOps.isEnabled().catch(() => true),
       window.db.setting.get(FIELD_COLLECTION_SETTING_KEY).catch(() => null),
-      window.db.setting.get(MEMORY_INJECTION_SETTING_KEY).catch(() => null)
-    ]).then(([analytics, fieldRaw, memoryRaw]) => {
+      window.db.setting.get(MEMORY_INJECTION_SETTING_KEY).catch(() => null),
+      window.db.setting.get(BASH_OUTPUT_CAPTURE_SETTING_KEY).catch(() => null)
+    ]).then(([analytics, fieldRaw, memoryRaw, bashRaw]) => {
       setAnalyticsEnabled(analytics)
       // Default ON when absent or any value other than the literal 'false'
       setFieldCollectionEnabled(fieldRaw !== 'false')
       setMemoryInjectionEnabled(memoryRaw !== 'false')
+      // Phase 21.5: default OFF — must be literally 'true' to enable, since
+      // bash output can contain secrets (API keys, env dumps, error tokens).
+      setBashOutputCaptureEnabled(bashRaw === 'true')
       setLoaded(true)
     })
   }, [])
@@ -128,6 +134,12 @@ export function SettingsPrivacy(): React.JSX.Element {
     void window.db.setting.set(MEMORY_INJECTION_SETTING_KEY, String(newValue))
   }
 
+  const handleBashOutputCaptureToggle = (): void => {
+    const newValue = !bashOutputCaptureEnabled
+    setBashOutputCaptureEnabled(newValue)
+    void window.db.setting.set(BASH_OUTPUT_CAPTURE_SETTING_KEY, String(newValue))
+  }
+
   const handleOpenFdaSettings = async (): Promise<void> => {
     const result = await window.systemOps.openFullDiskAccessSettings()
     if (!result.success) {
@@ -164,6 +176,12 @@ export function SettingsPrivacy(): React.JSX.Element {
           description={t('settings.privacy.memoryInjection.description')}
           enabled={memoryInjectionEnabled}
           onToggle={handleMemoryInjectionToggle}
+        />
+        <Toggle
+          label={t('settings.privacy.bashOutputCapture.label')}
+          description={t('settings.privacy.bashOutputCapture.description')}
+          enabled={bashOutputCaptureEnabled}
+          onToggle={handleBashOutputCaptureToggle}
         />
       </div>
 

--- a/src/renderer/src/i18n/messages.ts
+++ b/src/renderer/src/i18n/messages.ts
@@ -252,6 +252,11 @@ export const messages: Record<AppLocale, MessageTree> = {
           description:
             'Read .xuanpu/memory.md (project-level, in your worktree) and ~/.xuanpu/memory.md (global) and prepend them to agent prompts. Local-only.'
         },
+        bashOutputCapture: {
+          label: 'Capture agent Bash stdout/stderr',
+          description:
+            "When the agent runs a shell command, also store the first 1 KB of stdout and last 1 KB of stderr in the local event log. Default OFF because command output often contains API keys, env dumps, or error stacks with tokens. The command text itself is always captured regardless of this setting."
+        },
         fda: {
           title: 'Full Disk Access',
           description: 'Helps Xuanpu and agent runtimes read files in protected macOS locations.',
@@ -2532,6 +2537,11 @@ export const messages: Record<AppLocale, MessageTree> = {
           label: '把 memory.md 注入到 AI prompt',
           description:
             '读取 .xuanpu/memory.md(worktree 级)和 ~/.xuanpu/memory.md(全局),把它们拼到 AI prompt 最前面。数据只保存在本机。'
+        },
+        bashOutputCapture: {
+          label: '采集 Agent Bash 的 stdout/stderr',
+          description:
+            'Agent 跑 shell 命令时,把 stdout 前 1KB 和 stderr 后 1KB 也存进本地事件日志。默认关闭,因为命令输出常含 API key、env dump、带 token 的错误堆栈。命令本身无论此开关如何都会被采集。'
         },
         fda: {
           title: '完全磁盘访问权限',

--- a/src/shared/types/field-event.ts
+++ b/src/shared/types/field-event.ts
@@ -16,6 +16,10 @@ export type FieldEventType =
   | 'terminal.command'
   | 'terminal.output'
   | 'session.message'
+  | 'agent.file_read'
+  | 'agent.file_write'
+  | 'agent.file_search'
+  | 'agent.bash_exec'
 
 /**
  * Common envelope shared by all field events.
@@ -118,6 +122,72 @@ export interface SessionMessagePayload {
 }
 
 // ---------------------------------------------------------------------------
+// Agent tool events (Phase 21.5)
+//
+// Captured when a runtime adapter (Claude Code / Codex / OpenCode) observes
+// a tool_use → tool_result completion. Lets fully-delegated users (where the
+// agent does all reads/edits/commands) populate hot_files, Current Focus,
+// and the Phase 24C session checkpoint.
+//
+// Sub-agent / Task-tool nested events are SKIPPED at emit time (V1) — only
+// outermost-session tool calls are captured.
+//
+// `toolUseId` is mandatory in every payload as a join key for future
+// Outcome Loop attribution (e.g. linking a test_pass back to the bash
+// command that triggered it).
+// ---------------------------------------------------------------------------
+
+export interface AgentFileReadPayload {
+  /** Tool-use id from the SDK (Claude block.id / Codex item.id / OpenCode part id). */
+  toolUseId: string
+  /** Tool name as reported by the SDK (Read / NotebookRead / file_read). */
+  toolName: string
+  /** Path relative to the worktree root. Never a glob — Glob/Grep emit `agent.file_search` instead. */
+  path: string
+  /** Bytes returned by the read, if known. */
+  bytes: number | null
+}
+
+export interface AgentFileWritePayload {
+  toolUseId: string
+  toolName: string
+  path: string
+  /**
+   * V1: always 'edit'. Future Outcome Loop may refine to
+   * 'create' | 'edit' | 'delete' once file-existed-before detection is
+   * implemented. Single-value union is forward-compatible.
+   */
+  operation: 'edit'
+}
+
+export interface AgentFileSearchPayload {
+  toolUseId: string
+  toolName: string
+  /** The glob/regex pattern as given to the tool (truncated 512 chars). */
+  pattern: string
+  /** Number of matches returned, if known. */
+  matchCount: number | null
+}
+
+export interface AgentBashExecPayload {
+  toolUseId: string
+  toolName: string
+  /** First 512 chars of the command. */
+  command: string
+  exitCode: number | null
+  durationMs: number | null
+  /**
+   * First 1024 chars of stdout. Only populated when the user has explicitly
+   * opted into bash output capture (Settings → Privacy → "Capture Bash
+   * stdout/stderr for agent analysis"). Default OFF — bash output frequently
+   * contains secrets (API keys, env dumps, error stacks with tokens).
+   */
+  stdoutHead: string | null
+  /** Last 1024 chars of stderr. Same opt-in rule as stdoutHead. */
+  stderrTail: string | null
+}
+
+// ---------------------------------------------------------------------------
 // Discriminated union
 // ---------------------------------------------------------------------------
 
@@ -129,6 +199,10 @@ export type FieldEvent =
   | (FieldEventEnvelope & { type: 'terminal.command'; payload: TerminalCommandPayload })
   | (FieldEventEnvelope & { type: 'terminal.output'; payload: TerminalOutputPayload })
   | (FieldEventEnvelope & { type: 'session.message'; payload: SessionMessagePayload })
+  | (FieldEventEnvelope & { type: 'agent.file_read'; payload: AgentFileReadPayload })
+  | (FieldEventEnvelope & { type: 'agent.file_write'; payload: AgentFileWritePayload })
+  | (FieldEventEnvelope & { type: 'agent.file_search'; payload: AgentFileSearchPayload })
+  | (FieldEventEnvelope & { type: 'agent.bash_exec'; payload: AgentBashExecPayload })
 
 /**
  * Renderer-side input for the narrow `field:reportWorktreeSwitch` IPC channel.

--- a/test/phase-21-5/consumers.test.ts
+++ b/test/phase-21-5/consumers.test.ts
@@ -1,0 +1,342 @@
+/**
+ * Phase 21.5 downstream consumer integration tests — ensure agent.* events
+ * correctly flow through rankHotFiles + deriveFocus + editCount.
+ *
+ * These cover the "full-delegation user" case where only agent events
+ * exist (no file.focus / file.selection), which was previously broken.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'fs'
+
+vi.mock('@shared/app-identity', () => ({
+  getActiveAppDatabasePath: (home: string) => join(home, '.xuanpu', 'test.db'),
+  APP_BUNDLE_ID: 'test',
+  APP_CLI_NAME: 'test',
+  APP_PRODUCT_NAME: 'test'
+}))
+
+vi.mock('../../src/main/services/logger', () => ({
+  createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })
+}))
+
+vi.mock('../../src/main/db', async () => {
+  const actual =
+    await vi.importActual<typeof import('../../src/main/db')>('../../src/main/db')
+  return {
+    ...actual,
+    getDatabase: () => {
+      const g = globalThis as unknown as {
+        __checkpointTestDb?: import('../../src/main/db/database').DatabaseService
+      }
+      if (!g.__checkpointTestDb) throw new Error('test DB not initialized')
+      return g.__checkpointTestDb
+    }
+  }
+})
+
+import type { StoredFieldEvent } from '../../src/main/field/repository'
+import {
+  rankHotFiles,
+  generateCheckpoint,
+  type GitProbe
+} from '../../src/main/field/checkpoint-generator'
+import { DatabaseService } from '../../src/main/db/database'
+
+let tmpDir: string
+let worktreePath: string
+let db: DatabaseService
+let seqCounter = 0
+
+const mkEvent = (
+  payload: unknown,
+  type: StoredFieldEvent['type'],
+  ts = Date.now(),
+  id?: string
+): StoredFieldEvent => ({
+  id: id ?? `e-${++seqCounter}`,
+  seq: seqCounter,
+  timestamp: ts,
+  worktreeId: 'w-1',
+  projectId: null,
+  sessionId: 's-1',
+  relatedEventId: null,
+  type,
+  payload
+})
+
+function touchFile(rel: string, content = 'x'): void {
+  const abs = join(worktreePath, rel)
+  mkdirSync(join(abs, '..'), { recursive: true })
+  writeFileSync(abs, content)
+}
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'xuanpu-phase21-5-consumers-'))
+  worktreePath = join(tmpDir, 'wt')
+  mkdirSync(worktreePath, { recursive: true })
+  db = new DatabaseService(join(tmpDir, 't.db'))
+  db.init()
+  ;(globalThis as unknown as { __checkpointTestDb: DatabaseService }).__checkpointTestDb = db
+})
+
+afterEach(() => {
+  db.close()
+  delete (globalThis as { __checkpointTestDb?: DatabaseService }).__checkpointTestDb
+  rmSync(tmpDir, { recursive: true, force: true })
+})
+
+// ─── rankHotFiles with agent events ────────────────────────────────────────
+
+describe('rankHotFiles — agent event scoring (Phase 21.5)', () => {
+  it('agent.file_write scores 3 points (strongest signal)', () => {
+    touchFile('src/a.ts')
+    touchFile('src/b.ts')
+    const events = [
+      mkEvent({ toolUseId: 'tu-1', toolName: 'Edit', path: 'src/a.ts', operation: 'edit' }, 'agent.file_write'),
+      mkEvent({ path: join(worktreePath, 'src/b.ts'), name: 'b.ts', fromPath: null }, 'file.focus')
+    ]
+    const hot = rankHotFiles(events, worktreePath)
+    // a.ts (write=3) should rank higher than b.ts (focus=1)
+    expect(hot[0]).toBe('src/a.ts')
+    expect(hot[1]).toBe('src/b.ts')
+  })
+
+  it('agent.file_read scores 1 point (weakest signal)', () => {
+    touchFile('a.ts')
+    touchFile('b.ts')
+    const events = [
+      mkEvent({ toolUseId: 'tu-1', toolName: 'Read', path: 'a.ts', bytes: 100 }, 'agent.file_read'),
+      mkEvent({ toolUseId: 'tu-2', toolName: 'Read', path: 'a.ts', bytes: 200 }, 'agent.file_read'),
+      mkEvent(
+        { path: join(worktreePath, 'b.ts'), fromLine: 1, toLine: 5, length: 50 },
+        'file.selection'
+      )
+    ]
+    // a.ts: read+read = 2; b.ts: selection = 2 — tie, both included
+    const hot = rankHotFiles(events, worktreePath)
+    expect(hot.sort()).toEqual(['a.ts', 'b.ts'])
+  })
+
+  it('agent.file_search (glob pattern) does NOT contribute to hot_files', () => {
+    touchFile('a.ts')
+    const events = [
+      mkEvent(
+        { toolUseId: 'tu-1', toolName: 'Glob', pattern: '**/*.ts', matchCount: 50 },
+        'agent.file_search'
+      ),
+      mkEvent({ toolUseId: 'tu-2', toolName: 'Read', path: 'a.ts', bytes: 100 }, 'agent.file_read')
+    ]
+    const hot = rankHotFiles(events, worktreePath)
+    // Only a.ts (from file_read); glob pattern was NOT stat()ed or added.
+    expect(hot).toEqual(['a.ts'])
+  })
+
+  it('agent.bash_exec does NOT contribute to hot_files', () => {
+    touchFile('a.ts')
+    const events = [
+      mkEvent(
+        {
+          toolUseId: 'tu-1',
+          toolName: 'Bash',
+          command: 'pnpm test',
+          exitCode: 0,
+          durationMs: 1234,
+          stdoutHead: null,
+          stderrTail: null
+        },
+        'agent.bash_exec'
+      ),
+      mkEvent({ toolUseId: 'tu-2', toolName: 'Read', path: 'a.ts', bytes: 100 }, 'agent.file_read')
+    ]
+    expect(rankHotFiles(events, worktreePath)).toEqual(['a.ts'])
+  })
+
+  it('full-delegation user (no human events) still populates hot_files', () => {
+    touchFile('src/auth/refresh.ts')
+    touchFile('src/auth/index.ts')
+    touchFile('test/auth.test.ts')
+    const events = [
+      mkEvent(
+        { toolUseId: 'tu-1', toolName: 'Read', path: 'src/auth/refresh.ts', bytes: 500 },
+        'agent.file_read'
+      ),
+      mkEvent(
+        {
+          toolUseId: 'tu-2',
+          toolName: 'Edit',
+          path: 'src/auth/refresh.ts',
+          operation: 'edit'
+        },
+        'agent.file_write'
+      ),
+      mkEvent(
+        { toolUseId: 'tu-3', toolName: 'Read', path: 'src/auth/index.ts', bytes: 300 },
+        'agent.file_read'
+      ),
+      mkEvent(
+        { toolUseId: 'tu-4', toolName: 'Edit', path: 'test/auth.test.ts', operation: 'edit' },
+        'agent.file_write'
+      )
+    ]
+    const hot = rankHotFiles(events, worktreePath)
+    // refresh.ts: read+write = 4; test/auth.test.ts: write = 3; index.ts: read = 1
+    expect(hot[0]).toBe('src/auth/refresh.ts')
+    expect(hot.slice(1).sort()).toEqual(['src/auth/index.ts', 'test/auth.test.ts'])
+  })
+
+  it('filters out agent.file_write paths whose file does not exist', () => {
+    touchFile('exists.ts')
+    const events = [
+      mkEvent(
+        { toolUseId: 'tu-1', toolName: 'Edit', path: 'exists.ts', operation: 'edit' },
+        'agent.file_write'
+      ),
+      mkEvent(
+        { toolUseId: 'tu-2', toolName: 'Edit', path: 'gone.ts', operation: 'edit' },
+        'agent.file_write'
+      )
+    ]
+    expect(rankHotFiles(events, worktreePath)).toEqual(['exists.ts'])
+  })
+})
+
+// ─── generateCheckpoint editCount / commandCount (Phase 21.5) ──────────────
+
+describe('generateCheckpoint stats — agent event counting (Phase 21.5)', () => {
+  const mockGit: GitProbe = {
+    revParseHead: async () => null,
+    abbrevRefHead: async () => null
+  }
+
+  function insertEvents(rows: StoredFieldEvent[]): void {
+    const stmt = db.getDbHandle().prepare(
+      `INSERT INTO field_events (id, timestamp, worktree_id, project_id,
+         session_id, type, related_event_id, payload_json)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+    )
+    for (const r of rows) {
+      stmt.run(
+        r.id,
+        r.timestamp,
+        r.worktreeId,
+        r.projectId,
+        r.sessionId,
+        r.type,
+        r.relatedEventId,
+        JSON.stringify(r.payload)
+      )
+    }
+  }
+
+  it('editCount includes distinct agent-touched files', async () => {
+    touchFile('a.ts')
+    touchFile('b.ts')
+    const now = 10 * 60_000 // 10 min
+    insertEvents([
+      mkEvent(
+        { toolUseId: 'tu-1', toolName: 'Edit', path: 'a.ts', operation: 'edit' },
+        'agent.file_write',
+        now - 5_000
+      ),
+      mkEvent(
+        { toolUseId: 'tu-2', toolName: 'Read', path: 'b.ts', bytes: 100 },
+        'agent.file_read',
+        now - 4_000
+      )
+    ])
+
+    const rec = await generateCheckpoint(
+      { worktreeId: 'w-1', worktreePath, sessionId: 's-1', source: 'abort', now: () => now },
+      mockGit
+    )
+    expect(rec!.summary).toContain('2 files edited')
+  })
+
+  it('commandCount includes agent.bash_exec', async () => {
+    touchFile('a.ts')
+    const now = 10 * 60_000
+    insertEvents([
+      mkEvent(
+        { toolUseId: 'tu-1', toolName: 'Read', path: 'a.ts', bytes: 10 },
+        'agent.file_read',
+        now - 5_000
+      ),
+      mkEvent(
+        {
+          toolUseId: 'tu-2',
+          toolName: 'Bash',
+          command: 'pnpm test',
+          exitCode: 0,
+          durationMs: 100,
+          stdoutHead: null,
+          stderrTail: null
+        },
+        'agent.bash_exec',
+        now - 3_000
+      ),
+      mkEvent(
+        {
+          toolUseId: 'tu-3',
+          toolName: 'Bash',
+          command: 'pnpm build',
+          exitCode: 0,
+          durationMs: 200,
+          stdoutHead: null,
+          stderrTail: null
+        },
+        'agent.bash_exec',
+        now - 2_000
+      )
+    ])
+
+    const rec = await generateCheckpoint(
+      { worktreeId: 'w-1', worktreePath, sessionId: 's-1', source: 'abort', now: () => now },
+      mockGit
+    )
+    expect(rec!.summary).toContain('2 commands run')
+  })
+
+  it('full-delegation: only agent events → checkpoint still populated', async () => {
+    touchFile('src/auth.ts')
+    const now = 10 * 60_000
+    insertEvents([
+      mkEvent(
+        { toolUseId: 'tu-1', toolName: 'Read', path: 'src/auth.ts', bytes: 500 },
+        'agent.file_read',
+        now - 5_000
+      ),
+      mkEvent(
+        {
+          toolUseId: 'tu-2',
+          toolName: 'Edit',
+          path: 'src/auth.ts',
+          operation: 'edit'
+        },
+        'agent.file_write',
+        now - 3_000
+      ),
+      mkEvent(
+        {
+          text: 'refactor auth module\nTODO: add retry',
+          agentSdk: 'claude-code',
+          agentSessionId: 's-1',
+          attachmentCount: 0
+        },
+        'session.message',
+        now - 1_000
+      )
+    ])
+
+    const rec = await generateCheckpoint(
+      { worktreeId: 'w-1', worktreePath, sessionId: 's-1', source: 'abort', now: () => now },
+      mockGit
+    )
+    expect(rec).not.toBeNull()
+    expect(rec!.hotFiles).toContain('src/auth.ts')
+    expect(rec!.hotFileDigests!['src/auth.ts']).toMatch(/^[a-f0-9]{40}$/)
+    expect(rec!.currentGoal).toBe('refactor auth module')
+    expect(rec!.nextAction).toContain('TODO')
+  })
+})

--- a/test/phase-21-5/derive-focus.test.ts
+++ b/test/phase-21-5/derive-focus.test.ts
@@ -1,0 +1,216 @@
+/**
+ * Phase 21.5 — context-builder deriveFocus integration test.
+ *
+ * Verifies that the Field Context's `## Current Focus` section correctly
+ * falls back to agent.file_write/agent.file_read when no human focus
+ * events exist (the full-delegation user case).
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { mkdtempSync, rmSync, mkdirSync } from 'fs'
+
+vi.mock('@shared/app-identity', () => ({
+  getActiveAppDatabasePath: (home: string) => join(home, '.xuanpu', 'test.db'),
+  APP_BUNDLE_ID: 'test',
+  APP_CLI_NAME: 'test',
+  APP_PRODUCT_NAME: 'test'
+}))
+
+vi.mock('../../src/main/services/logger', () => ({
+  createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })
+}))
+
+vi.mock('electron', () => ({ app: undefined }))
+
+vi.mock('../../src/main/db', async () => {
+  const actual =
+    await vi.importActual<typeof import('../../src/main/db')>('../../src/main/db')
+  return {
+    ...actual,
+    getDatabase: () => {
+      const g = globalThis as unknown as {
+        __checkpointTestDb?: import('../../src/main/db/database').DatabaseService
+      }
+      if (!g.__checkpointTestDb) throw new Error('test DB not initialized')
+      return g.__checkpointTestDb
+    }
+  }
+})
+
+vi.mock('../../src/main/field/privacy', () => ({
+  isFieldCollectionEnabled: vi.fn(() => true),
+  isMemoryInjectionEnabled: vi.fn(() => true)
+}))
+
+import { DatabaseService } from '../../src/main/db/database'
+import { buildFieldContextSnapshot } from '../../src/main/field/context-builder'
+
+let tmpDir: string
+let worktreePath: string
+let db: DatabaseService
+
+async function seedWorktree(): Promise<void> {
+  const nowIso = new Date().toISOString()
+  db.getDbHandle()
+    .prepare(
+      `INSERT INTO projects (id, name, path, created_at, last_accessed_at)
+       VALUES ('p-1', 'p', ?, ?, ?)`
+    )
+    .run(worktreePath, nowIso, nowIso)
+  db.getDbHandle()
+    .prepare(
+      `INSERT INTO worktrees (id, project_id, name, branch_name, path, status,
+         is_default, created_at, last_accessed_at)
+       VALUES ('w-1', 'p-1', 'wt', 'main', ?, 'active', 0, ?, ?)`
+    )
+    .run(worktreePath, nowIso, nowIso)
+}
+
+function emitEvent(
+  type: string,
+  payload: unknown,
+  ts: number,
+  id = `e-${Math.random().toString(36).slice(2, 10)}`
+): void {
+  db.getDbHandle()
+    .prepare(
+      `INSERT INTO field_events (id, timestamp, worktree_id, project_id,
+         session_id, type, related_event_id, payload_json)
+       VALUES (?, ?, 'w-1', 'p-1', 's-1', ?, NULL, ?)`
+    )
+    .run(id, ts, type, JSON.stringify(payload))
+}
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'xuanpu-phase21-5-focus-'))
+  worktreePath = join(tmpDir, 'wt')
+  mkdirSync(worktreePath, { recursive: true })
+  db = new DatabaseService(join(tmpDir, 't.db'))
+  db.init()
+  ;(globalThis as unknown as { __checkpointTestDb: DatabaseService }).__checkpointTestDb = db
+})
+
+afterEach(() => {
+  db.close()
+  delete (globalThis as { __checkpointTestDb?: DatabaseService }).__checkpointTestDb
+  rmSync(tmpDir, { recursive: true, force: true })
+})
+
+describe('deriveFocus — agent fallback (Phase 21.5)', () => {
+  it('full-delegation: only agent.file_write → focus.file populated', async () => {
+    await seedWorktree()
+    const now = Date.now() - 30_000 // within window
+    emitEvent(
+      'agent.file_write',
+      { toolUseId: 'tu-1', toolName: 'Edit', path: 'src/auth.ts', operation: 'edit' },
+      now
+    )
+    const snap = await buildFieldContextSnapshot({ worktreeId: 'w-1' })
+    expect(snap!.focus.file).not.toBeNull()
+    expect(snap!.focus.file!.path).toBe('src/auth.ts')
+    expect(snap!.focus.file!.name).toBe('auth.ts')
+  })
+
+  it('agent.file_write outranks agent.file_read in fallback chain', async () => {
+    await seedWorktree()
+    const now = Date.now() - 30_000
+    emitEvent(
+      'agent.file_read',
+      { toolUseId: 'tu-1', toolName: 'Read', path: 'reading.ts', bytes: 100 },
+      now
+    )
+    emitEvent(
+      'agent.file_write',
+      { toolUseId: 'tu-2', toolName: 'Edit', path: 'writing.ts', operation: 'edit' },
+      now + 1000
+    )
+    const snap = await buildFieldContextSnapshot({ worktreeId: 'w-1' })
+    // Both write and read exist → write wins
+    expect(snap!.focus.file!.path).toBe('writing.ts')
+  })
+
+  it('agent.file_read alone → fallback used', async () => {
+    await seedWorktree()
+    const now = Date.now() - 30_000
+    emitEvent(
+      'agent.file_read',
+      { toolUseId: 'tu-1', toolName: 'Read', path: 'src/lib.ts', bytes: 200 },
+      now
+    )
+    const snap = await buildFieldContextSnapshot({ worktreeId: 'w-1' })
+    expect(snap!.focus.file!.path).toBe('src/lib.ts')
+  })
+
+  it('human file.focus wins over agent events (no fallback when human signal exists)', async () => {
+    await seedWorktree()
+    const now = Date.now() - 30_000
+    emitEvent(
+      'agent.file_write',
+      { toolUseId: 'tu-1', toolName: 'Edit', path: 'agent-edited.ts', operation: 'edit' },
+      now
+    )
+    emitEvent(
+      'file.focus',
+      { path: '/abs/human-focused.ts', name: 'human-focused.ts', fromPath: null },
+      now + 5000
+    )
+    const snap = await buildFieldContextSnapshot({ worktreeId: 'w-1' })
+    // Human signal exists → fallback skipped, human path used
+    expect(snap!.focus.file!.path).toBe('/abs/human-focused.ts')
+  })
+
+  it('agent.file_search does NOT populate focus (search is not focus)', async () => {
+    await seedWorktree()
+    const now = Date.now() - 30_000
+    emitEvent(
+      'agent.file_search',
+      { toolUseId: 'tu-1', toolName: 'Glob', pattern: '**/*.ts', matchCount: 50 },
+      now
+    )
+    const snap = await buildFieldContextSnapshot({ worktreeId: 'w-1' })
+    expect(snap!.focus.file).toBeNull()
+  })
+
+  it('agent.bash_exec does NOT populate focus', async () => {
+    await seedWorktree()
+    const now = Date.now() - 30_000
+    emitEvent(
+      'agent.bash_exec',
+      {
+        toolUseId: 'tu-1',
+        toolName: 'Bash',
+        command: 'pnpm test',
+        exitCode: 0,
+        durationMs: 100,
+        stdoutHead: null,
+        stderrTail: null
+      },
+      now
+    )
+    const snap = await buildFieldContextSnapshot({ worktreeId: 'w-1' })
+    expect(snap!.focus.file).toBeNull()
+  })
+
+  it('latest agent.file_write wins (last-event semantics)', async () => {
+    await seedWorktree()
+    const now = Date.now() - 30_000
+    emitEvent(
+      'agent.file_write',
+      { toolUseId: 'tu-1', toolName: 'Edit', path: 'first.ts', operation: 'edit' },
+      now
+    )
+    emitEvent(
+      'agent.file_write',
+      { toolUseId: 'tu-2', toolName: 'Edit', path: 'second.ts', operation: 'edit' },
+      now + 1000
+    )
+    emitEvent(
+      'agent.file_write',
+      { toolUseId: 'tu-3', toolName: 'Edit', path: 'third.ts', operation: 'edit' },
+      now + 2000
+    )
+    const snap = await buildFieldContextSnapshot({ worktreeId: 'w-1' })
+    expect(snap!.focus.file!.path).toBe('third.ts')
+  })
+})

--- a/test/phase-21-5/emit-agent-tool.test.ts
+++ b/test/phase-21-5/emit-agent-tool.test.ts
@@ -1,0 +1,467 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
+
+vi.mock('../../src/main/db', () => ({
+  getDatabase: vi.fn()
+}))
+
+vi.mock('../../src/main/services/logger', () => ({
+  createLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn()
+  })
+}))
+
+import { emitAgentToolEvent } from '../../src/main/field/emit-agent-tool'
+import { getFieldEventSink, resetFieldEventSink } from '../../src/main/field/sink'
+import {
+  invalidatePrivacyCache,
+  setFieldCollectionEnabledCache,
+  setBashOutputCaptureEnabledCache
+} from '../../src/main/field/privacy'
+import { resetEventBus } from '../../src/server/event-bus'
+import type { FieldEvent } from '../../src/shared/types/field-event'
+
+const WORKTREE_PATH = '/Users/dev/proj/wt'
+
+function captureLastEnqueued(): FieldEvent | null {
+  const sink = getFieldEventSink()
+  let last: FieldEvent | null = null
+  vi.spyOn(sink, 'enqueue').mockImplementation((evt: FieldEvent) => {
+    last = evt
+    return undefined as unknown as void
+  })
+  return new Proxy(
+    {},
+    {
+      get: (_t, prop) => (prop === 'value' ? last : undefined)
+    }
+  ) as { value: FieldEvent | null }
+}
+
+beforeEach(() => {
+  resetFieldEventSink()
+  resetEventBus()
+  invalidatePrivacyCache()
+  setFieldCollectionEnabledCache(true)
+  setBashOutputCaptureEnabledCache(false) // default OFF
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+// ─── Sub-agent skip ─────────────────────────────────────────────────────────
+
+describe('emitAgentToolEvent — sub-agent skip (Phase 21.5)', () => {
+  it('returns null and emits nothing when parentToolUseId is set', () => {
+    const sink = getFieldEventSink()
+    const spy = vi.spyOn(sink, 'enqueue')
+    const id = emitAgentToolEvent({
+      worktreeId: 'w-1',
+      projectId: 'p-1',
+      sessionId: 's-1',
+      worktreePath: WORKTREE_PATH,
+      toolName: 'Read',
+      toolUseId: 'tu-1',
+      parentToolUseId: 'tu-parent',
+      input: { file_path: '/Users/dev/proj/wt/src/a.ts' }
+    })
+    expect(id).toBeNull()
+    expect(spy).not.toHaveBeenCalled()
+  })
+
+  it('emits when parentToolUseId is null/undefined', () => {
+    const sink = getFieldEventSink()
+    const spy = vi.spyOn(sink, 'enqueue')
+    const id = emitAgentToolEvent({
+      worktreeId: 'w-1',
+      projectId: 'p-1',
+      sessionId: 's-1',
+      worktreePath: WORKTREE_PATH,
+      toolName: 'Read',
+      toolUseId: 'tu-1',
+      input: { file_path: '/Users/dev/proj/wt/src/a.ts' }
+    })
+    expect(id).not.toBeNull()
+    expect(spy).toHaveBeenCalledOnce()
+  })
+})
+
+// ─── Routing by tool name ───────────────────────────────────────────────────
+
+describe('emitAgentToolEvent — tool routing (Phase 21.5)', () => {
+  it('Read → agent.file_read with path relative to worktree', () => {
+    const sink = getFieldEventSink()
+    let captured: FieldEvent | null = null
+    vi.spyOn(sink, 'enqueue').mockImplementation((evt: FieldEvent) => {
+      captured = evt
+    })
+    emitAgentToolEvent({
+      worktreeId: 'w-1',
+      projectId: null,
+      sessionId: null,
+      worktreePath: WORKTREE_PATH,
+      toolName: 'Read',
+      toolUseId: 'tu-1',
+      input: { file_path: '/Users/dev/proj/wt/src/auth.ts' },
+      output: { text: 'file contents' }
+    })
+    expect(captured).not.toBeNull()
+    expect(captured!.type).toBe('agent.file_read')
+    expect((captured!.payload as { path: string }).path).toBe('src/auth.ts')
+    expect((captured!.payload as { bytes: number }).bytes).toBe(13)
+    expect((captured!.payload as { toolUseId: string }).toolUseId).toBe('tu-1')
+  })
+
+  it('Edit → agent.file_write with operation="edit"', () => {
+    const sink = getFieldEventSink()
+    let captured: FieldEvent | null = null
+    vi.spyOn(sink, 'enqueue').mockImplementation((evt: FieldEvent) => {
+      captured = evt
+    })
+    emitAgentToolEvent({
+      worktreeId: 'w-1',
+      projectId: null,
+      sessionId: null,
+      worktreePath: WORKTREE_PATH,
+      toolName: 'Edit',
+      toolUseId: 'tu-2',
+      input: { file_path: '/Users/dev/proj/wt/src/foo.ts' }
+    })
+    expect(captured!.type).toBe('agent.file_write')
+    expect((captured!.payload as { operation: string }).operation).toBe('edit')
+    expect((captured!.payload as { path: string }).path).toBe('src/foo.ts')
+  })
+
+  it('Glob → agent.file_search with pattern (NOT path)', () => {
+    const sink = getFieldEventSink()
+    let captured: FieldEvent | null = null
+    vi.spyOn(sink, 'enqueue').mockImplementation((evt: FieldEvent) => {
+      captured = evt
+    })
+    emitAgentToolEvent({
+      worktreeId: 'w-1',
+      projectId: null,
+      sessionId: null,
+      worktreePath: WORKTREE_PATH,
+      toolName: 'Glob',
+      toolUseId: 'tu-3',
+      input: { pattern: '**/*.ts' },
+      output: { matchCount: 12 }
+    })
+    expect(captured!.type).toBe('agent.file_search')
+    expect((captured!.payload as { pattern: string }).pattern).toBe('**/*.ts')
+    expect((captured!.payload as { matchCount: number }).matchCount).toBe(12)
+    // Critical: no `path` field in agent.file_search payload.
+    expect((captured!.payload as { path?: string }).path).toBeUndefined()
+  })
+
+  it('Bash → agent.bash_exec with command + exitCode + duration', () => {
+    const sink = getFieldEventSink()
+    let captured: FieldEvent | null = null
+    vi.spyOn(sink, 'enqueue').mockImplementation((evt: FieldEvent) => {
+      captured = evt
+    })
+    emitAgentToolEvent({
+      worktreeId: 'w-1',
+      projectId: null,
+      sessionId: null,
+      worktreePath: WORKTREE_PATH,
+      toolName: 'Bash',
+      toolUseId: 'tu-4',
+      input: { command: 'pnpm test src/auth' },
+      output: { exitCode: 0, durationMs: 1234 }
+    })
+    expect(captured!.type).toBe('agent.bash_exec')
+    expect((captured!.payload as { command: string }).command).toBe('pnpm test src/auth')
+    expect((captured!.payload as { exitCode: number }).exitCode).toBe(0)
+    expect((captured!.payload as { durationMs: number }).durationMs).toBe(1234)
+  })
+
+  it.each([
+    ['NotebookRead', 'agent.file_read'],
+    ['file_read', 'agent.file_read'],
+    ['Write', 'agent.file_write'],
+    ['MultiEdit', 'agent.file_write'],
+    ['NotebookEdit', 'agent.file_write'],
+    ['apply_patch', 'agent.file_write'],
+    ['Grep', 'agent.file_search'],
+    ['exec_command', 'agent.bash_exec']
+  ])('routes tool %s → %s', (toolName, expectedType) => {
+    const sink = getFieldEventSink()
+    let captured: FieldEvent | null = null
+    vi.spyOn(sink, 'enqueue').mockImplementation((evt: FieldEvent) => {
+      captured = evt
+    })
+    const isSearch = expectedType === 'agent.file_search'
+    const isBash = expectedType === 'agent.bash_exec'
+    emitAgentToolEvent({
+      worktreeId: 'w-1',
+      projectId: null,
+      sessionId: null,
+      worktreePath: WORKTREE_PATH,
+      toolName,
+      toolUseId: 'tu-x',
+      input: isSearch
+        ? { pattern: 'foo' }
+        : isBash
+          ? { command: 'echo' }
+          : { file_path: '/Users/dev/proj/wt/x.ts' }
+    })
+    expect(captured!.type).toBe(expectedType)
+  })
+
+  it('unknown tool name → no-op (returns null, nothing enqueued)', () => {
+    const sink = getFieldEventSink()
+    const spy = vi.spyOn(sink, 'enqueue')
+    const id = emitAgentToolEvent({
+      worktreeId: 'w-1',
+      projectId: null,
+      sessionId: null,
+      worktreePath: WORKTREE_PATH,
+      toolName: 'WeirdNewTool',
+      toolUseId: 'tu-z',
+      input: { file_path: '/x' }
+    })
+    expect(id).toBeNull()
+    expect(spy).not.toHaveBeenCalled()
+  })
+})
+
+// ─── Glob-string guard for read/write paths ─────────────────────────────────
+
+describe('emitAgentToolEvent — glob guard (Phase 21.5)', () => {
+  it('drops Read with a glob string in file_path', () => {
+    const sink = getFieldEventSink()
+    const spy = vi.spyOn(sink, 'enqueue')
+    const id = emitAgentToolEvent({
+      worktreeId: 'w-1',
+      projectId: null,
+      sessionId: null,
+      worktreePath: WORKTREE_PATH,
+      toolName: 'Read',
+      toolUseId: 'tu-1',
+      input: { file_path: '**/*.ts' }
+    })
+    expect(id).toBeNull()
+    expect(spy).not.toHaveBeenCalled()
+  })
+
+  it('drops Edit with a ? wildcard in path', () => {
+    const sink = getFieldEventSink()
+    const spy = vi.spyOn(sink, 'enqueue')
+    const id = emitAgentToolEvent({
+      worktreeId: 'w-1',
+      projectId: null,
+      sessionId: null,
+      worktreePath: WORKTREE_PATH,
+      toolName: 'Edit',
+      toolUseId: 'tu-1',
+      input: { file_path: 'src/file?.ts' }
+    })
+    expect(id).toBeNull()
+    expect(spy).not.toHaveBeenCalled()
+  })
+
+  it('Glob still works fine with wildcard pattern (not subject to guard)', () => {
+    const sink = getFieldEventSink()
+    const spy = vi.spyOn(sink, 'enqueue')
+    const id = emitAgentToolEvent({
+      worktreeId: 'w-1',
+      projectId: null,
+      sessionId: null,
+      worktreePath: WORKTREE_PATH,
+      toolName: 'Glob',
+      toolUseId: 'tu-1',
+      input: { pattern: '**/*.ts' }
+    })
+    expect(id).not.toBeNull()
+    expect(spy).toHaveBeenCalledOnce()
+  })
+})
+
+// ─── Privacy gates ──────────────────────────────────────────────────────────
+
+describe('emitAgentToolEvent — privacy (Phase 21.5)', () => {
+  it('field_collection_enabled = false → all agent events dropped', () => {
+    setFieldCollectionEnabledCache(false)
+    const sink = getFieldEventSink()
+    const spy = vi.spyOn(sink, 'enqueue')
+
+    for (const tool of ['Read', 'Edit', 'Glob', 'Bash']) {
+      emitAgentToolEvent({
+        worktreeId: 'w-1',
+        projectId: null,
+        sessionId: null,
+        worktreePath: WORKTREE_PATH,
+        toolName: tool,
+        toolUseId: `tu-${tool}`,
+        input:
+          tool === 'Glob'
+            ? { pattern: 'x' }
+            : tool === 'Bash'
+              ? { command: 'echo' }
+              : { file_path: '/Users/dev/proj/wt/x.ts' }
+      })
+    }
+    expect(spy).not.toHaveBeenCalled()
+  })
+
+  it('Bash output capture default OFF → stdoutHead/stderrTail are null', () => {
+    setBashOutputCaptureEnabledCache(false)
+    const sink = getFieldEventSink()
+    let captured: FieldEvent | null = null
+    vi.spyOn(sink, 'enqueue').mockImplementation((evt: FieldEvent) => {
+      captured = evt
+    })
+    emitAgentToolEvent({
+      worktreeId: 'w-1',
+      projectId: null,
+      sessionId: null,
+      worktreePath: WORKTREE_PATH,
+      toolName: 'Bash',
+      toolUseId: 'tu-1',
+      input: { command: 'env' },
+      output: { text: 'API_KEY=secret', error: 'fatal: token=abc', exitCode: 1 }
+    })
+    expect((captured!.payload as { stdoutHead: string | null }).stdoutHead).toBeNull()
+    expect((captured!.payload as { stderrTail: string | null }).stderrTail).toBeNull()
+    // Command is still captured (user can see it in sidebar anyway)
+    expect((captured!.payload as { command: string }).command).toBe('env')
+  })
+
+  it('Bash output capture ON → head/tail truncated to 1024 chars', () => {
+    setBashOutputCaptureEnabledCache(true)
+    const sink = getFieldEventSink()
+    let captured: FieldEvent | null = null
+    vi.spyOn(sink, 'enqueue').mockImplementation((evt: FieldEvent) => {
+      captured = evt
+    })
+    const longOut = 'A'.repeat(2000)
+    const longErr = 'B'.repeat(2000) + 'TAIL_END'
+    emitAgentToolEvent({
+      worktreeId: 'w-1',
+      projectId: null,
+      sessionId: null,
+      worktreePath: WORKTREE_PATH,
+      toolName: 'Bash',
+      toolUseId: 'tu-1',
+      input: { command: 'pnpm build' },
+      output: { text: longOut, error: longErr, exitCode: 0 }
+    })
+    const stdout = (captured!.payload as { stdoutHead: string }).stdoutHead
+    const stderr = (captured!.payload as { stderrTail: string }).stderrTail
+    expect(stdout.length).toBe(1024)
+    expect(stdout.startsWith('A')).toBe(true)
+    expect(stderr.length).toBe(1024)
+    expect(stderr.endsWith('TAIL_END')).toBe(true)
+  })
+})
+
+// ─── Field-level constraints ───────────────────────────────────────────────
+
+describe('emitAgentToolEvent — field constraints (Phase 21.5)', () => {
+  it('truncates command to 512 chars', () => {
+    const sink = getFieldEventSink()
+    let captured: FieldEvent | null = null
+    vi.spyOn(sink, 'enqueue').mockImplementation((evt: FieldEvent) => {
+      captured = evt
+    })
+    emitAgentToolEvent({
+      worktreeId: 'w-1',
+      projectId: null,
+      sessionId: null,
+      worktreePath: WORKTREE_PATH,
+      toolName: 'Bash',
+      toolUseId: 'tu-1',
+      input: { command: 'x'.repeat(2000) }
+    })
+    expect((captured!.payload as { command: string }).command.length).toBe(512)
+  })
+
+  it('drops Read without file_path', () => {
+    const sink = getFieldEventSink()
+    const spy = vi.spyOn(sink, 'enqueue')
+    const id = emitAgentToolEvent({
+      worktreeId: 'w-1',
+      projectId: null,
+      sessionId: null,
+      worktreePath: WORKTREE_PATH,
+      toolName: 'Read',
+      toolUseId: 'tu-1',
+      input: {}
+    })
+    expect(id).toBeNull()
+    expect(spy).not.toHaveBeenCalled()
+  })
+
+  it('drops Glob without pattern', () => {
+    const sink = getFieldEventSink()
+    const spy = vi.spyOn(sink, 'enqueue')
+    const id = emitAgentToolEvent({
+      worktreeId: 'w-1',
+      projectId: null,
+      sessionId: null,
+      worktreePath: WORKTREE_PATH,
+      toolName: 'Glob',
+      toolUseId: 'tu-1',
+      input: {}
+    })
+    expect(id).toBeNull()
+    expect(spy).not.toHaveBeenCalled()
+  })
+
+  it('drops calls missing toolUseId', () => {
+    const sink = getFieldEventSink()
+    const spy = vi.spyOn(sink, 'enqueue')
+    const id = emitAgentToolEvent({
+      worktreeId: 'w-1',
+      projectId: null,
+      sessionId: null,
+      worktreePath: WORKTREE_PATH,
+      toolName: 'Read',
+      toolUseId: '',
+      input: { file_path: '/Users/dev/proj/wt/x.ts' }
+    })
+    expect(id).toBeNull()
+    expect(spy).not.toHaveBeenCalled()
+  })
+
+  it('keeps already-relative paths unchanged', () => {
+    const sink = getFieldEventSink()
+    let captured: FieldEvent | null = null
+    vi.spyOn(sink, 'enqueue').mockImplementation((evt: FieldEvent) => {
+      captured = evt
+    })
+    emitAgentToolEvent({
+      worktreeId: 'w-1',
+      projectId: null,
+      sessionId: null,
+      worktreePath: WORKTREE_PATH,
+      toolName: 'Read',
+      toolUseId: 'tu-1',
+      input: { file_path: 'src/foo.ts' }
+    })
+    expect((captured!.payload as { path: string }).path).toBe('src/foo.ts')
+  })
+
+  it('reads input.path when input.file_path is absent (fallback)', () => {
+    const sink = getFieldEventSink()
+    let captured: FieldEvent | null = null
+    vi.spyOn(sink, 'enqueue').mockImplementation((evt: FieldEvent) => {
+      captured = evt
+    })
+    emitAgentToolEvent({
+      worktreeId: 'w-1',
+      projectId: null,
+      sessionId: null,
+      worktreePath: WORKTREE_PATH,
+      toolName: 'Read',
+      toolUseId: 'tu-1',
+      input: { path: '/Users/dev/proj/wt/x.ts' }
+    })
+    expect((captured!.payload as { path: string }).path).toBe('x.ts')
+  })
+})

--- a/test/phase-21-5/privacy-bash-capture.test.ts
+++ b/test/phase-21-5/privacy-bash-capture.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Phase 21.5 — isBashOutputCaptureEnabled privacy gate tests.
+ *
+ * Default OFF (must be literally 'true' to enable) — validates that secrets
+ * in bash output don't leak to the DB unless the user explicitly opts in.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+const getSettingMock = vi.fn<(key: string) => string | null | undefined>()
+
+vi.mock('../../src/main/db', () => ({
+  getDatabase: () => ({
+    getSetting: getSettingMock
+  })
+}))
+
+import {
+  isBashOutputCaptureEnabled,
+  setBashOutputCaptureEnabledCache,
+  invalidatePrivacyCache,
+  BASH_OUTPUT_CAPTURE_SETTING_KEY
+} from '../../src/main/field/privacy'
+
+beforeEach(() => {
+  invalidatePrivacyCache()
+  getSettingMock.mockReset()
+})
+
+describe('isBashOutputCaptureEnabled (Phase 21.5)', () => {
+  it('default OFF when setting is absent (null from DB)', () => {
+    getSettingMock.mockReturnValue(null)
+    expect(isBashOutputCaptureEnabled()).toBe(false)
+  })
+
+  it('default OFF when setting is undefined', () => {
+    getSettingMock.mockReturnValue(undefined)
+    expect(isBashOutputCaptureEnabled()).toBe(false)
+  })
+
+  it('OFF when setting is the literal string "false"', () => {
+    getSettingMock.mockReturnValue('false')
+    expect(isBashOutputCaptureEnabled()).toBe(false)
+  })
+
+  it('OFF when setting is any string other than "true"', () => {
+    for (const val of ['yes', '1', 'True', 'TRUE', '']) {
+      invalidatePrivacyCache()
+      getSettingMock.mockReturnValue(val)
+      expect(isBashOutputCaptureEnabled()).toBe(false)
+    }
+  })
+
+  it('ON only when setting is the literal string "true"', () => {
+    getSettingMock.mockReturnValue('true')
+    expect(isBashOutputCaptureEnabled()).toBe(true)
+  })
+
+  it('caches the value after first lookup', () => {
+    getSettingMock.mockReturnValue('true')
+    expect(isBashOutputCaptureEnabled()).toBe(true)
+    expect(isBashOutputCaptureEnabled()).toBe(true)
+    // Should only have queried the DB once
+    expect(getSettingMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('setBashOutputCaptureEnabledCache updates the cache in-band', () => {
+    getSettingMock.mockReturnValue(null)
+    expect(isBashOutputCaptureEnabled()).toBe(false)
+    setBashOutputCaptureEnabledCache(true)
+    expect(isBashOutputCaptureEnabled()).toBe(true)
+    setBashOutputCaptureEnabledCache(false)
+    expect(isBashOutputCaptureEnabled()).toBe(false)
+  })
+
+  it('invalidatePrivacyCache forces re-read from DB next call', () => {
+    getSettingMock.mockReturnValueOnce('true').mockReturnValueOnce('false')
+    expect(isBashOutputCaptureEnabled()).toBe(true) // 1st read
+    expect(isBashOutputCaptureEnabled()).toBe(true) // cached
+    invalidatePrivacyCache()
+    expect(isBashOutputCaptureEnabled()).toBe(false) // 2nd read
+    expect(getSettingMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('exports the setting key for IPC handlers', () => {
+    expect(BASH_OUTPUT_CAPTURE_SETTING_KEY).toBe('agent_bash_capture_output')
+  })
+})

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -15,6 +15,7 @@ export default defineWorkspace([
         'test/phase-9/session-13/**/*.test.ts',
         'test/server/**/*.test.ts',
         'test/lsp/**/*.test.ts',
+        'test/phase-21-5/**/*.test.ts',
         'test/phase-24/**/*.test.ts',
         'test/phase-24c/**/*.test.ts'
       ]
@@ -32,6 +33,7 @@ export default defineWorkspace([
         'test/server/**/*.test.ts',
         'test/lsp/**/*.test.ts',
         'test/phase-21/**/*.test.ts',
+        'test/phase-21-5/**/*.test.ts',
         'test/phase-24/**/*.test.ts',
         'test/phase-24c/**/*.test.ts'
       ],


### PR DESCRIPTION
## Overview

Phase 21 captured 7 human-action event types (file.focus, file.selection, terminal.command, session.message). **Fully-delegated users where the agent does all reads/edits/commands fired almost zero events** — author's own measurement: 45 events in a session, 24 session.message, only 3 terminal.command and 2 file.selection (both from manual validation). This made Phase 22/24C effectively invisible to that user segment: hot_files always empty, Current Focus always empty.

Phase 21.5 captures **4 new agent-side event types** from runtime adapter tool_use → tool_result observations:

| Type | Tools | Scoring in hot_files |
|---|---|---|
| `agent.file_read` | Read / NotebookRead / file_read | +1 |
| `agent.file_write` | Edit / Write / MultiEdit / NotebookEdit / apply_patch | +3 |
| `agent.file_search` | Glob / Grep | **not included** (pattern ≠ file) |
| `agent.bash_exec` | Bash / exec_command | not included (not file-specific) |

Base: `feat_20260422_checkpoint` (Phase 24C Session Checkpoint — PR #29).

## Design decisions (from reviewed PRD v2)

- **Glob/Grep get their OWN type** (not stuffed into `file_read`) so glob patterns like `**/*.ts` can't leak into hot_files via `statSync(pattern)` failures.
- **`operation` V1 = `'edit'`** (single value) — `'create' | 'delete'` deferred to Outcome Loop once file-existed-before detection exists.
- **`toolUseId` mandatory** in every payload — reserved as low-cost join key for future Outcome Loop attribution (e.g. linking a `test_pass` outcome back to the `agent.bash_exec` that triggered it).
- **Sub-agent events SKIPPED** — `parentToolUseId` non-null → emit is a no-op. User's mental model = outermost session. Future `session.sub_agent_summary` aggregation can be added separately.
- **Bash stdout/stderr is OPT-IN** (default OFF). Output frequently contains API keys, env dumps, tokenized error stacks. New setting `agent_bash_capture_output`; command text itself always captured.
- **Glob guard in emit**: if a path field accidentally contains `*` or `?`, the event is dropped (defense against future tools mis-routing patterns).

## Integration

### Runtime adapters (3 — each with different SDK shape)

| File | Hook point |
|---|---|
| `claude-code-implementer.ts` | After `tool_result` merges back into `tool_use` part (line ~1076); new `emitAgentToolField` private method |
| `codex-implementer.ts` | `handleManagerEvent` on `item/completed` (itemType=commandExecution/fileChange); new `emitAgentToolField` |
| `opencode-service.ts` | `message.part.updated` when tool part reaches terminal status (completed/error); new `maybeEmitAgentToolField` |

All three wrap in try/catch; Phase 21.5 failure never breaks main event flow.

### Consumers

- `checkpoint-generator.ts`
  - `rankHotFiles`: +3 for `agent.file_write`, +1 for `agent.file_read`; `file_search`/`bash_exec` excluded
  - `editCount`: distinct files touched by human OR agent
  - `commandCount`: `terminal.command` + `agent.bash_exec`
- `context-builder.ts`
  - `deriveFocus`: fallback chain when no human signal — `agent.file_write` > `agent.file_read`
  - `summarizeEvent`: renders 4 new types in Recent Activity
- `scripts/dump-field-events.ts`: new `formatRow` cases for dump output

### UI & IPC

- `SettingsPrivacy.tsx`: new toggle "Capture agent Bash stdout/stderr" (default OFF)
- `i18n/messages.ts`: EN + ZH translations
- `database-handlers.ts`: sync `setBashOutputCaptureEnabledCache` on `db:setting:set/delete`

## Tests — 52 new in `test/phase-21-5/`

| File | Count | Focus |
|---|---|---|
| `emit-agent-tool.test.ts` | 27 | routing (4 types), sub-agent skip, glob guard, privacy gates, field constraints, truncation |
| `consumers.test.ts` | 9 | `rankHotFiles` scoring, glob/bash exclusion, full-delegation end-to-end |
| `derive-focus.test.ts` | 7 | agent fallback only when no human signal, write > read, search/bash don't populate focus |
| `privacy-bash-capture.test.ts` | 9 | default OFF, `'true'`-only gate, cache invalidation |

**587/587 passing** (`test/phase-21/field-events` + `test/phase-21-5` + `test/phase-24c`, baseline 535 → +52).

## Edge cases covered

- Glob string in `path` field → event dropped (not routed to file_read)
- Unknown tool name → no-op (safer than miscategorizing)
- Empty `toolUseId` → drop
- Missing `file_path` → drop (`input.path` fallback tried first)
- DB closed mid-read → silent noop (no throw)
- `stdoutHead`/`stderrTail` null by default, truncated to 1 KB when enabled
- Concurrent tool calls → `toolUseId` uniqueness prevents merge conflicts
- Latest event wins semantics for `deriveFocus` fallback

## What this unlocks

For full-delegation users (who are the primary target of 1.4.0):
- `## Current Focus` in Field Context now populated even when agent does everything
- Phase 24C's "Resumed from previous session" block now carries real `hot_files` instead of empty list
- Checkpoints produced on abort after a fully-agent-driven session are actually useful on the next prompt

## Non-goals (left for later)

- LLM-based episodic summaries (22B.2)
- Auto-update memory.md (22C.2)
- Redaction / PII filter beyond the bash output toggle
- `agent.thinking` / `agent.plan_update` (noise > value)
- WebFetch / WebSearch (not local workbench)
- Sub-agent nested observation (V1 skips)
- `operation: 'create' | 'delete'` refinement (Outcome Loop territory)

## PRD

`docs/prd/phase-21.5-agent-tool-events-v2.md` — revised after oracle-style review (5 must-fix + 2 nice-to-have items landed).

## Branch

`feat_20260423_agent_events` splits from `feat_20260422_checkpoint` (Phase 24C, PR #29).
