### PR TITLE
release: v1.4.2 — hotfix mobile UI dist missing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,6 +106,17 @@ jobs:
         shell: bash
         run: bash scripts/download-cloudflared.sh
 
+      # Mobile UI (#44) — built by the standalone Vite project under
+      # mobile/. The output (mobile/dist/) is referenced by
+      # extraResources `from: mobile/dist, to: mobile-ui` and served by
+      # hub-server.tryServeStatic at runtime. Local build:mac/build:win
+      # scripts run this automatically; CI forgot. Without this step
+      # the Hub server returns {"error":{"code":"NOT_FOUND","message":"/"}}
+      # when a user opens the URL in a browser — exactly what hit v1.4.0
+      # and v1.4.1.
+      - name: Build mobile UI
+        run: pnpm run build:mobile
+
       # ── Package — each job builds ONE arch only ──
       - name: Package (${{ matrix.platform }} ${{ matrix.arch }})
         run: pnpm exec electron-builder ${{ matrix.eb_flags }} --publish always

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xuanpu",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Xuanpu Workbench - an AI-native workbench for builders",
   "main": "./out/main/index.js",
   "author": "slicenferqin",


### PR DESCRIPTION
## v1.4.2 hotfix

跟 v1.4.1 的 cloudflared 同款 bug 第二次：CI 也没 build mobile UI，所以打出来的包里 \`Resources/mobile-ui/\` 是空的。用户打开 Hub 本机 URL 浏览器返回：

\`\`\`json
{"error":{"code":"NOT_FOUND","message":"/"}}
\`\`\`

修法：CI workflow 加 \`pnpm run build:mobile\` 步骤。

### 影响版本
- v1.4.0 / v1.4.1 → 浏览器访问 Hub URL 全部 404
- v1.4.2 → 修复

🤖 Generated with [Claude Code](https://claude.com/claude-code)