### PR TITLE
Phase 22B.2: Claude Haiku episodic compactor with RuleBased fallback

### DIFF
--- a/src/main/field/claude-haiku-compactor.ts
+++ b/src/main/field/claude-haiku-compactor.ts
@@ -1,0 +1,337 @@
+/**
+ * Claude Haiku Episodic Compactor — Phase 22B.2
+ *
+ * Real LLM implementation of the EpisodicCompactor interface. Reuses the
+ * Claude Agent SDK codepath from `claude-session-title.ts` (model: 'haiku',
+ * effort: low, thinking: disabled, no tools, no session persistence) to keep
+ * cost and latency minimal.
+ *
+ * Strict prompt contract:
+ *   - Restate observed facts + a short abstract summary
+ *   - NEVER invent events, file paths, commands, outcomes, or intent
+ *   - If the event stream is too thin to justify an abstract, say so
+ *
+ * On failure (timeout, quota, network, malformed output) the compactor
+ * throws. The updater treats that as "try the fallback compactor" and logs
+ * a counter; the user's main flow is never blocked.
+ *
+ * Retry policy:
+ *   - Per-attempt 30s timeout
+ *   - 1 retry (2 attempts total)
+ *   - Exponential backoff for 429 / 502 (1s, then 2s)
+ */
+import { basename } from 'path'
+import { homedir } from 'node:os'
+import { loadClaudeSDK } from '../services/claude-sdk-loader'
+import { createLogger } from '../services/logger'
+import {
+  InsufficientEventsError,
+  type CompactionInput,
+  type CompactionOutput,
+  type EpisodicCompactor
+} from './episodic-compactor'
+import type { StoredFieldEvent } from './repository'
+
+const log = createLogger({ component: 'ClaudeHaikuCompactor' })
+
+const MIN_EVENTS = 5
+const REQUEST_TIMEOUT_MS = 30_000
+const MAX_ATTEMPTS = 2
+const BACKOFF_BASE_MS = 1_000
+const MAX_EVENTS_IN_PROMPT = 200
+const MAX_OUTPUT_CHARS = 4_000
+const MIN_OUTPUT_CHARS = 40
+const MAX_TEXT_SNIPPET = 160
+
+const SYSTEM_PROMPT = `You summarize a developer's recent activity in a git worktree.
+
+Rules (strict):
+- Restate only events that appear in the input. Do NOT invent anything.
+- No guessing about intent unless the event text makes it obvious (e.g. commit messages).
+- Do NOT enumerate counts like "the user sent 12 prompts". Synthesize what the user was actually working on (files, commands, errors, topics).
+- Output must be clean markdown, no preamble ("Here is..."), no code fences around the whole reply.
+- Structure: a first one-line abstract sentence, then a short "Observed" bullet list (3-8 bullets) of concrete observations (files touched, commands run, failures, topics from prompts). End with a "Signals" line if there are notable failures or unresolved issues; skip it otherwise.
+- Keep under 400 words.
+- If the events are too sparse to summarize honestly, write exactly one line: "Not enough activity to summarize." and stop.`
+
+// ---------------------------------------------------------------------------
+// Types for testability
+// ---------------------------------------------------------------------------
+
+/** Minimal shape of the SDK we depend on, injectable for tests. */
+export interface HaikuSDK {
+  query(args: {
+    prompt: string
+    options: Record<string, unknown>
+  }): AsyncIterable<{ type: string; result?: string }>
+}
+
+export type HaikuSDKLoader = () => Promise<HaikuSDK>
+
+export interface ClaudeHaikuCompactorOptions {
+  /** Inject an alternative loader (tests / ASAR path). */
+  loadSDK?: HaikuSDKLoader
+  /** Path to the Claude CLI binary (passed through to SDK for packaged apps). */
+  claudeBinaryPath?: string | null
+  /** Override the per-attempt timeout (tests). */
+  timeoutMs?: number
+  /** Override the retry count (tests). */
+  maxAttempts?: number
+}
+
+// ---------------------------------------------------------------------------
+// Compactor
+// ---------------------------------------------------------------------------
+
+export class ClaudeHaikuCompactor implements EpisodicCompactor {
+  readonly id = 'claude-haiku'
+  readonly version = 1
+
+  private readonly loadSDK: HaikuSDKLoader
+  private readonly claudeBinaryPath: string | null
+  private readonly timeoutMs: number
+  private readonly maxAttempts: number
+
+  constructor(options: ClaudeHaikuCompactorOptions = {}) {
+    this.loadSDK = options.loadSDK ?? (loadClaudeSDK as unknown as HaikuSDKLoader)
+    this.claudeBinaryPath = options.claudeBinaryPath ?? null
+    this.timeoutMs = options.timeoutMs ?? REQUEST_TIMEOUT_MS
+    this.maxAttempts = options.maxAttempts ?? MAX_ATTEMPTS
+  }
+
+  async compact(input: CompactionInput): Promise<CompactionOutput> {
+    if (input.events.length < MIN_EVENTS) {
+      throw new InsufficientEventsError(input.events.length)
+    }
+
+    const userPrompt = buildUserPrompt(input)
+    const sdk = await this.loadSDK()
+
+    let lastErr: unknown = null
+    for (let attempt = 0; attempt < this.maxAttempts; attempt++) {
+      if (attempt > 0) {
+        const delay = BACKOFF_BASE_MS * Math.pow(2, attempt - 1)
+        await sleep(delay)
+      }
+      try {
+        const raw = await this.runOnce(sdk, userPrompt)
+        const markdown = postProcess(raw)
+        if (!markdown) {
+          throw new Error('empty or too-short Haiku response')
+        }
+        return { markdown, compactorId: this.id, version: this.version }
+      } catch (err) {
+        lastErr = err
+        const msg = err instanceof Error ? err.message : String(err)
+        const retryable = isRetryable(err)
+        log.warn('Haiku compaction attempt failed', {
+          attempt,
+          retryable,
+          error: msg
+        })
+        if (!retryable) break
+      }
+    }
+    throw lastErr instanceof Error
+      ? lastErr
+      : new Error(`Haiku compaction failed: ${String(lastErr)}`)
+  }
+
+  private async runOnce(sdk: HaikuSDK, userPrompt: string): Promise<string> {
+    const abortController = new AbortController()
+    const timer = setTimeout(() => abortController.abort(), this.timeoutMs)
+    try {
+      const query = sdk.query({
+        prompt: userPrompt,
+        options: {
+          cwd: homedir(),
+          model: 'haiku',
+          maxTurns: 1,
+          abortController,
+          systemPrompt: SYSTEM_PROMPT,
+          effort: 'low',
+          thinking: { type: 'disabled' },
+          tools: [],
+          persistSession: false,
+          ...(this.claudeBinaryPath ? { pathToClaudeCodeExecutable: this.claudeBinaryPath } : {})
+        }
+      })
+
+      let result = ''
+      for await (const msg of query) {
+        if (msg.type === 'result') {
+          result = msg.result ?? ''
+          break
+        }
+      }
+      return result
+    } finally {
+      clearTimeout(timer)
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Prompt construction
+// ---------------------------------------------------------------------------
+
+function buildUserPrompt(input: CompactionInput): string {
+  const header =
+    `Worktree: ${input.worktreeName}` +
+    (input.branchName ? ` (branch: ${input.branchName})` : '') +
+    `\nTime window: ${new Date(input.since).toISOString()} → ${new Date(input.until).toISOString()}` +
+    `\nTotal events: ${input.events.length}`
+
+  // Keep the tail (most recent) when clipping — that's what the user cares about.
+  const slice =
+    input.events.length > MAX_EVENTS_IN_PROMPT
+      ? input.events.slice(-MAX_EVENTS_IN_PROMPT)
+      : input.events
+
+  const lines = slice.map(serializeEvent).filter((x) => x.length > 0)
+
+  return (
+    `${header}\n\nEvent stream (chronological, redacted):\n${lines.join('\n')}\n\n` +
+    `Write the summary now, following the rules.`
+  )
+}
+
+function serializeEvent(ev: StoredFieldEvent): string {
+  const ts = formatClock(ev.timestamp)
+  switch (ev.type) {
+    case 'worktree.switch': {
+      const p = ev.payload as { fromWorktreeId?: string | null; toWorktreeId?: string | null }
+      return `${ts} worktree.switch ${p.fromWorktreeId ?? '∅'} → ${p.toWorktreeId ?? '∅'}`
+    }
+    case 'file.open':
+    case 'file.focus': {
+      const p = ev.payload as { path?: string }
+      if (!p?.path) return ''
+      return `${ts} ${ev.type} ${basename(p.path)} (${p.path})`
+    }
+    case 'file.selection': {
+      // Selection is a drag-storm event; don't bloat the prompt with it.
+      return ''
+    }
+    case 'terminal.command': {
+      const p = ev.payload as { command?: string }
+      return `${ts} $ ${truncate(p?.command ?? '(unknown)', MAX_TEXT_SNIPPET)}`
+    }
+    case 'terminal.output': {
+      const p = ev.payload as { exitCode?: number | null; excerpt?: string }
+      const code = typeof p?.exitCode === 'number' ? `exit=${p.exitCode}` : 'exit=?'
+      const excerpt = p?.excerpt ? ` :: ${truncate(p.excerpt, MAX_TEXT_SNIPPET)}` : ''
+      return `${ts} ← ${code}${excerpt}`
+    }
+    case 'session.message': {
+      const p = ev.payload as { text?: string; agentSdk?: string }
+      const text = truncate(redactSecrets(p?.text ?? ''), MAX_TEXT_SNIPPET)
+      const agent = p?.agentSdk ? ` [${p.agentSdk}]` : ''
+      return `${ts} prompt${agent}: ${text}`
+    }
+    case 'agent.file_read':
+    case 'agent.file_write': {
+      const p = ev.payload as { path?: string }
+      if (!p?.path) return ''
+      return `${ts} ${ev.type} ${basename(p.path)}`
+    }
+    case 'agent.file_search': {
+      const p = ev.payload as { query?: string }
+      return `${ts} agent.file_search "${truncate(p?.query ?? '', 80)}"`
+    }
+    case 'agent.bash_exec': {
+      const p = ev.payload as { command?: string }
+      return `${ts} agent.bash_exec $ ${truncate(p?.command ?? '', MAX_TEXT_SNIPPET)}`
+    }
+    default:
+      return ''
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Response post-processing & validation
+// ---------------------------------------------------------------------------
+
+function postProcess(raw: string): string | null {
+  if (!raw) return null
+  // Strip <think>...</think> reasoning artifacts if any.
+  let s = raw.replace(/<think>[\s\S]*?<\/think>/g, '').trim()
+  // Strip surrounding ``` code fences if the model wrapped the whole reply.
+  if (s.startsWith('```')) {
+    s = s
+      .replace(/^```[a-zA-Z]*\n?/, '')
+      .replace(/```$/, '')
+      .trim()
+  }
+  if (s.length < MIN_OUTPUT_CHARS) return null
+  if (s.length > MAX_OUTPUT_CHARS) {
+    const cut = s.slice(0, MAX_OUTPUT_CHARS)
+    const lastBreak = cut.lastIndexOf('\n\n')
+    s = lastBreak > 0 ? cut.slice(0, lastBreak) + '\n\n…(truncated)' : cut + '…'
+  }
+  return s
+}
+
+// ---------------------------------------------------------------------------
+// Retry classification
+// ---------------------------------------------------------------------------
+
+function isRetryable(err: unknown): boolean {
+  const msg = (err instanceof Error ? err.message : String(err)).toLowerCase()
+  if (msg.includes('abort')) return true // timeout abort
+  if (msg.includes('timeout')) return true
+  if (msg.includes('429')) return true
+  if (msg.includes('502')) return true
+  if (msg.includes('rate limit')) return true
+  if (msg.includes('econnreset') || msg.includes('etimedout')) return true
+  if (msg.includes('network')) return true
+  return false
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function formatClock(ms: number): string {
+  const d = new Date(ms)
+  const hh = String(d.getHours()).padStart(2, '0')
+  const mm = String(d.getMinutes()).padStart(2, '0')
+  const ss = String(d.getSeconds()).padStart(2, '0')
+  return `${hh}:${mm}:${ss}`
+}
+
+function truncate(s: string, max: number): string {
+  if (!s) return ''
+  const single = s.replace(/\s+/g, ' ').trim()
+  return single.length <= max ? single : single.slice(0, Math.max(0, max - 1)) + '…'
+}
+
+const SECRET_INLINE_REGEX =
+  /(api[_-]?key|password|token|secret|authorization|bearer)\s*[:=]?\s*\S+/gi
+
+function redactSecrets(s: string): string {
+  return s.replace(SECRET_INLINE_REGEX, (_m, kw: string) => `${kw}=[REDACTED]`)
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+export const __HAIKU_COMPACTOR_TUNABLES_FOR_TEST = {
+  MIN_EVENTS,
+  REQUEST_TIMEOUT_MS,
+  MAX_ATTEMPTS,
+  BACKOFF_BASE_MS,
+  MAX_EVENTS_IN_PROMPT,
+  MAX_OUTPUT_CHARS,
+  MIN_OUTPUT_CHARS,
+  SYSTEM_PROMPT,
+  isRetryable,
+  redactSecrets,
+  postProcess,
+  buildUserPrompt
+}

--- a/src/main/field/episodic-updater.ts
+++ b/src/main/field/episodic-updater.ts
@@ -28,6 +28,7 @@ import {
   type EpisodicCompactor,
   type CompactionOutput
 } from './episodic-compactor'
+import { ClaudeHaikuCompactor } from './claude-haiku-compactor'
 import type { FieldEvent } from '../../shared/types'
 
 const log = createLogger({ component: 'EpisodicMemoryUpdater' })
@@ -80,6 +81,7 @@ export interface EpisodicUpdaterCounters {
   compactions_skipped_invalid: number
   compactions_failed: number
   compactions_skipped_privacy: number
+  compactions_fallback_used: number
   last_compaction_at: number
 }
 
@@ -93,6 +95,7 @@ class EpisodicMemoryUpdater {
   private unsubscribeEmit: (() => void) | null = null
   private isShuttingDown = false
   private compactor: EpisodicCompactor
+  private fallback: EpisodicCompactor | null
 
   private counters: EpisodicUpdaterCounters = {
     compactions_attempted: 0,
@@ -102,14 +105,26 @@ class EpisodicMemoryUpdater {
     compactions_skipped_invalid: 0,
     compactions_failed: 0,
     compactions_skipped_privacy: 0,
+    compactions_fallback_used: 0,
     last_compaction_at: 0
   }
 
   constructor(
-    compactor: EpisodicCompactor = new RuleBasedCompactor(),
-    private readonly debounceMs = DEBOUNCE_MS
+    compactor: EpisodicCompactor = new ClaudeHaikuCompactor(),
+    private readonly debounceMs = DEBOUNCE_MS,
+    fallback: EpisodicCompactor | null = null
   ) {
     this.compactor = compactor
+    // Default fallback: if the primary is the Haiku compactor, fall back to
+    // the deterministic rule-based compactor on LLM failure. Tests can pass
+    // an explicit fallback (or null) to override.
+    if (fallback !== undefined && fallback !== null) {
+      this.fallback = fallback
+    } else if (compactor.id === 'claude-haiku') {
+      this.fallback = new RuleBasedCompactor()
+    } else {
+      this.fallback = null
+    }
     this.start()
   }
 
@@ -202,8 +217,7 @@ class EpisodicMemoryUpdater {
     if (state.eventsSinceCompaction < MIN_EVENTS_BEFORE_TRIGGER) return
 
     const existing = getDatabase().getEpisodicMemory(event.worktreeId)
-    const tooSoon =
-      existing && Date.now() - existing.compactedAt < MIN_AGE_BEFORE_TRIGGER_MS
+    const tooSoon = existing && Date.now() - existing.compactedAt < MIN_AGE_BEFORE_TRIGGER_MS
     if (tooSoon) return
 
     this.schedule(event.worktreeId)
@@ -226,8 +240,7 @@ class EpisodicMemoryUpdater {
     for (const { worktree_id } of rows) {
       if (this.isShuttingDown) break
       const existing = getDatabase().getEpisodicMemory(worktree_id)
-      const isStale =
-        !existing || Date.now() - existing.compactedAt > STALE_THRESHOLD_MS
+      const isStale = !existing || Date.now() - existing.compactedAt > STALE_THRESHOLD_MS
       if (isStale) this.schedule(worktree_id)
     }
   }
@@ -276,22 +289,6 @@ class EpisodicMemoryUpdater {
     const worktree = db.getWorktree(worktreeId)
     if (!worktree) return null // silently skip unknown worktrees
 
-    // "Don't downgrade" check
-    const existing = db.getEpisodicMemory(worktreeId)
-    const currentPriority = COMPACTOR_PRIORITY[this.compactor.id] ?? 0
-    if (existing) {
-      const existingPriority = COMPACTOR_PRIORITY[existing.compactorId] ?? 0
-      if (existingPriority > currentPriority) {
-        log.debug('skip: existing summary has higher priority', {
-          worktreeId,
-          existing: existing.compactorId,
-          current: this.compactor.id
-        })
-        this.counters.compactions_skipped_downgrade++
-        return null
-      }
-    }
-
     // Ensure the latest events are persisted before we read them.
     try {
       await getFieldEventSink().flushNow()
@@ -311,70 +308,105 @@ class EpisodicMemoryUpdater {
       order: 'asc'
     })
 
-    const startedAt = Date.now()
-    let output: CompactionOutput
-    try {
-      output = await this.compactor.compact({
-        worktreeId,
-        worktreeName: worktree.name,
-        branchName: worktree.branch_name ?? null,
-        events,
-        since,
-        until
-      })
-    } catch (err) {
-      if (err instanceof InsufficientEventsError) {
-        this.counters.compactions_skipped_insufficient++
-        return null
+    // Build the chain: primary first, then fallback if present.
+    const chain: EpisodicCompactor[] = [this.compactor]
+    if (this.fallback) chain.push(this.fallback)
+
+    const existing = db.getEpisodicMemory(worktreeId)
+    const existingPriority = existing ? (COMPACTOR_PRIORITY[existing.compactorId] ?? 0) : -1
+
+    let primaryFailed = false
+    for (let i = 0; i < chain.length; i++) {
+      const c = chain[i]
+      const priority = COMPACTOR_PRIORITY[c.id] ?? 0
+
+      // "Don't downgrade" check — evaluated per-compactor so the fallback
+      // (lower priority) can still be skipped if a previous higher-priority
+      // summary exists.
+      if (existing && existingPriority > priority) {
+        log.debug('skip: existing summary has higher priority', {
+          worktreeId,
+          existing: existing.compactorId,
+          current: c.id
+        })
+        this.counters.compactions_skipped_downgrade++
+        continue
       }
-      this.counters.compactions_failed++
-      log.warn('compactor threw', {
+
+      const startedAt = Date.now()
+      let output: CompactionOutput
+      try {
+        output = await c.compact({
+          worktreeId,
+          worktreeName: worktree.name,
+          branchName: worktree.branch_name ?? null,
+          events,
+          since,
+          until
+        })
+      } catch (err) {
+        if (err instanceof InsufficientEventsError) {
+          // Insufficient events is a data-level skip that applies to the
+          // whole chain. No point trying the fallback on the same stream.
+          this.counters.compactions_skipped_insufficient++
+          return null
+        }
+        this.counters.compactions_failed++
+        log.warn('compactor threw; will try fallback if available', {
+          worktreeId,
+          compactor: c.id,
+          isPrimary: i === 0,
+          error: err instanceof Error ? err.message : String(err)
+        })
+        if (i === 0) primaryFailed = true
+        continue
+      }
+
+      if (!this.isValidOutput(output)) {
+        this.counters.compactions_skipped_invalid++
+        log.warn('compactor produced invalid output; will try fallback if available', {
+          worktreeId,
+          compactor: c.id
+        })
+        if (i === 0) primaryFailed = true
+        continue
+      }
+
+      const durationMs = Date.now() - startedAt
+
+      db.upsertEpisodicMemory({
         worktreeId,
-        compactor: this.compactor.id,
-        error: err instanceof Error ? err.message : String(err)
+        summaryMarkdown: output.markdown,
+        compactorId: output.compactorId,
+        version: output.version,
+        compactedAt: Date.now(),
+        sourceEventCount: events.length,
+        sourceSince: since,
+        sourceUntil: until
       })
-      return null
-    }
 
-    if (!this.isValidOutput(output)) {
-      this.counters.compactions_skipped_invalid++
-      log.warn('compactor produced invalid output; keeping existing summary', {
+      this.counters.compactions_written++
+      this.counters.last_compaction_at = Date.now()
+      if (primaryFailed && i > 0) this.counters.compactions_fallback_used++
+
+      log.info('Episodic compaction written', {
         worktreeId,
-        compactor: this.compactor.id
+        eventCount: events.length,
+        durationMs,
+        compactorId: output.compactorId,
+        version: output.version,
+        chars: output.markdown.length,
+        usedFallback: primaryFailed && i > 0
       })
-      return null
+
+      if (process.env.XUANPU_FIELD_DEBUG_BODIES === 'true') {
+        log.debug('Episodic compaction body', { body: redactSecrets(output.markdown) })
+      }
+
+      return output
     }
 
-    const durationMs = Date.now() - startedAt
-
-    db.upsertEpisodicMemory({
-      worktreeId,
-      summaryMarkdown: output.markdown,
-      compactorId: output.compactorId,
-      version: output.version,
-      compactedAt: Date.now(),
-      sourceEventCount: events.length,
-      sourceSince: since,
-      sourceUntil: until
-    })
-
-    this.counters.compactions_written++
-    this.counters.last_compaction_at = Date.now()
-
-    log.info('Episodic compaction written', {
-      worktreeId,
-      eventCount: events.length,
-      durationMs,
-      compactorId: output.compactorId,
-      version: output.version,
-      chars: output.markdown.length
-    })
-
-    if (process.env.XUANPU_FIELD_DEBUG_BODIES === 'true') {
-      log.debug('Episodic compaction body', { body: redactSecrets(output.markdown) })
-    }
-
-    return output
+    return null
   }
 
   private isValidOutput(output: CompactionOutput): boolean {
@@ -423,11 +455,14 @@ export function getEpisodicMemoryUpdater(): EpisodicMemoryUpdater {
 }
 
 /** Test helper: replace the singleton with a fresh instance (optionally with a mock compactor). */
-export function resetEpisodicMemoryUpdaterForTest(compactor?: EpisodicCompactor): EpisodicMemoryUpdater {
+export function resetEpisodicMemoryUpdaterForTest(
+  compactor?: EpisodicCompactor,
+  fallback: EpisodicCompactor | null = null
+): EpisodicMemoryUpdater {
   if (instance) {
     void instance.shutdown()
   }
-  instance = new EpisodicMemoryUpdater(compactor)
+  instance = new EpisodicMemoryUpdater(compactor, DEBOUNCE_MS, fallback)
   return instance
 }
 

--- a/test/phase-22b/claude-haiku-compactor.test.ts
+++ b/test/phase-22b/claude-haiku-compactor.test.ts
@@ -1,0 +1,303 @@
+import { describe, it, expect, vi } from 'vitest'
+import {
+  ClaudeHaikuCompactor,
+  __HAIKU_COMPACTOR_TUNABLES_FOR_TEST,
+  type HaikuSDK
+} from '../../src/main/field/claude-haiku-compactor'
+import {
+  InsufficientEventsError,
+  type CompactionInput
+} from '../../src/main/field/episodic-compactor'
+import type { StoredFieldEvent } from '../../src/main/field/repository'
+import type { FieldEventType } from '../../src/shared/types'
+
+vi.mock('../../src/main/services/logger', () => ({
+  createLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn()
+  })
+}))
+
+// ── Helpers ─────────────────────────────────────────────────────────────
+
+function e(overrides: Partial<StoredFieldEvent>): StoredFieldEvent {
+  return {
+    seq: overrides.seq ?? Math.floor(Math.random() * 1_000_000),
+    id: overrides.id ?? crypto.randomUUID(),
+    timestamp: overrides.timestamp ?? Date.now(),
+    worktreeId: overrides.worktreeId ?? 'w-1',
+    projectId: overrides.projectId ?? 'p-1',
+    sessionId: overrides.sessionId ?? null,
+    relatedEventId: overrides.relatedEventId ?? null,
+    type: (overrides.type as FieldEventType) ?? 'file.focus',
+    payload: overrides.payload ?? { path: '/a.ts', name: 'a.ts', fromPath: null }
+  } as StoredFieldEvent
+}
+
+function makeInput(eventCount = 10): CompactionInput {
+  const t = 1_700_000_000_000
+  const events: StoredFieldEvent[] = []
+  for (let i = 0; i < eventCount; i++) {
+    events.push(
+      e({
+        id: `e-${i}`,
+        timestamp: t + i * 1000,
+        type: 'file.focus',
+        payload: { path: `/src/file-${i % 3}.ts`, name: `file-${i % 3}.ts`, fromPath: null }
+      })
+    )
+  }
+  return {
+    worktreeId: 'w-1',
+    worktreeName: 'hub-mobile',
+    branchName: 'feat/stream-render',
+    events,
+    since: t - 60_000,
+    until: t + eventCount * 1000
+  }
+}
+
+function sdkReturning(text: string): HaikuSDK {
+  return {
+    query: () =>
+      (async function* () {
+        yield { type: 'result', result: text }
+      })()
+  }
+}
+
+function sdkThrowing(err: Error): HaikuSDK {
+  return {
+    query: () => ({
+      async next(): Promise<IteratorResult<{ type: string; result?: string }>> {
+        throw err
+      },
+      [Symbol.asyncIterator]() {
+        return this
+      }
+    })
+  }
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────
+
+describe('ClaudeHaikuCompactor — Phase 22B.2', () => {
+  describe('identity', () => {
+    it('declares id "claude-haiku" and version 1', () => {
+      const c = new ClaudeHaikuCompactor({ loadSDK: async () => sdkReturning('') })
+      expect(c.id).toBe('claude-haiku')
+      expect(c.version).toBe(1)
+    })
+  })
+
+  describe('minimum events guard', () => {
+    it('throws InsufficientEventsError when events.length < 5', async () => {
+      const c = new ClaudeHaikuCompactor({ loadSDK: async () => sdkReturning('x') })
+      await expect(c.compact(makeInput(3))).rejects.toBeInstanceOf(InsufficientEventsError)
+    })
+  })
+
+  describe('happy path', () => {
+    it('returns a CompactionOutput with LLM markdown', async () => {
+      const expected =
+        'Worked on streaming renderer in hub-mobile.\n\nObserved:\n- Edited file-0.ts, file-1.ts\n- No failures observed\n'
+      const sdk = sdkReturning(expected)
+      const querySpy = vi.spyOn(sdk, 'query')
+      const c = new ClaudeHaikuCompactor({ loadSDK: async () => sdk })
+
+      const out = await c.compact(makeInput(10))
+
+      expect(out.compactorId).toBe('claude-haiku')
+      expect(out.version).toBe(1)
+      expect(out.markdown).toContain('streaming renderer')
+      expect(querySpy).toHaveBeenCalledTimes(1)
+
+      // Sanity-check the prompt we actually sent the model:
+      const args = querySpy.mock.calls[0][0]
+      expect(args.options.model).toBe('haiku')
+      expect(args.options.thinking).toEqual({ type: 'disabled' })
+      expect(args.options.tools).toEqual([])
+      expect(args.options.persistSession).toBe(false)
+      expect(args.prompt).toContain('hub-mobile')
+      expect(args.prompt).toContain('feat/stream-render')
+    })
+
+    it('strips <think> tags and code fences', async () => {
+      const withThink =
+        '<think>internal reasoning</think>\n```markdown\nHere is the summary body line one.\nLine two with enough substance to pass validation.\n```'
+      const c = new ClaudeHaikuCompactor({ loadSDK: async () => sdkReturning(withThink) })
+      const out = await c.compact(makeInput(10))
+      expect(out.markdown).not.toContain('<think>')
+      expect(out.markdown).not.toContain('internal reasoning')
+      expect(out.markdown).not.toMatch(/^```/)
+      expect(out.markdown).toContain('summary body')
+    })
+
+    it('rejects too-short responses (treated as failure, not success)', async () => {
+      const c = new ClaudeHaikuCompactor({
+        loadSDK: async () => sdkReturning('ok'),
+        maxAttempts: 1
+      })
+      await expect(c.compact(makeInput(10))).rejects.toThrow()
+    })
+  })
+
+  describe('retry + timeout', () => {
+    it('retries once on abort/timeout and succeeds on the second attempt', async () => {
+      let call = 0
+      const sdk: HaikuSDK = {
+        query() {
+          call++
+          if (call === 1) {
+            return {
+              async next(): Promise<IteratorResult<{ type: string; result?: string }>> {
+                throw new Error('request aborted')
+              },
+              [Symbol.asyncIterator]() {
+                return this
+              }
+            }
+          }
+          return (async function* () {
+            yield {
+              type: 'result',
+              result:
+                'Second-attempt summary of what the developer worked on — plenty of content here.'
+            }
+          })()
+        }
+      }
+      const c = new ClaudeHaikuCompactor({
+        loadSDK: async () => sdk,
+        maxAttempts: 2
+      })
+      const out = await c.compact(makeInput(10))
+      expect(out.markdown).toContain('Second-attempt')
+      expect(call).toBe(2)
+    })
+
+    it('does NOT retry on non-retryable errors (e.g. "invalid api key")', async () => {
+      const sdk = sdkThrowing(new Error('invalid api key'))
+      const querySpy = vi.spyOn(sdk, 'query')
+      const c = new ClaudeHaikuCompactor({
+        loadSDK: async () => sdk,
+        maxAttempts: 3
+      })
+      await expect(c.compact(makeInput(10))).rejects.toThrow(/invalid api key/)
+      expect(querySpy).toHaveBeenCalledTimes(1)
+    })
+
+    it('gives up after maxAttempts on persistent 429', async () => {
+      const sdk = sdkThrowing(new Error('HTTP 429 Too Many Requests'))
+      const querySpy = vi.spyOn(sdk, 'query')
+      const c = new ClaudeHaikuCompactor({
+        loadSDK: async () => sdk,
+        maxAttempts: 2
+      })
+      await expect(c.compact(makeInput(10))).rejects.toThrow(/429/)
+      expect(querySpy).toHaveBeenCalledTimes(2)
+    })
+
+    it('aborts the query when the per-attempt timeout elapses', async () => {
+      let capturedOptions: Record<string, unknown> | null = null
+      const sdk: HaikuSDK = {
+        query(args) {
+          capturedOptions = args.options
+          const ctrl = args.options.abortController as AbortController
+          return {
+            async next(): Promise<IteratorResult<{ type: string; result?: string }>> {
+              return new Promise((_, reject) => {
+                ctrl.signal.addEventListener('abort', () => reject(new Error('aborted')))
+              })
+            },
+            [Symbol.asyncIterator]() {
+              return this
+            }
+          }
+        }
+      }
+      const c = new ClaudeHaikuCompactor({
+        loadSDK: async () => sdk,
+        maxAttempts: 1,
+        timeoutMs: 20
+      })
+      await expect(c.compact(makeInput(10))).rejects.toThrow()
+      expect(capturedOptions).not.toBeNull()
+      expect(capturedOptions!.abortController).toBeInstanceOf(AbortController)
+    })
+  })
+
+  describe('retry classifier', () => {
+    it('classifies network/timeout/429/502 as retryable', () => {
+      const { isRetryable } = __HAIKU_COMPACTOR_TUNABLES_FOR_TEST
+      expect(isRetryable(new Error('request aborted'))).toBe(true)
+      expect(isRetryable(new Error('ETIMEDOUT'))).toBe(true)
+      expect(isRetryable(new Error('ECONNRESET on upstream'))).toBe(true)
+      expect(isRetryable(new Error('HTTP 429'))).toBe(true)
+      expect(isRetryable(new Error('HTTP 502 Bad Gateway'))).toBe(true)
+      expect(isRetryable(new Error('rate limit exceeded'))).toBe(true)
+      expect(isRetryable(new Error('network unreachable'))).toBe(true)
+    })
+    it('classifies auth/validation errors as non-retryable', () => {
+      const { isRetryable } = __HAIKU_COMPACTOR_TUNABLES_FOR_TEST
+      expect(isRetryable(new Error('invalid api key'))).toBe(false)
+      expect(isRetryable(new Error('model not found'))).toBe(false)
+      expect(isRetryable(new Error('malformed request'))).toBe(false)
+    })
+  })
+
+  describe('prompt construction', () => {
+    it('redacts inline secrets in session.message payloads', () => {
+      const { buildUserPrompt } = __HAIKU_COMPACTOR_TUNABLES_FOR_TEST
+      const events: StoredFieldEvent[] = [
+        e({
+          id: 'p',
+          type: 'session.message',
+          payload: {
+            text: 'deploy with api_key=abc123 and BEARER xyz',
+            agentSdk: 'claude-code',
+            agentSessionId: 's-1',
+            attachmentCount: 0
+          }
+        })
+      ]
+      const prompt = buildUserPrompt({
+        worktreeId: 'w-1',
+        worktreeName: 'wt',
+        branchName: null,
+        events,
+        since: 0,
+        until: Date.now()
+      })
+      expect(prompt).not.toContain('abc123')
+      expect(prompt).not.toContain('xyz')
+      expect(prompt).toContain('[REDACTED]')
+    })
+
+    it('clips event stream to tail when too many events', () => {
+      const { buildUserPrompt, MAX_EVENTS_IN_PROMPT } = __HAIKU_COMPACTOR_TUNABLES_FOR_TEST
+      const events: StoredFieldEvent[] = Array.from({ length: MAX_EVENTS_IN_PROMPT + 50 }, (_, i) =>
+        e({
+          id: `e-${i}`,
+          timestamp: i * 1000,
+          type: 'terminal.command',
+          payload: { command: `cmd-${i}` }
+        })
+      )
+      const prompt = buildUserPrompt({
+        worktreeId: 'w-1',
+        worktreeName: 'wt',
+        branchName: null,
+        events,
+        since: 0,
+        until: Date.now()
+      })
+      // First 50 commands should be clipped
+      expect(prompt).not.toContain('cmd-0 ')
+      // Last command should survive
+      expect(prompt).toContain(`cmd-${MAX_EVENTS_IN_PROMPT + 49}`)
+    })
+  })
+})

--- a/test/phase-22b/episodic-updater-haiku.test.ts
+++ b/test/phase-22b/episodic-updater-haiku.test.ts
@@ -1,0 +1,287 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { mkdtempSync, rmSync } from 'fs'
+
+vi.mock('../../src/main/services/logger', () => ({
+  createLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn()
+  })
+}))
+
+vi.mock('electron', () => ({ app: undefined }))
+
+vi.mock('@shared/app-identity', () => ({
+  getActiveAppDatabasePath: (home: string) => join(home, '.xuanpu', 'test.db'),
+  APP_BUNDLE_ID: 'test',
+  APP_CLI_NAME: 'test',
+  APP_PRODUCT_NAME: 'test'
+}))
+
+vi.mock('../../src/main/db', async () => {
+  const actual = await vi.importActual<typeof import('../../src/main/db')>('../../src/main/db')
+  return {
+    ...actual,
+    getDatabase: () => {
+      const g = globalThis as unknown as {
+        __sinkTestDb?: import('../../src/main/db/database').DatabaseService
+      }
+      if (!g.__sinkTestDb) throw new Error('test DB not initialized')
+      return g.__sinkTestDb
+    }
+  }
+})
+
+import { DatabaseService } from '../../src/main/db/database'
+import { getFieldEventSink, resetFieldEventSink } from '../../src/main/field/sink'
+import {
+  setFieldCollectionEnabledCache,
+  invalidatePrivacyCache
+} from '../../src/main/field/privacy'
+import { resetEventBus } from '../../src/server/event-bus'
+import { EpisodicMemoryUpdater } from '../../src/main/field/episodic-updater'
+import {
+  RuleBasedCompactor,
+  type EpisodicCompactor,
+  type CompactionOutput,
+  type CompactionInput,
+  InsufficientEventsError
+} from '../../src/main/field/episodic-compactor'
+
+let tmpDir: string
+let db: DatabaseService
+
+function seedWorktree(id: string): void {
+  const now = new Date().toISOString()
+  const project = db.createProject({
+    name: `proj-${id}`,
+    path: `/tmp/proj-${id}`,
+    description: null,
+    tags: null
+  })
+  db.getDbHandle()
+    .prepare(
+      `INSERT INTO worktrees (id, project_id, name, branch_name, path, status, is_default, branch_renamed,
+        session_titles, attachments, pinned, created_at, last_accessed_at)
+       VALUES (?, ?, ?, ?, ?, 'active', 0, 0, '[]', '[]', 0, ?, ?)`
+    )
+    .run(id, project.id, `wt-${id}`, `feature/${id}`, `/tmp/wt-${id}`, now, now)
+}
+
+async function seedEvents(worktreeId: string, count = 20): Promise<void> {
+  const sink = getFieldEventSink()
+  const t = Date.now()
+  for (let i = 0; i < count; i++) {
+    const evt = {
+      id: `e-${worktreeId}-${i}`,
+      timestamp: t - (count - i) * 1000,
+      worktreeId,
+      projectId: 'p-1',
+      sessionId: null,
+      relatedEventId: null,
+      type: 'file.focus' as const,
+      payload: { path: `/src/a-${i % 3}.ts`, name: `a-${i % 3}.ts`, fromPath: null }
+    }
+    sink.enqueue(evt as never, JSON.stringify(evt.payload))
+  }
+  await sink.flushNow()
+}
+
+function makeHaikuCompactor(opts: {
+  fail?: Error | null
+  markdown?: string
+}): EpisodicCompactor & { calls: number } {
+  let calls = 0
+  const compactor = {
+    id: 'claude-haiku',
+    version: 1,
+    async compact(input: CompactionInput): Promise<CompactionOutput> {
+      calls++
+      ;(compactor as unknown as { calls: number }).calls = calls
+      if (input.events.length < 5) throw new InsufficientEventsError(input.events.length)
+      if (opts.fail) throw opts.fail
+      return {
+        markdown:
+          opts.markdown ??
+          '## Claude Haiku Summary\nWorked on streaming renderer in hub-mobile; touched a-0.ts and a-1.ts; no failures observed.',
+        compactorId: 'claude-haiku',
+        version: 1
+      }
+    }
+  } as EpisodicCompactor & { calls: number }
+  compactor.calls = 0
+  return compactor
+}
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'xuanpu-episodic-haiku-updater-'))
+  db = new DatabaseService(join(tmpDir, 'test.db'))
+  db.init()
+  ;(globalThis as unknown as { __sinkTestDb: DatabaseService }).__sinkTestDb = db
+  resetFieldEventSink()
+  resetEventBus()
+  invalidatePrivacyCache()
+  setFieldCollectionEnabledCache(true)
+})
+
+afterEach(async () => {
+  try {
+    await getFieldEventSink().shutdown()
+  } catch {
+    /* noop */
+  }
+  db.close()
+  rmSync(tmpDir, { recursive: true, force: true })
+  delete (globalThis as unknown as { __sinkTestDb?: DatabaseService }).__sinkTestDb
+})
+
+describe('EpisodicMemoryUpdater — Phase 22B.2 Haiku injection + fallback', () => {
+  describe('happy path', () => {
+    it('writes a Haiku summary when the primary compactor succeeds', async () => {
+      seedWorktree('w-1')
+      await seedEvents('w-1', 20)
+      const haiku = makeHaikuCompactor({})
+      const fallback = new RuleBasedCompactor()
+      const updater = new EpisodicMemoryUpdater(haiku, 8_000, fallback)
+
+      const out = await updater.forceCompact('w-1')
+      expect(out?.compactorId).toBe('claude-haiku')
+
+      const stored = db.getEpisodicMemory('w-1')
+      expect(stored?.compactorId).toBe('claude-haiku')
+      expect(stored?.summaryMarkdown).toContain('Claude Haiku')
+      expect(updater.getCounters().compactions_written).toBe(1)
+      expect(updater.getCounters().compactions_fallback_used).toBe(0)
+      expect(haiku.calls).toBe(1)
+      await updater.shutdown()
+    })
+  })
+
+  describe('fallback', () => {
+    it('falls back to RuleBased when Haiku throws (timeout/quota/network)', async () => {
+      seedWorktree('w-1')
+      await seedEvents('w-1', 20)
+      const haiku = makeHaikuCompactor({ fail: new Error('HTTP 429 rate limit exceeded') })
+      const updater = new EpisodicMemoryUpdater(haiku, 8_000, new RuleBasedCompactor())
+
+      const out = await updater.forceCompact('w-1')
+      expect(out).not.toBeNull()
+      expect(out?.compactorId).toBe('rule-based')
+
+      const stored = db.getEpisodicMemory('w-1')
+      expect(stored?.compactorId).toBe('rule-based')
+      expect(stored?.summaryMarkdown).toContain('## Observed Recent Work')
+
+      const counters = updater.getCounters()
+      expect(counters.compactions_written).toBe(1)
+      expect(counters.compactions_failed).toBe(1)
+      expect(counters.compactions_fallback_used).toBe(1)
+      await updater.shutdown()
+    })
+
+    it('InsufficientEvents from primary does NOT trigger fallback (applies to stream, not compactor)', async () => {
+      seedWorktree('w-1')
+      // Only seed 3 events — below the min.
+      await seedEvents('w-1', 3)
+      const haiku = makeHaikuCompactor({})
+      const ruleSpy: EpisodicCompactor = {
+        id: 'rule-based',
+        version: 1,
+        compact: vi.fn(async () => ({
+          markdown: 'should not be called',
+          compactorId: 'rule-based',
+          version: 1
+        }))
+      }
+      const updater = new EpisodicMemoryUpdater(haiku, 8_000, ruleSpy)
+      const out = await updater.forceCompact('w-1')
+      expect(out).toBeNull()
+      expect(updater.getCounters().compactions_skipped_insufficient).toBe(1)
+      expect(ruleSpy.compact).not.toHaveBeenCalled()
+      await updater.shutdown()
+    })
+  })
+
+  describe("don't-downgrade guarantee", () => {
+    it('does not overwrite an existing Haiku summary with RuleBased when primary fails', async () => {
+      seedWorktree('w-1')
+      await seedEvents('w-1', 20)
+      // Seed an existing Haiku summary
+      db.upsertEpisodicMemory({
+        worktreeId: 'w-1',
+        summaryMarkdown: '## Pretend earlier Haiku output — must be preserved.',
+        compactorId: 'claude-haiku',
+        version: 1,
+        compactedAt: Date.now() - 60_000,
+        sourceEventCount: 10,
+        sourceSince: 0,
+        sourceUntil: Date.now()
+      })
+
+      // Primary (Haiku) fails; fallback is RuleBased, but existing summary is Haiku.
+      const haiku = makeHaikuCompactor({ fail: new Error('network error') })
+      const updater = new EpisodicMemoryUpdater(haiku, 8_000, new RuleBasedCompactor())
+
+      const out = await updater.forceCompact('w-1')
+      expect(out).toBeNull()
+
+      const stored = db.getEpisodicMemory('w-1')
+      expect(stored?.compactorId).toBe('claude-haiku')
+      expect(stored?.summaryMarkdown).toContain('Pretend earlier Haiku')
+
+      const counters = updater.getCounters()
+      expect(counters.compactions_skipped_downgrade).toBeGreaterThanOrEqual(1)
+      expect(counters.compactions_written).toBe(0)
+      await updater.shutdown()
+    })
+
+    it('still overwrites an existing RuleBased summary when Haiku succeeds (upgrade)', async () => {
+      seedWorktree('w-1')
+      await seedEvents('w-1', 20)
+      db.upsertEpisodicMemory({
+        worktreeId: 'w-1',
+        summaryMarkdown: '## Old rule-based summary kept until upgraded',
+        compactorId: 'rule-based',
+        version: 1,
+        compactedAt: Date.now() - 60_000,
+        sourceEventCount: 10,
+        sourceSince: 0,
+        sourceUntil: Date.now()
+      })
+
+      const haiku = makeHaikuCompactor({})
+      const updater = new EpisodicMemoryUpdater(haiku, 8_000, new RuleBasedCompactor())
+      const out = await updater.forceCompact('w-1')
+      expect(out?.compactorId).toBe('claude-haiku')
+
+      const stored = db.getEpisodicMemory('w-1')
+      expect(stored?.compactorId).toBe('claude-haiku')
+      expect(stored?.summaryMarkdown).not.toContain('Old rule-based summary')
+      await updater.shutdown()
+    })
+  })
+
+  describe('default fallback wiring', () => {
+    it('default constructor wires RuleBased as the fallback for Haiku', async () => {
+      // When we pass only a Haiku compactor (no explicit fallback), the
+      // updater should auto-wire a RuleBasedCompactor. We verify this by
+      // making the primary fail and checking that a rule-based summary
+      // still lands in the DB.
+      seedWorktree('w-1')
+      await seedEvents('w-1', 20)
+      const haiku = makeHaikuCompactor({ fail: new Error('HTTP 502 Bad Gateway') })
+      const updater = new EpisodicMemoryUpdater(haiku) // no explicit fallback
+
+      const out = await updater.forceCompact('w-1')
+      expect(out?.compactorId).toBe('rule-based')
+
+      const stored = db.getEpisodicMemory('w-1')
+      expect(stored?.compactorId).toBe('rule-based')
+      expect(updater.getCounters().compactions_fallback_used).toBe(1)
+      await updater.shutdown()
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Upgrades the episodic-memory compactor from the Phase 22B.1 rule-based stub to a real Claude Haiku summarizer, with the rule-based implementation retained as a fallback.

PRD: `docs/prd/phase-22b-episodic-memory.md` §Appendix (22B.1 → 22B.2)

## Changes

**New** `src/main/field/claude-haiku-compactor.ts`
- `ClaudeHaikuCompactor` implements `EpisodicCompactor` (`id='claude-haiku'`, `version=1`)
- Reuses `loadClaudeSDK` Haiku codepath from `claude-session-title.ts` — `model: 'haiku'`, `effort: 'low'`, `thinking: disabled`, no tools, no session persistence
- Prompt requires factual restatement + short abstract; explicitly forbids invention. Falls back to `Not enough activity to summarize.` on thin streams.
- 30s per-attempt timeout (AbortController), 1 retry (2 attempts), exponential backoff (1s, 2s) on `abort/timeout/429/502/rate-limit/ECONNRESET/ETIMEDOUT/network`
- Event stream clipped to tail 200 events; inline secrets (`api_key=...`, `Bearer xxx`) redacted before the LLM call
- Post-processes `<think>` tags and surrounding code fences; rejects too-short replies

**Updated** `src/main/field/episodic-updater.ts`
- Default primary compactor is now `ClaudeHaikuCompactor`; fallback auto-wired to `RuleBasedCompactor` when primary is `claude-haiku`
- `runCompact` refactored into a primary → fallback chain, still honoring `COMPACTOR_PRIORITY` so an existing Haiku summary is **never** overwritten by RuleBased
- `InsufficientEventsError` short-circuits the whole chain (same event stream, no point retrying fallback)
- New counter: `compactions_fallback_used`

## Tests

19 new tests, 53 related tests green.

- `test/phase-22b/claude-haiku-compactor.test.ts` — mocked `HaikuSDK`: happy path (asserts SDK options + prompt contents), `<think>`/fence stripping, too-short rejection, abort/timeout → retry success, 429 retry exhaustion, non-retryable errors skip retries, `AbortController` plumbed through timeout, retry classifier table, secret redaction, tail clipping
- `test/phase-22b/episodic-updater-haiku.test.ts` — Haiku happy path writes `claude-haiku`; primary failure falls back to RuleBased (`compactions_fallback_used++`); `InsufficientEventsError` does NOT trigger fallback; don't-downgrade preserves existing Haiku when primary fails; Haiku upgrade overwrites existing RuleBased; default constructor auto-wires fallback

```
Test Files  4 passed (4)
     Tests  53 passed (53)
```

## Manual verification still needed

On a real machine, let the updater actually fire (≥20 non-selection events, ≥10 min since last compaction, 8s debounce) and confirm the stored `summary_markdown` reads like *"过去 1 小时主要在修 hub mobile 的流式渲染"* rather than event counts.

```sql
SELECT compactor_id, summary_markdown FROM field_episodic_memory;
```