### PR TITLE
release: v1.4.3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,15 +118,185 @@ jobs:
         run: pnpm run build:mobile
 
       # ── Package — each job builds ONE arch only ──
+      # NOTE: --publish never is intentional. We publish in a separate step
+      # AFTER the post-package verify below, so a missing cloudflared / mobile
+      # asset never reaches the GitHub release page. See v1.4.0/v1.4.1
+      # post-mortems above.
       - name: Package (${{ matrix.platform }} ${{ matrix.arch }})
-        run: pnpm exec electron-builder ${{ matrix.eb_flags }} --publish always
+        run: pnpm exec electron-builder ${{ matrix.eb_flags }} --publish never
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      # ── Verify ──
-      - name: Verify build output
+      # ── Verify packaging completeness ──
+      # Post-package assertion: makes sure every artifact carries the
+      # bits that broke v1.4.0 / v1.4.1 (cloudflared binary + mobile UI
+      # dist + native .node addons). Fails the workflow before publish
+      # if anything is missing, so we never ship an empty-tunnel /
+      # 404-mobile-page release again.
+      - name: Verify packaging completeness (macOS)
+        if: matrix.platform == 'mac'
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "=== dist contents ==="
+          ls -lh dist/ || true
+
+          # Locate the .app — electron-builder names the dir mac-<arch>
+          # for non-default arch and `mac` for arm64 native, depending on
+          # version. Glob to be safe.
+          APP_PATH=$(find dist -maxdepth 3 -type d -name '*.app' | head -n 1)
+          if [ -z "$APP_PATH" ]; then
+            echo "::error::No .app bundle found under dist/"
+            exit 1
+          fi
+          RES="$APP_PATH/Contents/Resources"
+          echo "Checking $RES"
+
+          fail=0
+          check_file() {
+            if [ ! -f "$1" ]; then
+              echo "::error::missing file: $1"
+              fail=1
+            else
+              echo "ok: $1 ($(stat -f%z "$1" 2>/dev/null || stat -c%s "$1") bytes)"
+            fi
+          }
+
+          # cloudflared — only the matching arch is packed in
+          if [ "${{ matrix.arch }}" = "arm64" ]; then
+            check_file "$RES/cloudflared/darwin-arm64/cloudflared"
+          else
+            check_file "$RES/cloudflared/darwin-amd64/cloudflared"
+          fi
+
+          # mobile UI shipped to Resources/mobile-ui
+          check_file "$RES/mobile-ui/index.html"
+
+          # asar + unpacked native addons
+          check_file "$RES/app.asar"
+          if [ ! -d "$RES/app.asar.unpacked" ]; then
+            echo "::error::missing app.asar.unpacked"
+            fail=1
+          fi
+          # native .node addons must be extracted
+          if ! find "$RES/app.asar.unpacked" -name '*.node' | grep -q .; then
+            echo "::error::no .node files extracted under app.asar.unpacked"
+            fail=1
+          fi
+
+          # ghostty placeholder (or real binary) referenced by extraResources
+          check_file "$RES/native/ghostty.node"
+
+          # cloudflared binary must be non-empty (the v1.4.0 bug was a 0-byte file)
+          CF_BIN="$RES/cloudflared/darwin-${{ matrix.arch == 'arm64' && 'arm64' || 'amd64' }}/cloudflared"
+          if [ -f "$CF_BIN" ] && [ ! -s "$CF_BIN" ]; then
+            echo "::error::cloudflared binary is empty: $CF_BIN"
+            fail=1
+          fi
+
+          if [ "$fail" -ne 0 ]; then
+            echo "::error::Packaging verification failed — refusing to publish"
+            exit 1
+          fi
+          echo "Packaging verification passed."
+
+      - name: Verify packaging completeness (Windows)
+        if: matrix.platform == 'win'
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "=== dist contents ==="
+          ls -lh dist/ || true
+
+          # Locate the unpacked dir — usually win-unpacked or win-arm64-unpacked
+          UNPACKED=$(find dist -maxdepth 2 -type d -name '*unpacked*' | head -n 1)
+          if [ -z "$UNPACKED" ]; then
+            echo "::error::No *-unpacked directory found under dist/"
+            exit 1
+          fi
+          RES="$UNPACKED/resources"
+          echo "Checking $RES"
+
+          fail=0
+          check_file() {
+            if [ ! -f "$1" ]; then
+              echo "::error::missing file: $1"
+              fail=1
+            else
+              echo "ok: $1"
+            fi
+          }
+
+          if [ "${{ matrix.arch }}" = "arm64" ]; then
+            check_file "$RES/cloudflared/windows-arm64/cloudflared.exe"
+          else
+            check_file "$RES/cloudflared/windows-amd64/cloudflared.exe"
+          fi
+
+          check_file "$RES/mobile-ui/index.html"
+          check_file "$RES/app.asar"
+
+          if [ ! -d "$RES/app.asar.unpacked" ]; then
+            echo "::error::missing app.asar.unpacked"
+            fail=1
+          fi
+          if ! find "$RES/app.asar.unpacked" -name '*.node' | grep -q .; then
+            echo "::error::no .node files extracted under app.asar.unpacked"
+            fail=1
+          fi
+
+          # Setup installer / zip artifact must exist
+          if ! ls dist/Xuanpu-Setup-*.exe >/dev/null 2>&1 && ! ls dist/Xuanpu-*-${{ matrix.arch }}-win.zip >/dev/null 2>&1; then
+            echo "::error::no Windows installer or zip found in dist/"
+            fail=1
+          fi
+
+          if [ "$fail" -ne 0 ]; then
+            echo "::error::Packaging verification failed — refusing to publish"
+            exit 1
+          fi
+          echo "Packaging verification passed."
+
+      - name: List dist (always)
         if: always()
         shell: bash
         run: |
           echo "=== dist contents ==="
           ls -lh dist/ 2>/dev/null || echo "dist/ not found"
+
+      # ── Publish (after verify) ──
+      # Only runs if all previous steps succeeded — verify acts as a gate.
+      # We upload the artifacts that electron-builder produced under dist/,
+      # plus the auto-update metadata YAML files (latest-mac.yml /
+      # latest.yml) so the in-app updater keeps working.
+      - name: Publish to GitHub Release
+        if: startsWith(github.ref, 'refs/tags/v')
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          TAG="${GITHUB_REF_NAME}"
+          # Create the release if it doesn't exist yet (first matrix job to land wins).
+          if ! gh release view "$TAG" >/dev/null 2>&1; then
+            gh release create "$TAG" --draft --title "$TAG" --notes "Automated release for $TAG"
+          fi
+          # Collect platform-relevant artifacts.
+          shopt -s nullglob
+          files=()
+          if [ "${{ matrix.platform }}" = "mac" ]; then
+            files+=(dist/Xuanpu-*-${{ matrix.arch }}-mac.dmg dist/Xuanpu-*-${{ matrix.arch }}-mac.zip dist/latest-mac.yml dist/latest-mac-${{ matrix.arch }}.yml)
+          else
+            files+=(dist/Xuanpu-Setup-*.exe dist/Xuanpu-*-${{ matrix.arch }}-win.zip dist/latest.yml dist/latest-${{ matrix.arch }}.yml)
+          fi
+          # Filter to existing files only.
+          existing=()
+          for f in "${files[@]}"; do
+            [ -f "$f" ] && existing+=("$f")
+          done
+          if [ ${#existing[@]} -eq 0 ]; then
+            echo "::error::No artifacts to upload for ${{ matrix.platform }} ${{ matrix.arch }}"
+            exit 1
+          fi
+          echo "Uploading: ${existing[*]}"
+          gh release upload "$TAG" "${existing[@]}" --clobber

--- a/README.en.md
+++ b/README.en.md
@@ -14,43 +14,59 @@
 </div>
 
 ## What Is Xuanpu
-Xuanpu is an AI-native workbench for builders. It is not trying to be a traditional IDE with an AI sidebar. It treats the real units of modern work as first-class:
+Xuanpu is an AI-native workbench for builders. It is not "an editor with an AI sidebar" or "a terminal with a new theme." It puts the real first-class units of modern work back on the desktop:
 
-- `Workspace`
-- `Worktree`
-- `Session`
-- `Connections`
-- `Changes`
-- `Outputs`
+- `Workspace` — your projects, repos, linked repos, and the boundaries of your context
+- `Worktree` — the isolated execution surface for parallel tasks
+- `Session` — the thread an agent actually works in, not a one-shot Q&A
+- `Connections` — context shared across worktrees and across repos
+- `Changes` — files, diffs, command output, execution traces, approvals, questions
 
-If you regularly juggle multiple tasks, branches, repos, and agents, you already know the pain:
+If you regularly juggle multiple features, branches, repos, and agents at once, you already know the pain:
 
-- too many terminals and tabs
-- unclear agent state
-- polluted branches
-- fragmented context across repos
-- scattered approvals, diffs, questions, and outputs
+- too many terminals and tabs — no idea which agent is doing what
+- multiple tasks share one branch and pollute each other
+- jumping between front-end / back-end / multiple repos shreds the context you held in your head
+- agent generation, edits, questions, and approvals are scattered across different tools
 
-Xuanpu exists to pull that workflow back into one coherent desktop workbench.
+Xuanpu's goal is to pull that workflow back into one coherent desktop workbench.
 
-## What It Can Do Today
-- Project, worktree, and space management
-- Native session flows for Claude Code, OpenCode, and Codex
-- Streaming transcripts, approvals, question prompts, and task tracking
-- File tree, git status, inline diff, Monaco diff, and image diff
-- Embedded terminal, setup/run scripts, and execution state
-- Worktree connections for cross-branch and cross-repo context sharing
-- Headless mode backed by the same local database and services
-- Chinese-first UI and onboarding flow
+> **📖 v1.4.0 milestone**: Xuanpu just finished its turning point — from "an Electron workbench with Hub bolted on" to "a field provider for agents."
+> Read more (Chinese): [**From 1.3 to 1.4: Xuanpu's thinking on the AI-native workbench**](./docs/essays/2026-04-25-from-1-3-to-1-4-ai-native-workbench.md)
 
-## Why It Is Not Positioned As a Traditional IDE
-Xuanpu is centered on task progression rather than file editing:
+## Current Capabilities
 
-- what you move forward is a goal, not a single file
-- one task usually spans code, docs, scripts, reviews, and multiple repos
-- in the AI era, sessions, approvals, context, and worktree isolation deserve first-class UI
+**Workbench foundation**:
 
-That is why `AI-native workbench` is a more accurate category than `IDE`.
+- project / worktree / space management
+- native session flows for Claude Code, OpenCode, and Codex
+- streaming transcripts, permission approvals, question prompts, task tracking
+- file tree, git status, inline diff, Monaco diff, image diff
+- embedded terminal, setup / run script entry points, command run state
+- worktree connections for cross-branch and cross-repo context sharing
+- headless mode — same local DB and services exposed via GraphQL + WebSocket
+- Chinese-first UI, localized copy, first-launch environment check and agent onboarding
+
+**v1.4 field awareness** ([details, Chinese](./docs/essays/2026-04-25-from-1-3-to-1-4-ai-native-workbench.md)):
+
+- **Field event stream** — every bash command, file read/write, terminal output, and agent tool call is structured into SQLite, sharded by worktree
+- **Layered memory** — Working / Episodic (real summaries from Claude Haiku) / Semantic (your `memory.md`), shared across agents
+- **Field injection** — every prompt is automatically prefixed with Field Context (worktree, current focus, recent activity, what you were doing when you last hit abort), so you don't have to "translate" yourself again
+- **Session checkpoints** — abort, sleep, or crash, the next launch picks the field back up
+- **Hub remote / mobile** — desktop runs the service, your phone scans the QR code and takes over the session; the same field follows you across devices
+- **New Session UI (v2)** — unified timeline, three-state Composer, Agent Rail, Field Context Debug panel
+
+This means it's no longer just "a convenient Electron shell for browsing files" — it's a desktop workbench that actually lets agents see the field they're operating in.
+
+## Xuanpu Is Not an IDE — It's a Field Provider for Agents
+
+Open Cursor, Claude Code, Codex, or Amp and at heart it's the same interaction: user intent → translate to natural language → type into a box → model replies.
+
+**The problem isn't that the model isn't smart enough — it's that the model can't see the field.** Which worktree you're in, which file is open, what command you just ran, what you've been doing the last hour, what you were doing when you last hit abort. All of this is naturally visible to a human collaborator and completely invisible to the AI.
+
+What Xuanpu does is move that visibility layer out of the user's head and into the agent's prompt. Its differentiation isn't in the UI (we did rewrite it), and not in the agent model (we don't train one) — it's that **any agent inside Xuanpu becomes more capable than in its native environment, because for the first time it gets a field**.
+
+Full reasoning: [VISION](./docs/VISION.md) and the [v1.4.0 retrospective](./docs/essays/2026-04-25-from-1-3-to-1-4-ai-native-workbench.md) (Chinese).
 
 ## Install
 ### Releases
@@ -84,6 +100,15 @@ pnpm dev
 - `Windows`: supported — all core features work; Ghostty terminal is macOS-only
 - `Linux`: planned target, still evolving
 
+## Quick Start
+1. Add a local git repo as a project
+2. Create a dedicated worktree for the current task
+3. Start an agent session inside that worktree
+4. Browse files, diffs, run output, and changes on the right
+5. When you need it, pull related worktrees / repos in via connections
+
+If you live on the keyboard, the command palette, session switcher, sidebar toggles, and terminal/file pane interplay should feel natural.
+
 <p>
   <a href="https://github.com/slicenferqin/xuanpu/releases"><img src="https://img.shields.io/github/downloads/slicenferqin/xuanpu/total?style=flat-square&label=total%20downloads&color=blue" alt="Total Downloads" /></a>
   <a href="https://github.com/slicenferqin/xuanpu/releases/latest"><img src="https://img.shields.io/github/downloads/slicenferqin/xuanpu/latest/total?style=flat-square&label=latest%20release&color=brightgreen" alt="Latest Release Downloads" /></a>
@@ -92,7 +117,7 @@ pnpm dev
 📊 [View full download analytics →](https://greedeks.github.io/Pulse/?username=slicenferqin&repo=xuanpu)
 
 ## Repo Status
-Current stack:
+This repo is the desktop main line. Current stack:
 
 - Electron 33
 - React 19
@@ -101,15 +126,32 @@ Current stack:
 - Zustand 5
 - SQLite / better-sqlite3
 
-Architecture:
+Architecture (three layers):
 
-- `src/main/`: Electron main process, database, services, IPC
-- `src/preload/`: typed bridge
-- `src/renderer/`: React UI
-- `src/server/`: headless / remote GraphQL entry
+- `src/main/` — main process, database, services, IPC
+- `src/preload/` — typed bridge
+- `src/renderer/` — React UI
+
+A `headless` service entry is also kept, so the desktop app and automation / remote control share the same local core.
+
+## Current Priorities
+
+v1.4.0 cracked the first mile of "field." The 1.4.x line is about **making memory visible and editable**:
+
+- **1.4.3 release / onboarding hardening** — CI post-package verify, first-run onboarding card, README.en.md sync, Edit/Write diff preview, Composer image large preview
+- **1.4.4 Codex experience overhaul** — make Codex inside Xuanpu actually feel native
+- **1.4.5 Memory panel** — promote the 4-tab Field Context Debug into a real Memory panel: see + edit + reset + regenerate
+- **1.4.6 Cost visibility** — token / ¥ spend on compaction, surfaced clearly per month
+- **1.4.x cross-agent injection quality** — empirically verify Codex / OpenCode / Amp are *using* the Field Context prefix, not silently dropping it
+
+The next ring (VISION §3.2) is **XFP (Xuanpu Field Protocol)** — let any agent vendor obtain the field through a shared protocol, so "agents are stronger inside Xuanpu" becomes a standard, not a moat.
+
+Full roadmap (Chinese): [docs/plans/2026-04-25-memory-product-direction.md](./docs/plans/2026-04-25-memory-product-direction.md)
+
+If you open the repo today you'll see parts that are still in motion — that's expected. Xuanpu is transitioning from an early fork into a standalone product line.
 
 ## Origins
-Xuanpu started as a fork / evolution of [Hive](https://github.com/slicenferqin/xuanpu). A meaningful part of the original engineering foundation and product inspiration came from Hive, and that credit should remain visible.
+Xuanpu started as a fork / evolution of [Hive](https://github.com/slicenferqin/xuanpu). A meaningful part of the original engineering foundation, workbench structure, and product inspiration came from Hive. This product line has since diverged toward Chinese-first workflow, desktop-native interaction, and an independent brand, but credit to the original should stay visible.
 
 ## Contributing
 Contributions are especially valuable in these areas:

--- a/docs/plans/2026-04-23-amp-adapter-integration.md
+++ b/docs/plans/2026-04-23-amp-adapter-integration.md
@@ -1,0 +1,459 @@
+# Amp Adapter 接入技术方案
+
+**日期**：2026-04-23
+**性质**：1.4.0 发布后启动的实验性接入
+**状态**：方案定稿，待 1.4.0 发版后在 `feat/amp-adapter` 分支实施
+**负责人**：TBD（首批自用 + 个人驱动）
+**关联文档**：[2026-04-23-companion-and-autopilot-direction.md](./2026-04-23-companion-and-autopilot-direction.md)
+
+---
+
+## TL;DR
+
+- **目标**：把 Sourcegraph Amp 作为玄圃第 4 个 agent runtime 接入，与 CC / Codex / OpenCode 同级
+- **路径**：直接依赖官方 `@sourcegraph/amp-sdk`（TypeScript SDK），SDK 调用收拢在 `amp-implementer.ts` 单文件
+- **License**：PolyForm-Noncommercial-1.0.0，当前自用/pre-commercial 阶段可接受，商业化前必须切换到 CLI spawn 方案
+- **工作量**：MVP ≈ 5 人日；完整版（含 Phase 21.5 对齐） ≈ 7.5 人日
+- **启动时机**：1.4.0 发版后，不绑定主线节奏
+
+---
+
+## 一、背景与动机
+
+### 1.1 起点
+
+来自 2026-04-23 的产品方向讨论（见关联文档）。讨论中识别的三个事实：
+
+1. **玄圃护城河 = 跨 agent 横向视野**，不是单一 agent 的深度
+2. **市场上有程序化接入通道的 agent 不多**：CC / Codex / OpenCode / Amp / Continue.dev 是目前主要候选
+3. **Amp 有官方 TS SDK + `--stream-json` CLI 模式**，接入门槛和现有三家相当
+
+### 1.2 驱动力
+
+当前 Amp 接入**不是主线路线图任务**，驱动力是：
+
+- **个人使用习惯**：维护者日常也在用 Amp，希望纳入玄圃的"多 worktree + 多 session + FieldEvent"统一视野
+- **验证 adapter 层的扩展性**：当前 `AgentRuntimeAdapter` 抽象只服务三家，接第四家是对抽象层的首次真正考验
+- **为未来商业/主流扩展留路径**：如果自用体验好，1.6.0+ 可以考虑作为官方支持的 agent
+
+### 1.3 与 1.5.0 规划的关系
+
+1.5.0 主线是 **Phase 21.5 跨 agent 化**（给 OpenCode / Codex 补齐 Claude Code 已有的 agent tool events 抽象）。Amp adapter **独立于这条主线**，建议作为：
+
+- 实验分支（`feat/amp-adapter`）先跑通 MVP
+- 不阻塞 1.5.0 发版
+- 自用验证后再决定是否合入主线
+
+---
+
+## 二、调研结论
+
+### 2.1 Amp 产品概览
+
+**Amp** 是 [Sourcegraph 2026 推出的 agent 级 AI 编码产品](https://ampcode.com/)，定位对标 Claude Code / Codex，主要特征：
+
+- 多模型支持（Claude Opus / GPT-5 等，用户无需自己配 key，Sourcegraph 代管）
+- 独立 CLI（`npm i -g @sourcegraph/amp`）+ VS Code / JetBrains 插件
+- Thread 模型（对应玄圃的 session 概念）
+- 官方 Skills / MCP 集成 / 自定义 Tools
+
+### 2.2 接入通道
+
+Amp 提供**三条**程序化接入通道：
+
+| 通道 | 包名 | 说明 |
+|---|---|---|
+| TypeScript SDK | [`@sourcegraph/amp-sdk`](https://libraries.io/npm/@sourcegraph%2Famp-sdk) | 官方 SDK，async iterator 流式消息 |
+| Python SDK | [`amp-sdk` (PyPI)](https://pypi.org/project/amp-sdk/) | 同语义，但对 Electron 项目不友好 |
+| CLI `--stream-json` | 内置于 `@sourcegraph/amp` | NDJSON 格式，stdin/stdout 协议 |
+
+玄圃是 Electron + TypeScript 技术栈，**TS SDK 是最自然匹配**。
+
+### 2.3 TS SDK API 形态
+
+```ts
+import { AmpOptions, execute } from '@sourcegraph/amp-sdk'
+
+const messages = execute({ prompt, options })
+for await (const message of messages) {
+  if (message.type === 'system')    { /* { session_id, cwd, tools, mcp_servers } */ }
+  if (message.type === 'user')      { /* echoed user input */ }
+  if (message.type === 'assistant') { /* streaming model output */ }
+  if (message.type === 'result')    { /* { duration_ms, is_error, num_turns, result } */ }
+}
+```
+
+**关键能力**：
+- `execute()` 返回 `AsyncIterator` —— 和 CC SDK 风格一致
+- `AmpOptions` 支持 `cwd` / `dangerouslyAllowAll` / `toolbox` / thread 参数
+- `create_permission` helper 做细粒度工具权限
+- `create_user_message()` 在流中追加 user 消息（实现 `steer`）
+- Thread 级别 resume（`amp threads continue` 语义）
+
+### 2.4 License
+
+```
+License: PolyForm-Noncommercial-1.0.0
+```
+
+**边界**（[原文](https://polyformproject.org/licenses/noncommercial/1.0.0/)）：
+
+| 场景 | 合规性 |
+|---|---|
+| 个人自用 | ✅ 安全 |
+| 公开开源分发免费二进制（玄圃当前形态） | ✅ 安全 |
+| 在公司内部用玄圃写公司代码 | ⚠️ 灰色 |
+| 玄圃付费版 / 接受商业赞助 | ❌ 违规 |
+
+**结论**：当前阶段可接受，**商业化前必须评估是否切换到 CLI spawn 方案**。
+
+---
+
+## 三、能力矩阵（Amp ↔ AgentRuntimeAdapter）
+
+参考 `src/main/services/agent-runtime-types.ts` 中的 21 个方法接口。
+
+| AgentRuntimeAdapter 方法 | Amp 实现 | 覆盖度 | 备注 |
+|---|---|---|---|
+| `connect` / `disconnect` | Thread 创建 / 关闭 | ✅ | `execute()` 首次调用产生 `system.init` 含 `session_id` |
+| `reconnect` | `amp threads continue <threadID>` 语义 | ✅ | SDK options 接受 thread 参数 |
+| `cleanup` | 清理所有 thread | ✅ | |
+| `prompt` | `execute({ prompt, options })` | ✅ | 一次性 prompt |
+| `steer` | `create_user_message()` 流追加 | ✅ | SDK 支持 `AsyncIterator<UserInputMessage>` |
+| `abort` | `AbortController` 传入 SDK | ✅ | |
+| `getMessages` | 解析已收 messages 缓存 / `threads.markdown()` | ✅ | |
+| `getSessionInfo` | 自维护 revertMessageID | ⚠️ | undo/redo 不支持时返回 null |
+| `questionReply` | 通过 stream input 回 question 响应 | ✅ | 需细看 [plugin-api](https://ampcode.com/manual/plugin-api) |
+| `questionReject` | 同上 | ✅ | |
+| `permissionReply` | `create_permission` + `ToolCallEvent` 协议 | ✅ | action: `allow` / `reject-and-continue` / `modify` |
+| `permissionList` | 自维护 pending 列表 | ✅ | |
+| `hasPendingQuestion` / `hasPendingApproval` | 自维护 | ✅ | |
+| `undo` / `redo` | ❌ Amp 暂无原生 API | ❌ | 初版 capabilities `false`，抛 `NOT_SUPPORTED` |
+| `listCommands` / `sendCommand` | Amp 用 Skills 概念，不映射 | ❌ | 初版 capabilities `false` |
+| `getAvailableModels` / `getModelInfo` | SDK 通过 settings 文件配置 | ⚠️ | 初版可硬编码已知模型清单，迭代再做动态发现 |
+| `setSelectedModel` / `clearSelectedModel` | 写入 AmpOptions | ✅ | |
+| `renameSession` | Thread Labels API | ✅ | |
+| `forkSession` | Thread Visibility 不等同 fork | ❌ | 初版抛 `FORK_NOT_SUPPORTED`（与 CC/Codex 一致） |
+| `setMainWindow` | 玄圃自身机制 | ✅ | |
+
+**覆盖度评估**：核心 lifecycle / messaging / permission **100%**；P2 能力（undo/fork/commands）有缺口，**与 OpenCode/Codex 同级**，不是退化版。
+
+### 3.1 AMP_CAPABILITIES（初版）
+
+```ts
+export const AMP_CAPABILITIES: AgentRuntimeCapabilities = {
+  supportsUndo: false,           // 初版 false，等 Amp 出原生 API
+  supportsRedo: false,
+  supportsSteer: true,           // SDK 流式输入支持
+  supportsCommands: false,       // Skills 概念不映射
+  supportsPermissionRequests: true,
+  supportsQuestionPrompts: true,
+  supportsModelSelection: true,
+  supportsReconnect: true,       // thread continue
+  supportsPartialStreaming: true
+}
+```
+
+---
+
+## 四、架构设计
+
+### 4.1 文件布局
+
+新增文件（参考 Codex adapter 的模块化风格）：
+
+```
+src/main/services/
+├── amp-binary-resolver.ts       # 检测用户本地 amp CLI 安装
+├── amp-implementer.ts           # AgentRuntimeAdapter 实现（唯一 SDK 引入点）
+├── amp-event-mapper.ts          # SDK message → agent event bus 归一化
+├── amp-activity-mapper.ts       # SDK message → Session HQ activity 流
+├── amp-session-title.ts         # 自动命名 thread（复用 CC/Codex 的模板）
+├── amp-models.ts                # 已知模型清单（初版硬编码）
+└── amp-utils.ts                 # 辅助函数
+```
+
+**强约束**：`@sourcegraph/amp-sdk` 的 import 只出现在 `amp-implementer.ts`。其他文件通过 `amp-implementer.ts` 导出的类型 alias 使用 SDK 类型。这是 License 风险的软着陆设计（详见第五章）。
+
+### 4.2 事件归一化
+
+SDK 的 message 类型与玄圃 `normalize-agent-event` 的映射：
+
+| Amp message | 玄圃 agent event | 备注 |
+|---|---|---|
+| `system` (subtype: init) | `session.connected` | 取出 `session_id` 作为 agentSessionId |
+| `user` | `message.user.committed` | echo 回来的用户输入 |
+| `assistant` (streaming) | `message.assistant.delta` | 增量输出 |
+| `assistant` (final) | `message.assistant.committed` | stop_reason != null |
+| tool_use（在 assistant content 里） | `tool.call.started` | 对齐 Phase 21.5 tool events |
+| tool_result | `tool.call.completed` | |
+| `result` | `session.turn.completed` | 含 duration_ms / num_turns / token usage |
+| permission 请求 | `permission.requested` | 需细看 ToolCallEvent 协议 |
+
+### 4.3 SDK 调用隔离模式
+
+```ts
+// amp-implementer.ts —— 唯一引入 @sourcegraph/amp-sdk 的文件
+import {
+  execute,
+  AmpOptions,
+  create_permission,
+  create_user_message
+} from '@sourcegraph/amp-sdk'
+
+// 所有 SDK 类型向外 re-export 为玄圃内部别名
+export type AmpMessage = /* SDK 类型别名 */
+export type AmpUserInput = /* SDK 类型别名 */
+
+export class AmpImplementer implements AgentRuntimeAdapter {
+  readonly id: AgentRuntimeId = 'amp'
+  readonly capabilities = AMP_CAPABILITIES
+
+  // ... 所有 SDK 调用收拢在此类中
+}
+```
+
+**切换成本**：如果未来需要改走 CLI spawn，只需重写 `amp-implementer.ts` 一个文件，其他七个文件零改动。预估切换成本 ≈ 3 人日。
+
+### 4.4 进程内 vs 子进程
+
+- **TS SDK 路径**：SDK 调用在 Electron **main 进程内**，SDK 自己会管理与 Amp 后端的 HTTP/SSE 连接
+- **不需要 spawn 额外子进程**（对比 Codex 要 spawn app-server、OpenCode 要 spawn server）
+- **优点**：进程管理简单、资源占用低
+- **注意**：需测试 SDK 在 Electron main 进程（Node runtime）的兼容性，特别是 fetch / AbortSignal / async iteration 行为
+
+---
+
+## 五、License 决策（嵌入式 ADR）
+
+### ADR-001: Amp adapter 直接依赖 @sourcegraph/amp-sdk
+
+**决策日期**：2026-04-23
+**决策状态**：已接受（自用 / pre-commercial 阶段）
+**决策者**：项目 owner
+
+#### 决策
+
+Amp adapter 的实现直接在 `package.json` 中依赖 `@sourcegraph/amp-sdk`，而非通过 CLI spawn + stream-json 方式间接调用。
+
+#### 考量对比
+
+| 维度 | TS SDK | CLI spawn |
+|---|---|---|
+| 开发工作量 | ~7.5 人日 | ~11 人日 |
+| Type safety | 完整 | 自写 NDJSON 类型 |
+| 运行时依赖 | npm package | 用户本地 `amp` 二进制 |
+| License 风险 | ⚠️ PolyForm-NC 进入 package.json | ✅ 不直接依赖 SDK |
+| Electron 打包复杂度 | 略增 | 无变化 |
+
+#### 已知风险
+
+**PolyForm-Noncommercial-1.0.0** license 的核心约束：
+
+> "any use that does not include an intention of or result in commercial advantage or monetary compensation"
+
+在以下任何事件发生时，必须**重新评估**本决策：
+
+1. 玄圃开始接受赞助 / 付费订阅 / 商业合作
+2. 企业版或付费版计划启动
+3. Sourcegraph 改变 Amp 的 license 条款
+4. 收到 Sourcegraph 的 cease-and-desist 或 license 合规询问
+
+#### 应对预案
+
+如需切换到 CLI spawn 方案：
+
+1. `amp-implementer.ts` 内部重写（spawn `@sourcegraph/amp` CLI 二进制 + `--stream-json` 解析）
+2. 从 `package.json` 移除 `@sourcegraph/amp-sdk` 依赖
+3. 其他七个文件无需改动（因为 SDK 调用已被隔离）
+4. 预估切换成本 ≈ 3 人日
+
+#### 拒绝的替代方案
+
+- **方案 B：直接走 CLI spawn**。拒绝理由：开发速度慢 ~30%、Type safety 自写成本高、license 优势在当前阶段尚不需要
+- **方案 D：插件化**。把 Amp 作为玄圃可选插件、用户自行安装 SDK。拒绝理由：玄圃当前没有插件系统，为此搭建插件架构代价远大于直接集成
+
+---
+
+## 六、实现路径
+
+### 6.1 Phase 0：前置准备（0.5 人日）
+
+- [ ] 在 `feat/amp-adapter` 分支启动
+- [ ] `pnpm add @sourcegraph/amp-sdk`，验证在 Electron main 进程的兼容性（特别是 fetch / streams / async iteration）
+- [ ] 阅读 [`/manual/plugin-api`](https://ampcode.com/manual/plugin-api) 中 `ToolCallEvent` 协议，确认 permission 双向流的具体格式
+- [ ] 用一个独立 sandbox 跑通 `execute()` 基本调用，确认 message 类型和 SDK 文档一致
+
+### 6.2 Phase 1：MVP（5 人日，自用够用）
+
+目标：在你自己机器上跑通 Amp 接入 Session HQ 的基础体验。
+
+| Task | 工作量 | 产出 |
+|---|---|---|
+| `agent-runtime-types.ts` 添加 `'amp'` 到 `AgentRuntimeId` union + `AMP_CAPABILITIES` 常量 | 0.25 天 | type 定义 |
+| `amp-binary-resolver.ts` | 0.5 天 | 检测 `npm i -g @sourcegraph/amp` 安装、版本号、未安装时友好提示 |
+| `amp-implementer.ts` 骨架（connect/disconnect/prompt/abort/getMessages） | 1.5 天 | 基础生命周期 |
+| `amp-event-mapper.ts` | 1 天 | SDK message 流 → agent event bus |
+| 注册到 `agent-runtime-manager.ts` | 0.25 天 | 让 manager 能创建 Amp 实例 |
+| Renderer 端最小适配（NewSessionDialog 加 Amp 选项 + SessionView 渲染） | 1 天 | UI 能跑 |
+| 自用联调 | 0.5 天 | |
+
+**MVP 验收**：能在玄圃里新建 Amp session、发 prompt、收到流式响应、能 abort、能查看历史 messages。
+
+### 6.3 Phase 2：完整版（再 +2.5 人日，达到三家同级）
+
+| Task | 工作量 | 产出 |
+|---|---|---|
+| `amp-activity-mapper.ts` + Phase 21.5 tool event 对齐 | 1.5 天 | Session HQ 活动流和 CC/Codex 一致 |
+| Permission 双向流（`ToolCallEvent` 完整实现） | 0.5 天 | 工具权限 UI 可用 |
+| `reconnect` / thread management | 0.25 天 | 重启玄圃后恢复 thread |
+| Model selection（初版硬编码已知模型） | 0.25 天 | UI 可切换 Claude Opus / GPT-5 等 |
+
+### 6.4 Phase 3：可选增强（按需）
+
+- onboarding-doctor 集成（检测 amp 已装、登录态、网络）
+- session-title 自动命名
+- 模型清单动态发现（如 Amp 后续提供 API）
+- E2E 测试用例
+
+### 6.5 文件改动清单
+
+**新增**（7 文件）：
+```
+src/main/services/amp-binary-resolver.ts
+src/main/services/amp-implementer.ts
+src/main/services/amp-event-mapper.ts
+src/main/services/amp-activity-mapper.ts
+src/main/services/amp-session-title.ts
+src/main/services/amp-models.ts
+src/main/services/amp-utils.ts
+```
+
+**修改**（基于 Grep `AgentRuntimeId` 引用点）：
+
+| 文件 | 改动 |
+|---|---|
+| `src/main/services/agent-runtime-types.ts` | union 加 `'amp'`、新增 `AMP_CAPABILITIES` |
+| `src/main/services/agent-runtime-manager.ts` | 注册 AmpImplementer |
+| `src/main/db/database.ts` | 如有 agent 类型枚举校验，需扩展 |
+| `src/main/db/types.ts` | 同上 |
+| `src/preload/index.ts` / `index.d.ts` | 如有类型 union 暴露，扩展 |
+| `src/shared/types/worktree.ts` | union 扩展 |
+| `src/shared/types/session.ts` | union 扩展 |
+| `src/shared/types/agent-protocol.ts` | union 扩展 |
+| `src/server/resolvers/helpers/sdk-dispatch.ts` | switch case 加 amp 分支 |
+| `src/server/resolvers/helpers/runtime-dispatch.ts` | 同上 |
+| `src/main/ipc/agent-handler-wrapper.ts` | 同上 |
+| `src/renderer/src/stores/useWorktreeStore.ts` | union 扩展 |
+| `src/renderer/src/stores/useSettingsStore.ts` | 同上 |
+| `src/renderer/src/stores/useSessionStore.ts` | 同上 |
+| `src/renderer/src/components/setup/AgentSetupGuard.tsx` | Amp 安装引导 |
+| `src/renderer/src/components/sessions/NewSessionDialog.tsx` | 选项加 Amp |
+| `src/renderer/src/components/sessions/SessionView.tsx` | 渲染分支 |
+| `src/renderer/src/components/sessions/SessionTabs.tsx` | tab 图标 / 颜色 |
+| `src/renderer/src/components/session-hq/SessionHeader.tsx` | header 显示 |
+| `package.json` | 加 `@sourcegraph/amp-sdk` 依赖 |
+
+**实施时第一步**：在分支上跑 `grep -r "'opencode' | 'claude-code' | 'codex' | 'terminal'" src/` 拿到所有需扩展的 union 字面量位置，逐个加 `'amp'`。
+
+---
+
+## 七、风险与应对
+
+| 风险 | 概率 | 影响 | 应对 |
+|---|---|---|---|
+| SDK 在 Electron main 进程不兼容（fetch/streams 行为） | 低 | 中 | Phase 0 sandbox 先验证；不兼容则降级为 CLI spawn |
+| `ToolCallEvent` 协议文档���完整、permission 流走不通 | 中 | 中 | 先实现 `dangerouslyAllowAll: true` 跑通主流程，permission 流作为 Phase 2 |
+| Amp SDK 频繁 pre-release 更新（npm 上看到 nightly 节奏）破坏 API | 中 | 低 | 锁定具体版本号，不用 `^` 范围；定期手动升级 |
+| Phase 21.5 抽象不能干净映射 Amp 的 tool event | 中 | 低 | Phase 21.5 跨 agent 化主线推进时同步对齐，必要时反过来调整抽象 |
+| License 状态突变（Sourcegraph 改条款 / 玄圃商业化） | 低-中 | 高 | 隔离设计已就绪，3 人日切换到 CLI spawn |
+| Amp 后端依赖 Sourcegraph 服务（不是纯本地 agent） | 高 | 低 | 这是 Amp 产品定性，玄圃不解决；onboarding-doctor 提示用户登录态 |
+
+---
+
+## 八、验收标准
+
+### 8.1 MVP 验收（Phase 1 完成）
+
+- [ ] 在玄圃 NewSessionDialog 中可选 Amp 作为 agent
+- [ ] 新建 Amp session 后能成功 connect，UI 显示 connected 状态
+- [ ] 发送 prompt 后能收到流式响应，渲染到 Session HQ
+- [ ] Abort 按钮能中断进行中的 turn
+- [ ] 关闭 session 不留僵尸进程 / 残留连接
+- [ ] 至少在你的日常工作流程下连续使用 1 周无致命 bug
+
+### 8.2 完整版验收（Phase 2 完成）
+
+MVP 全部通过 +：
+
+- [ ] Tool 使用在 Session HQ 活动流中显示，格式与 CC/Codex 一致
+- [ ] Permission 请求弹窗工作正常，allow / reject / modify 三种 action 都能回包
+- [ ] 玄圃重启后能 reconnect 上次的 thread
+- [ ] 模型切换 UI 工作（至少能切换 Claude Opus / GPT-5）
+- [ ] `lint` / `tsc` / `vitest` 全绿
+- [ ] 不破坏现有三家 agent 的任何行为
+
+### 8.3 合并主线门槛（决定是否合入 main）
+
+完整版通过 +：
+
+- [ ] 自用满意度评估：连续 2 周自用，体验不弱于 CC / Codex
+- [ ] License 状态复核：玄圃当前阶段仍是 pre-commercial，无新风险
+- [ ] 文档：在 `docs/GUIDE.md` 中加 Amp 接入说明（用户视角）
+
+---
+
+## 九、实施日历建议
+
+| 时间 | 事件 |
+|---|---|
+| 1.4.0 发版 | 不动 Amp adapter，全力发版 |
+| 1.4.0 发版 +1 天 | 开 `feat/amp-adapter` 分支，启动 Phase 0 |
+| +1 周 | Phase 1 MVP 完成，开始自用 |
+| +2 周 | Phase 2 完整版完成 |
+| +4 周 | 自用 2 周后做合并决策 |
+
+不绑死 1.5.0 节奏。1.5.0 主线（Phase 21.5 跨 agent 化）由其他人/其他时间窗口推进，Amp adapter 不阻塞、不抢资源。
+
+---
+
+## 十、参考资料
+
+### Amp 官方
+- [Amp 官网](https://ampcode.com/)
+- [Amp Owner's Manual](https://ampcode.com/manual)
+- [Amp SDK 文档](https://ampcode.com/manual/sdk)
+- [Amp TypeScript SDK 公告](https://ampcode.com/news/typescript-sdk)
+- [Amp Streaming JSON 公告](https://ampcode.com/news/streaming-json)
+- [Amp Plugin API（permission/tool 协议）](https://ampcode.com/manual/plugin-api)
+- [Amp CLI guide](https://github.com/sourcegraph/amp-examples-and-guides/blob/main/guides/cli/README.md)
+- [Amp CLI API 路由文档](https://help.router-for.me/agent-client/amp-cli)
+
+### 包
+- [`@sourcegraph/amp-sdk` (npm)](https://libraries.io/npm/@sourcegraph%2Famp-sdk)
+- [`@sourcegraph/amp` CLI (npm)](https://www.npmjs.com/package/@sourcegraph/amp)
+
+### License
+- [PolyForm Noncommercial 1.0.0](https://polyformproject.org/licenses/noncommercial/1.0.0/)
+
+### 玄圃内部
+- [2026-04-23 伴随式 / 自动驾驶方向](./2026-04-23-companion-and-autopilot-direction.md)
+- `src/main/services/agent-runtime-types.ts` —— AgentRuntimeAdapter 接口
+- `src/main/services/codex-implementer.ts` —— 接入参考（最近的同级实现）
+- `src/main/services/opencode-service.ts` —— 接入参考（spawn 风格对照）
+
+---
+
+## 附录 A：决策记忆
+
+为什么不等 Amp 出官方 ACP 实现？
+> ACP 当前还是 Zed 主推的早期协议，Amp 没表态。等 ACP 等于无限期推迟，且 ACP 设计偏 1:1 的「编辑器 ↔ agent」模型，无法覆盖玄圃跨 worktree / 多 session 的场景。直接走 SDK 是务实选择。
+
+为什么不做插件系统？
+> 插件系统是 1.7.0+ 才考虑的事情。现在为单个 agent 接入搭建插件架构，复杂度远大于收益。SDK 隔离设计已经提供了"未来插件化"的预演路径。
+
+为什么 Amp 优先级排在 Continue.dev 之前？
+> Continue.dev 用户重合度低（VS Code 内嵌），且与 OpenCode 生态位撞车（都是 BYOK + 开源）。Amp 是 Sourcegraph 背书的 SaaS 风格 agent，独立生态位。但**真正的优先级理由仍然是"项目 owner 个人使用"**，不是市场分析。
+
+
+

--- a/docs/plans/2026-04-23-companion-and-autopilot-direction.md
+++ b/docs/plans/2026-04-23-companion-and-autopilot-direction.md
@@ -1,0 +1,388 @@
+# 玄圃演进方向：伴随式工作台 + 意图级托管
+
+**日期**：2026-04-23
+**性质**：未来方向探索，**非当前迭代任务**
+**状态**：待时机成熟后再启动；当前 1.4.0 / Phase 21.5 / Phase 24c 优先
+
+---
+
+## 一、起点
+
+来自一次开放式讨论。两个直觉同时浮现：
+
+1. **伴随感** —— 受华为 HarmonyOS 6「小艺伴随式 AI」（2026-04 Pura X Max 首发）启发：工作台能否像「在场的同事」一样持续陪伴使用者，而不是被召唤的工具
+2. **托管模式** —— Claude Code / Codex / OpenCode 频繁打断用户做小决策（continue?、A or B?）。能否由玄圃在 user 和 agent 之间插入一层「代理决策层」，把这些微观打断接走，仅在重大歧义时才停下
+
+讨论结论：这两件事不是两个 feature，而是**同一个产品哲学的两面**——
+- 伴随 = 空间维度（AI 在场，不需召唤）
+- 托管 = 时间维度（AI 自主推进，不需逐步指挥）
+
+合起来定义玄圃的下一个产品形态：**在场 + 自主**。
+
+---
+
+## 二、产业参照系（2026-04 同月爆发）
+
+### 华为「小艺伴随式 AI」（消费级伴随）
+
+四个机制可借鉴：
+1. **侧边常驻**：始终在场，不占主界面
+2. **三种伴随模式**：侧边常驻 / 展开 / 后台静默——不同的「在场密度」
+3. **主动识别 + 时序整理**：订阅生活事件流（微信群、日历、机票），到点主动提醒
+4. **Agentic 自演进**：快慢思考融合、记忆与自主学习
+
+差别警示：华为做消费场景（事件语义标准化），玄圃做开发场景（事件语义远更复杂）。**借哲学，不抄形态。**
+
+### Anthropic Claude Code Auto Mode（工具级守护）
+
+- 基于 Sonnet 4.6 的 Classifier 对每个 tool call 做风险评估
+- 安全操作自动批准，危险操作（rm 批量、数据外泄等）自动拦截
+- 启用：`claude --enable-auto-mode`
+
+**核心局限**：只判断「这一步安不安全」，不判断「这一步和用户最初意图一致不一致」。Auto Mode 一路绿灯放行 20 个 tool call，第 21 步发现整个方向就是错的——用户损失不是被删数据，是 30 分钟跑在错误的赛道。
+
+### VS Code Autopilot Mode（2026-03）
+
+四件事 GitHub 没说清：作用域边界、审计可追溯性、密钥处理、安全默认值。**玄圃做托管必须第一天堵住这四个坑。**
+
+### Devin 团队实战教训
+
+- 长任务必须拆成小的、隔离的 sub-task，跨独立 session 跑
+- 成功与「范围具体程度」强相关；模糊范围自动偏航
+
+---
+
+## 三、产品定位（暂定）
+
+> **「你的工作台在场，替你守着 AI 的方向」**
+
+- "在场"对应伴随
+- "守着方向"对应托管（**意图级**而非工具级）
+- 不许诺情感联结（伙伴 → 守护者），只许诺一件可检验的事
+
+---
+
+## 四、三层架构
+
+| 层 | 名称 | 职责 | 玄圃现状对应 |
+|---|---|---|---|
+| 1 | 感知层 | 收集 FieldEvent：worktree/file/terminal/git/agent message/focus | Phase 21 Field Event Stream（已做）+ Phase 21.5（agent tool events，进行中）|
+| 2 | 决策层 | Guardian 替用户对 agent 的微观询问做代理决策 | **新做** |
+| 3 | 透明层 | 决策日志 + 可回退性 + 历史正确率 | 增强 Phase 24c Checkpoint |
+
+### 决策层的四个信号
+
+Guardian 基于以下四个信号产出决策：
+1. **任务原始意图**（用户最初需求文本，作为 hard anchor）
+2. **当前进度轨迹**（已完成步骤 vs 原始意图的偏离度）
+3. **用户历史偏好**（Phase 22 Memory 已在做）
+4. **风险等级**（可逆性、是否触及禁区）
+
+### 三种决策输出
+
+- **自动继续**：决策显然 + 风险低 + 与意图一致
+- **自动选择**：agent 给 A/B/C，Guardian 替选
+- **升级到用户**：重大歧义 / 超出意图边界 / 不可逆操作
+
+### 三档信任曲线（用户角度）
+
+| 档 | 行为 | 用户授权 |
+|---|---|---|
+| Observe | Guardian 只显示「我会选 B，因为…」，**用户自己决定** | 无需授权 |
+| Suggest | agent 暂停后倒计时 10s，用户不干预则按 Guardian 建议执行 | 单 session 授权 |
+| Autopilot | 完全自主，仅重大歧义停下 | 全局授权 + 累计准确率达标 |
+
+类比 L1-L5 辅助驾驶：**自动化的接受度不取决于能力，取决于信任**。
+
+---
+
+## 五、必须绕过的坑（讨论中识别）
+
+### 坑 1：意图漂移（Intent Drift）
+
+每一步对前一步都是合理延伸，累积起来已偏离原始意图（"做登录页面" → 改全局 CSS → 重构 token → 改 Button API）。
+
+**单靠 LLM 语义距离评分不够**。必须叠加硬规则兜底：
+- 文件/目录白名单（用户提需求时声明 scope）
+- 漂移预算（累计改动文件数 / 行数超阈值强制升级）
+- 每 K 步强制 checkpoint + 一句话摘要
+
+### 坑 2：silent approval
+
+托管下用户不在场，agent 写「我打算改 X」无人响应。Guardian 是唯一在场的人，必须靠硬规则兜底（白名单、预算、checkpoint），不能假设「用户没说话 = 同意」。
+
+### 坑 3：可回退性极难兜底
+
+Phase 24c Checkpoint 只覆盖 git/file 层。回退不了：
+- `git push` 后的 remote
+- 已调外部 API
+- `rm` 已执行
+
+**Guardian 默认作用域必须限定在「纯本地、未 push、未调外部 service」**。越界一律升级。
+
+### 坑 4：Guardian 架构选择 —— 规则 vs LLM
+
+- LLM Guardian：灵活但错误叠加（agent 漂 + Guardian 跟着漂）
+- 规则 Guardian：可解释但覆盖窄
+- **建议混合**：硬规则兜底 + LLM 仅做「这是不是真歧义」二分判断
+
+### 坑 5：责任问题
+
+Guardian 错了责任在谁？产品语言必须主动降温：
+> **代理你做决策，不替你背责任**
+
+边界语言越早立越好，避免用户把 Guardian 视为「伙伴 → 应担责」。
+
+### 坑 6：并发跨 session 架构
+
+玄圃实际并发活跃 session ≤ 5 个。架构选项：
+- 每 session 独立 Guardian（隔离、简单，学不到跨 session 模式）
+- 全局 Guardian（能识别冲突，但注意力分散）
+- 折中：每 session 独立决策 + 全局协调层（仅管资源/冲突，不管内容）
+
+第一天必须定。
+
+### 坑 7：被 Anthropic / OpenAI 追上
+
+Auto Mode 2.0 如果加上 intent-awareness，玄圃护城河剩什么？
+
+判断：Anthropic 没有「用户在做什么」的全景信号源——它只有 Claude Code 单进程内事件。**玄圃真正的护城河不是 Guardian 算法，而是 FieldEvent 的覆盖广度 + 跨 agent (CC/Codex/OpenCode) 的横向视野**。
+
+→ 这意味着 Phase 21.5（agent tool events）的战略重要性 > 现在的认知。
+
+### 坑 8：信任校准（Trust Calibration）
+
+学术结论（[Adaptive Trust Calibration](https://www.researchgate.net/publication/339424118)、[ECE 指标](https://www.emergentmind.com/topics/trust-calibration-in-ai)）：
+
+- 透明度的目的不是「让用户看到」，是让「主观信任」和「客观可靠度」对齐
+- 错位有两种：过度信任（错了不查）和过度怀疑（宁可自己点每一步）
+- 光给日志不够，要给：**置信度 + 历史正确率 + 可撤销性**
+
+---
+
+## 六、推荐切入路径
+
+**第一刀：只做 Observe 档**。
+
+- 不要求用户授权托管
+- 用户照常用 Claude Code / Codex
+- 玄圃只在旁边显示「Guardian 会选 B，因为 X Y Z」
+- 同时累计 Guardian 的**实际准确率**（用户最终选择 vs Guardian 建议的一致率）
+
+价值：**0 责任承担 + 拿到 Guardian 真实正确率数据**。
+- 数据 ≥ 85% 才开放 Suggest 档
+- 数据 ≥ 95% 才开放 Autopilot 档
+
+这条路径与 ECE 指标天然对齐——用真实数据校准用户信任，不靠营销语言。
+
+---
+
+## 七、待深入的开放问题
+
+继续深挖前需要先回答：
+
+1. **Guardian 规则 vs LLM 架构** —— 选错后面全返工
+2. **Phase 21.5 之后 FieldEvent 还缺什么** —— Guardian 信号源的完备性
+3. **Observe 档的 UI 位置** —— Session HQ 侧边栏 / Hub 手机推送 / Chat inline hint，三者优劣
+4. **scope 声明的交互形态** —— 用户提需求时如何低摩擦地圈定文件/目录白名单
+5. **决策日志的存储/渲染成本** —— 长期累积的工程约束（参考 Phase 24c 同类问题）
+6. **Agent Inbox 三分类**（notify / question / approve，[LangChain 范式](https://docs.langchain.com/oss/python/langchain/human-in-the-loop)）能否复用到 Hub M2
+
+---
+
+## 八、已知的产业参考链接
+
+- [华为 Pura X Max 伴随式 AI（知乎专栏）](https://zhuanlan.zhihu.com/p/2030246751236571245)
+- [小艺主动服务生态（品玩）](https://www.pingwest.com/a/310264)
+- [Anthropic Claude Code Auto Mode 指南](https://smartscope.blog/en/generative-ai/claude/claude-code-auto-permission-guide/)
+- [VS Code Autopilot Mode](https://leadai.dev/insider/vs-code-copilot-introduces-autopilot-mode-for-fully-autonomous-coding)
+- [VS Code Autopilot 风险讨论（The Register）](https://www.theregister.com/2026/03/11/visual_studio_code_moves_to/)
+- [Cognition 用 Devin 构建 Devin](https://cognition.ai/blog/how-cognition-uses-devin-to-build-devin)
+- [Ambient Agents 综述（ZBrain）](https://zbrain.ai/ambient-agents/)
+- [LangChain Human-in-the-loop](https://docs.langchain.com/oss/python/langchain/human-in-the-loop)
+- [Stanford Tech Review: Ambient Computing 2026](https://www.stanfordtechreview.com/articles/ambient-computing-and-ai-copilots-in-silicon-valley-2026)
+- [Adaptive Trust Calibration](https://www.researchgate.net/publication/339424118)
+- [Trust Calibration in AI（Emergent Mind）](https://www.emergentmind.com/topics/trust-calibration-in-ai)
+- [SitePoint: Claude Code as Autonomous Agent 2026](https://www.sitepoint.com/claude-code-as-an-autonomous-agent-advanced-workflows-2026/)
+
+---
+
+## 九、与当前迭代的关系
+
+**当前不动手**。1.4.0 优先：
+- PR #28 / #29 / Phase 21.5 / Phase 24c 合并 → rc.5 验证 → 发版
+- Hub M1 真机验证
+
+本文档为**未来方向锚点**。等 1.4.0 稳定、Phase 21.5 数据流跑通后，重读本文档判断启动时机。
+
+启动信号（满足任一）：
+- Phase 21 + 21.5 + 22 + 24c 全部 stable，FieldEvent 信号源完备
+- 用户开始反馈「频繁打断 agent 决策」是主要痛点
+- 业界出现 intent-aware Auto Mode 竞品，需要正面应对
+
+---
+
+## 十、IM 落地形态（2026-04-23 补充）
+
+原文档把伴随 / 托管定位在「用户 ↔ 玄圃」的一对一关系上。实际产品推演后发现，**IM 群聊是托管模式最自然的生产入口**，因为它天然解决了三件事：触发源（他人发起）、身份（群成员 identity）、通知通道（IM 原生推送）。
+
+但也因此，IM 形态把托管的复杂度**放大了一个量级**——不再是"我的玄圃替我做决策"，而是"别人通过 IM 让我的玄圃替我做事"，多了权限、归属、责任三条新线。
+
+### 目标场景
+
+PM / 测试在群里发现问题 → @玄圃 → 玄圃自动：
+1. **Intake**：理解自然语言问题描述（"下单页面挂了"）
+2. **Routing**：推断涉及哪个 project / worktree（业务语义 → 代码位置）
+3. **Triage**：开调研 session，agent 读 log、grep、复现、定位嫌疑
+4. **Fix**：agent 自主修，中间遇到歧义自己判断继续 / 问人
+5. **Build & Release**：rc 打包、验证、发布
+
+### 被低估的五个复杂度
+
+#### 1. Project 归属推断（路由层）
+
+业务描述（"下单页面加载慢"）≠ 代码描述（"frontend repo src/pages/checkout/"）。
+
+玄圃现有 project / worktree 模型**没有业务语义标签**。新增字段：
+- `project.business_tags`：人配的业务标签（["订单", "下单", "checkout"]）
+- `project.ownership_desc`：一段自然语言描述 project 的责任边界
+
+Router 策略推荐**规则 + LLM 混合**：
+- 关键词硬命中优先（快、可预测）
+- 低置信度时回退 LLM（读 README + recent commits + tags 推断）
+- 命中 0 个 → 回 IM 问"你说的是哪个 project？"
+- 命中 ≥ 2 个 → 回 IM 给选项按钮
+
+#### 2. agent 自主推进中的歧义 = Guardian 必需
+
+agent 跑到一半问"改 A 方案还是 B 方案"——**谁回答？**
+- 回给 PM：PM 不懂代码
+- 回给本人：人肉 Director，自动就破产
+- **Guardian 自动判断** = 本文档第四、五章的核心命题
+
+**没有 Guardian，IM 托管场景在第一个歧义点就破产。** → Phase C 强依赖。
+
+#### 3. 权限分层（目前玄圃完全没有）
+
+IM 身份 → 玄圃行动能力的映射，至少三档：
+
+| 角色 | 能 @ 请求 | 不能做 |
+|---|---|---|
+| 群里任何人 | triage（诊断报告，不动代码） | 动代码、合 PR |
+| 白名单成员 | 创建 fix branch + PR | 合 main、发布 |
+| 只有本人 | 授权 build & release | — |
+
+没有这层，群里任何人 @玄圃 就能触发自动发布 = 勒索攻击入口。
+
+#### 4. Build & Release 硬边界
+
+**产品第一天就必须立的承诺**：
+- ✅ 自动打 rc 包（可恢复）
+- ❌ 自动 release / tag main / 部署 prod（不可恢复）
+
+不管 Guardian 多自信，不可逆动作**一律升级人**。一次误发 = 信任清零。
+
+#### 5. 责任问题
+
+自动合 PR → 生产事故 → 责任归谁？
+- 产品语言必须降温：**"玄圃协助你推进，不替你背责"**
+- 每步留**决策日志 + 可回滚标记**（Phase 24c Checkpoint 是基础）
+- 群聊自动消息要显式带回滚提示（"已提交 PR #N，如需撤回点此"）
+
+### 能力表 vs 现状
+
+| 愿景要素 | 前置能力 | 1.4.0 状态 |
+|---|---|---|
+| Intake（NL 问题理解） | LLM | ✅ 能力已在 |
+| Routing（业务→代码） | project 业务标签 + LLM 推断 | ❌ 没做 |
+| Triage（调研 session） | Phase 21.5 agent tool events | ✅ 1.4.0 有 |
+| Fix 自主续跑 | **Guardian 决策层** | ❌ 没做（本文档第四章，1.6.0+） |
+| 漂移 / scope 兜底 | Scope 声明 + 白名单 + 漂移预算 | ❌ 没做 |
+| 权限分层 | 用户角色模型 + IM identity 绑定 | ❌ 没做 |
+| 回滚 / 决策日志 | Phase 24c Checkpoint | ✅ 1.4.0 有 |
+| 信任校准数据 | Observe 档跑真实数据 | ❌ 没跑 |
+
+**缺 5/8**，且缺的都是硬依赖。→ 不能一把梭。
+
+### 分层实现路径
+
+#### Phase A（1.4.1 / 1.4.x 补丁）：**IM 通知 + 手动入口**
+
+**目标**：把 Hub M1 的入口从 PWA 扩展到 IM，**不做 agent 编排**。
+
+- 玄圃桌面端 → IM 平台推事件：agent 完成、需要审批、PR 创建、构建失败
+- IM 里 @玄圃 → 回复**操作菜单**（列出你的 project，每个带交互按钮）
+- 点"打开 session" → 跳转 PWA / 桌面端（复用 Hub M1 通道）
+- **PM / 测试在这个阶段只能看状态，不能派活**
+
+**平台优先级**：
+- **飞书应用机器人**（首选）：API 最完整、交互卡片最成熟、个人开发者审核快
+- **企业微信智能机器人**（随后）：团队场景覆盖
+- **微信 ClawBot (iLink)**：观望半年再入场，生态还太早期
+
+**工作量**：2-3 天做完飞书，7 天做完全套飞书+企微。
+
+#### Phase B（1.5.0）：**Triage-Only（只诊断不修复）**
+
+**目标**：@玄圃 + 问题描述 → 诊断报告发回 IM。**不改任何代码。**
+
+- Router（规则 + LLM 混合）推断 project
+- 开**调研 session**：agent 自动读 log、grep 代码、跑测试复现
+- 产出**诊断报告卡片**推回 IM：嫌疑文件、相关 commit、建议方案
+- 群里 PM 的价值已经很高：少等半小时让人看
+- 玄圃自己的价值：**积累"问题类型 → 诊断准确率"数据**，为 Phase C 的 Guardian 做训练 / 校准
+
+**新依赖**：
+- project.business_tags 配置 UI
+- Router 模块（规则引擎 + LLM 兜底）
+- 诊断报告模板 + IM 交互卡片
+
+**估时**：4-6 周。
+
+#### Phase C（1.6.0+）：**真正的托管修复**
+
+基于 Phase B 积累的数据，引入完整 Guardian 体系：
+
+- **Guardian 决策层**（本文档第四章）：规则 + LLM 混合
+- **Observe / Suggest / Autopilot 三档信任曲线**（第四章）
+- **scope 声明**：@玄圃时带 `@xuanpu fix [scope:src/pages/checkout] ...`
+- **权限分层**：群成员 / 白名单 / 本人
+- **Build & Release**：
+  - 自动打 rc 包
+  - 发 release / tag main → **永远手动授权**
+  - prod 部署 → **永远手动**
+
+**估时**：12 周+，且不追求完备覆盖，只做 Phase B 数据证明"该类型问题 ≥ 95% 成功率"的那些子域。
+
+### 为什么必须分层（反面）
+
+一把梭（直接做 Phase C）的风险：
+1. **Guardian 判断基线 = 拍脑袋**。Phase B 不做，Guardian 的"置信度"没数据来源
+2. **用户信任来不及建立**。PM 要先看到 3 次准确诊断，才会信"它能诊断"；才会信"它能修"；才会信"它能发"。跳步 = 第一次出事全盘归零
+3. **玄圃产品心智不能一步到位成"无人驾驶开发"**。市场 / 法务 / 心理都没准备好
+
+### 与 Hub M1 的关系
+
+Hub M1（手机 PWA 远控）= **个人多设备场景**。
+IM 落地 = **多人协作场景**。
+
+两者是正交的，都值得做。但：
+- Hub M1 已经上线（1.4.0），先让它撑一段时间
+- IM 形态从 Phase A 开始，作为 Hub M1 的**扩展入口**，不替代
+
+### 开放问题
+
+1. **1.4.0 是否顺带做 Phase A？**
+   - Pro：IM 入口起步、手机 PWA + IM 构成完整远控矩阵
+   - Con：1.4.0 功能已密集，延期 1-2 周
+   - **倾向：1.4.0 先发，Phase A 作为 1.4.1 补丁**
+2. **飞书 or 企微先做？**取决于目标用户日常用哪个
+3. **Router 规则 vs LLM 权重**：Phase B 初版建议 **70% 规则 + 30% LLM**，数据多了再调
+4. **群聊权限如何绑定玄圃用户**：IM open_id / union_id ↔ 玄圃本地身份映射，新增配置层
+
+### 启动信号（本章补充）
+
+- Phase A：1.4.0 发版后，若真实场景出现"想把玄圃拉进群"的冲动 → 立刻做
+- Phase B：Phase A 跑 1 个月，通知量数据稳定 → 有信号源才做 Router
+- Phase C：Phase B 产生的诊断报告准确率 ≥ 85% → 才开放"修复"能力
+

--- a/docs/plans/2026-04-25-v1.4.3-plan.md
+++ b/docs/plans/2026-04-25-v1.4.3-plan.md
@@ -1,0 +1,419 @@
+# 玄圃 v1.4.3 规划（基础设施 + onboarding + 可用性补强）
+
+**日期**：2026-04-25
+**状态**：Draft
+**目标版本**：v1.4.3
+**背景**：v1.4.0 → 1.4.2 连续三次发布都踩到了同一类问题：本地 dev 正常、CI 打包缺关键产物（cloudflared / mobile UI），以及一些只在 packaged / cold-start / SessionShell 新布局下才会暴露的 wiring 和可见性 bug。用户已经明确 1.4.x 要沿两条主线推进：
+
+1. **事件流 / 现场提供继续做厚**
+2. **让 Codex / OpenCode / Amp 真正在玄圃里可用**
+
+在此之前，v1.4.3 先补一层基础设施和 onboarding，避免后续版本继续因为 packaging / wiring / 空状态体验问题浪费发布节奏。
+
+---
+
+## 1.4.3 主题
+
+**一句话**：把"能发版"和"第一次打开就看得懂"两件事补齐。
+
+这版不追求大功能，而是做一组高 ROI 的基础体验：
+
+1. **CI post-package 验证**（防止再发出缺产物的包）
+2. **首次 5 分钟 onboarding**（让新用户第一次就能看见现场注入 / 记忆）
+3. **Memory / Field Context 空状态补强**（不再是 4 个空 tab）
+4. **Edit / Write 卡片支持 diff 展开**（默认摘要 + 全量展开）
+5. **Composer 图片支持大图预览**（解决目前小缩略图不可读）
+6. **README.en.md 同步**（文档 front door 不再中英割裂）
+
+---
+
+## 1. 功能范围
+
+### 1.1 CI post-package 验证（P0）
+
+#### 问题
+
+v1.4.0 和 v1.4.1 两次热修复都暴露同一个事实：
+
+- 本地 `pnpm build:mac` 之所以正常，是因为它会隐式准备 cloudflared + mobile/dist
+- CI release workflow 直接调用 electron-builder，跳过了这些前置步骤
+- 我们直到用户安装后才发现：
+  - `Resources/cloudflared/.../cloudflared` 不存在 → Hub 公网隧道报"找不到二进制"
+  - `Resources/mobile-ui/index.html` 不存在 → 浏览器访问 Hub URL 返回 `{"error":{"code":"NOT_FOUND","message":"/"}}`
+
+即使 1.4.1 / 1.4.2 已分别把这两步补回 workflow，**仍然缺一层 post-package 断言**，保证以后不再发出空包。
+
+#### 目标
+
+在 `Release Xuanpu` workflow 的 package 步骤之后新增一个 **Verify packaging completeness** 步骤，对每个平台产物做最小必要验证。
+
+#### 验证项
+
+**macOS**
+
+针对 `dist/mac-${arch}/玄圃.app/Contents/Resources/`：
+
+- `cloudflared/<expected-platform>/cloudflared` 存在且可执行
+- `mobile-ui/index.html` 存在
+- `app.asar` 存在
+- `app.asar.unpacked` 下 better-sqlite3 / node-pty 的 `.node` 存在
+- `native/ghostty.node` 存在（占位或真实二进制都可）
+
+**Windows**
+
+针对 unpack 目录或 installer 之前的 app output：
+
+- `cloudflared/<expected-platform>/cloudflared.exe` 存在
+- `mobile-ui/index.html` 存在
+- 核心产物 `Xuanpu-Setup-*.exe` / zip 存在
+
+#### 文件
+
+- `.github/workflows/release.yml`
+
+#### 验收标准
+
+- 任一关键文件缺失 → workflow 直接 fail，release 不创建 / draft 不发布
+- 对 v1.4.0 / 1.4.1 的两个事故分别能在 CI 中被拦截
+
+---
+
+### 1.2 首次 5 分钟 onboarding（P0）
+
+#### 问题
+
+当前新用户装完 1.4.2 之后，面对的是：
+
+- 空工作台
+- Field Context Debug 4 个 tab 初始全空
+- 用户不知道 worktree / session / hub / memory 之间是什么关系
+- 不知道 `memory.md` 写在哪
+- 不知道事件流什么时候会积累、什么时候会压缩
+
+这会直接吞掉我们好不容易做出来的差异化——明明有"现场提供"，但用户第一次打开完全感知不到。
+
+#### 目标
+
+做一个**最小 onboarding**，让用户在 5 分钟内亲眼看到：
+
+1. Agent prompt 前会注入 Field Context
+2. FieldContextDebug 不是空的
+3. `memory.md` 在哪写
+4. Hub 扫码后能用手机打开
+
+#### 设计建议
+
+以一个轻量的 4-step checklist/card 方式存在，不做重型 wizard：
+
+1. **添加项目 / 选择 worktree**
+2. **启动一个 session 并发送第一条 prompt**（让 Last Injection tab 有内容）
+3. **展开 Field Context / Memory 面板**（告诉用户去哪里看）
+4. **可选：启用 Hub，扫码打开手机端**
+
+文案应该是"带你看懂玄圃为什么不是一个聊天框"，而不是泛泛的"欢迎使用"。
+
+#### 实现位置建议
+
+- 入口：SessionShell 或首页首次打开时的 callout
+- 状态：复用 `useSettingsStore.initialSetupComplete` 或新增 onboarding step state
+- 可关闭，但在用户未完成前保留可找回入口
+
+#### 文件（建议）
+
+- `src/renderer/src/components/layout/MainPane.tsx`
+- `src/renderer/src/components/session-hq/SessionShell.tsx`
+- `src/renderer/src/stores/useSettingsStore.ts`
+- 可能新增：`src/renderer/src/components/onboarding/FieldOnboardingCard.tsx`
+
+#### 验收标准
+
+- 新用户第一次发送 prompt 后，能通过引导找到 Field Context 面板
+- 引导文案明确提示 `memory.md` 路径和 Hub QR 能力
+
+---
+
+### 1.3 Memory / Field Context 空状态补强（P0）
+
+#### 问题
+
+当前 `FieldContextDebug.tsx` 的空状态只会说：
+
+- No injection yet
+- No episodic summary yet
+- Memory injection is disabled / file not found
+- No checkpoint yet
+
+这些信息**技术上没错，但不够产品化**。用户真正想知道的是：
+
+- 为什么是空的？
+- 我做什么它会有内容？
+- 这不是坏了吧？
+
+#### 目标
+
+把空状态改成**解释 + 下一步动作**：
+
+**Last Injection**
+- 解释：Field Context 会在下一条 prompt 前自动注入
+- 动作：发送一条消息试试
+
+**Episodic**
+- 解释：需要约 20 个事件（命令 / 文件编辑 / 对话）后自动压缩
+- 动作：继续工作；必要时提供"立即刷新 / 立即压缩"按钮（可选）
+
+**Semantic**
+- 解释：这里显示 worktree 的 `.xuanpu/memory.md` 和用户级 `~/.xuanpu/memory.md`
+- 动作：直接给出路径和"去创建"按钮（后续 1.4.5 Memory 面板会替代它）
+
+**Checkpoint**
+- 解释：abort 或 app shutdown 之后才会有
+- 动作：提示用户 abort 一次 session 再回来看看
+
+#### 文件
+
+- `src/renderer/src/components/sessions/FieldContextDebug.tsx`
+
+#### 额外建议
+
+在 1.4.3 里先保留 `FieldContextDebug` 命名；到 1.4.5 再升级为真正的 Memory 面板，不在这一版改组件命名和定位，避免 scope 膨胀。
+
+---
+
+### 1.4 Edit / Write 卡片支持 diff 展开（P1）
+
+#### 背景
+
+用户新增需求：
+
+> edit 和 write，可以考虑支持展开，diff 卡片，默认展示几行，支持全部展开
+
+当前 `FileWriteCard.tsx` 只有：
+- file path
+- add/remove 行数统计
+- 状态 icon（running/error/success）
+
+这对小改动勉强够，但对真正的 edit / write 来说信息远远不够，用户还是得跳到文件 diff 面板里找具体内容。既然这是 agent timeline 里的 tool card，至少应该给一个可读的 preview。
+
+#### 目标
+
+为 Edit / Write 类 tool card 增加一个**内联 diff 预览**：
+
+- 默认折叠
+- 默认显示前 N 行（建议 8-12 行）
+- 支持"展开全部 / 收起"
+- 优先展示 inline diff，而不是单纯 raw old/new text
+
+#### 现有资产
+
+- `src/renderer/src/components/session-hq/cards/FileWriteCard.tsx`
+- `src/renderer/src/components/diff/InlineDiffViewer.tsx`
+- `src/renderer/src/components/diff/DiffViewer.tsx`
+
+#### 设计建议
+
+**Edit**
+- 从 `toolUse.input.old_string` / `new_string` 生成一个最小 inline diff 片段
+- 默认展示前 8 行
+- 如果 diff 太长，底部按钮：`展开全部` / `收起`
+
+**Write**
+- 没有 old_string，可退化为"新增文件内容预览"
+- 默认展示前 8 行
+- 同样支持展开全部
+
+不要在 1.4.3 做跨文件完整 Monaco diff 弹窗——太重，且已有右侧 diff 面板能承载。1.4.3 只补 timeline card 自身的可读性。
+
+#### 交互建议
+
+卡片内结构：
+
+- 第一行：路径 + 状态 + add/remove 统计
+- 第二行开始：preview area（细边框 / 淡背景）
+- 底部：`展开全部` 按钮（仅当超出 N 行时出现）
+
+#### 验收标准
+
+- Edit tool card 默认能看见一小段 diff 片段
+- 超过 N 行时出现展开按钮
+- Write tool card 能看见内容前几行预览
+- 不引入明显的 timeline 高度抖动
+
+---
+
+### 1.5 Composer 图片支持大图预览（P1）
+
+#### 背景
+
+用户新增需求（见截图）：
+
+> 输入框里的图片支持大图预览，像图 3 这样
+
+当前 `ComposerBar.tsx` 里的附件预览通过 `AttachmentPreview.tsx` 渲染：
+
+- 横向滚动的小缩略图
+- 可删
+- 不能点开看大图
+
+对于截图类 prompt（尤其是让 agent 看 UI bug / 移动端截图），用户必须在脑子里记住图里内容，很不方便。
+
+#### 目标
+
+为 Composer 的图片附件增加**点击放大预览**：
+
+- 点击缩略图 → 打开 modal / lightbox
+- 保持原图比例，限制最大尺寸，不要拉伸
+- 支持 ESC / 点击蒙层关闭
+- 支持多图左右切换（1.4.3 可选，最低先做单图查看）
+
+#### 现有资产
+
+- `src/renderer/src/components/session-hq/ComposerBar.tsx`
+- `src/renderer/src/components/sessions/AttachmentPreview.tsx`
+- 项目已有 `Dialog` / `Popover` / `AlertDialog` 等 UI 基础组件
+
+#### 设计建议
+
+最小实现：
+- `AttachmentPreview` 对 image mime 的缩略图增加 `onClick`
+- 在该组件内部或父组件维护 `selectedImage`
+- 渲染一个简单 `Dialog`：大图 + 文件名 + 关闭按钮
+
+保持 scope：
+- 只支持 `attachment.kind === 'data' && mime.startsWith('image/')`
+- 不做多图导航也可，先解决"看不清"问题
+
+#### 验收标准
+
+- 粘贴一张 PNG/JPG 到 Composer 后，点击缩略图可以看大图
+- 大图预览不影响发送 / 删除附件
+- 深色/浅色主题都可读
+
+---
+
+### 1.6 README.en.md 同步（P1）
+
+#### 背景
+
+`README.md` 已更新为 1.4.0 的真实能力（Hub、现场事件流、分层记忆、Checkpoint、Session UI v2、1.4.x 路线图），`README.en.md` 仍是旧口径。
+
+#### 目标
+
+把中文版 README 的结构同步过去，不要求逐字翻译，但要保证：
+
+- 顶部有 v1.4.0 essay callout（英文）
+- Current Capabilities 反映 v1.4 的现场感知能力
+- "not IDE, but field provider for agents" 口径同步
+- priorities 改为 1.4.x roadmap
+
+#### 文件
+
+- `README.en.md`
+
+---
+
+## 2. 不在 1.4.3 范围内的内容
+
+以下内容暂不进入 1.4.3，避免 scope 失控：
+
+- Codex 体验大修（单独 1.4.4）
+- Pinned Facts / 完整 Memory 面板（单独 1.4.5）
+- 成本可见（单独 1.4.6）
+- OpenCode / Amp 集成
+- XFP 草案
+- 大型 diff modal / Monaco diff 嵌入 tool card
+- 多图图片预览左右切换
+
+---
+
+## 3. 建议拆分 PR
+
+虽然版本叫 1.4.3，但实现上建议拆成 3 个 PR：
+
+### PR A — Release / onboarding guardrails
+- release.yml post-package verify
+- onboarding card
+- README.en.md
+
+### PR B — Field / Memory UX polish
+- FieldContextDebug 空状态补强
+- （可选）Semantic "go create file" CTA
+
+### PR C — 可视化可读性增强
+- FileWriteCard diff preview + expand
+- Composer image large preview
+
+原因：
+- PR A 可以优先落，马上给后续发版兜底
+- PR B / C 风险独立，review 不会互相干扰
+- 就算 PR C 拖期，也不影响 1.4.3 的主目标
+
+如果你坚持按一个 PR 做，也可以，但不建议。
+
+---
+
+## 4. 验收清单
+
+### 4.1 CI / packaging
+- [ ] Release workflow package 后执行 verify step
+- [ ] 刻意删掉 cloudflared / mobile dist 时，verify step fail
+- [ ] 正常构建时 4 个平台全 success
+
+### 4.2 Onboarding / 空状态
+- [ ] 新用户 5 分钟内能看到 Last Injection 有内容
+- [ ] Semantic 空状态明确告诉用户 memory.md 路径
+- [ ] Checkpoint 空状态明确告诉用户 abort 一次后会生成
+
+### 4.3 Edit / Write 卡片
+- [ ] Edit tool card 能看到 diff preview
+- [ ] 超长 diff 可展开全部 / 收起
+- [ ] Write tool card 能看到内容前几行
+
+### 4.4 图片大图预览
+- [ ] 粘贴 PNG/JPG 到 Composer 后点击缩略图可看大图
+- [ ] 关闭后附件仍在
+- [ ] 发送后行为不变
+
+---
+
+## 5. 对后续版本的影响
+
+完成 1.4.3 后：
+
+- 1.4.4（Codex 大修）有 CI 兜底，不会再因为打包漏产物反复 hotfix
+- 1.4.5（Memory 面板）可以建立在改善后的空状态和 onboarding 上，不需要从空白开始教育用户
+- 用户第一次打开 1.4.x 就能看懂"现场提供"，不会再看到一堆空 tab
+
+---
+
+## 6. 推荐执行顺序
+
+如果下一会话直接开工，建议顺序：
+
+1. **先做 PR A（Release / onboarding guardrails）**
+2. 再做 **PR C（FileWriteCard + image preview）** —— 用户最有感
+3. 最后补 **PR B（Field 空状态）**
+
+原因：
+- PR A 最防御，先落地最安心
+- PR C 是你今天用户直接点名的功能，体感收益最高
+- PR B 文案类的收尾可以最后做
+
+---
+
+## 7. 参考文件
+
+- `src/renderer/src/components/session-hq/cards/FileWriteCard.tsx`
+- `src/renderer/src/components/diff/InlineDiffViewer.tsx`
+- `src/renderer/src/components/session-hq/ComposerBar.tsx`
+- `src/renderer/src/components/sessions/AttachmentPreview.tsx`
+- `.github/workflows/release.yml`
+- `README.md`
+- `README.en.md`
+- `docs/essays/2026-04-25-from-1-3-to-1-4-ai-native-workbench.md`
+- `docs/plans/2026-04-25-memory-product-direction.md`
+
+---
+
+## 8. 给下一会话的启动语
+
+> 做 v1.4.3，按 `docs/plans/2026-04-25-v1.4.3-plan.md` 执行。先做 PR A（release.yml post-package verify + onboarding + README.en.md），如果还有时间再做 PR C（FileWriteCard diff preview + Composer image large preview）。不要碰 Codex 大修、Pinned Facts、Memory 面板，这些不在本版范围。

--- a/src/renderer/src/components/session-hq/cards/FileWriteCard.tsx
+++ b/src/renderer/src/components/session-hq/cards/FileWriteCard.tsx
@@ -1,21 +1,44 @@
 /**
  * FileWriteCard — Renders a file write/edit action with line change counts.
+ *
+ * v1.4.3: now ships an inline diff preview. Edit cards show a unified
+ * diff snippet (old vs new), Write cards show the first N lines of new
+ * content. Defaults to a short preview; clicking "展开全部" reveals the rest.
+ * Keeps the timeline scannable while letting users read the actual change
+ * without jumping to the right-hand diff panel.
  */
 
-import React from 'react'
+import React, { useMemo, useState } from 'react'
 import { ActionCard } from './ActionCard'
 import { Check, X, Loader2 } from 'lucide-react'
+import { cn } from '@/lib/utils'
 import type { ToolUseInfo } from '@shared/lib/timeline-types'
 
 interface FileWriteCardProps {
   toolUse: ToolUseInfo
 }
 
+const PREVIEW_LINE_LIMIT = 10
+
+type DiffLine =
+  | { kind: 'context'; text: string }
+  | { kind: 'add'; text: string }
+  | { kind: 'remove'; text: string }
+
+function isEditTool(name: string | undefined): boolean {
+  const n = name?.toLowerCase() ?? ''
+  return n === 'edit' || n === 'editfile' || n === 'edit_file'
+}
+
+function isWriteTool(name: string | undefined): boolean {
+  const n = name?.toLowerCase() ?? ''
+  return n === 'write' || n === 'writefile' || n === 'write_file'
+}
+
 function computeLineDiff(toolUse: ToolUseInfo): { added: number; removed: number } | null {
   const input = toolUse.input ?? {}
-  const name = toolUse.name?.toLowerCase() ?? ''
 
-  if (name === 'edit' || name === 'editfile' || name === 'edit_file') {
+  if (isEditTool(toolUse.name)) {
     const oldStr = (input.old_string as string) ?? ''
     const newStr = (input.new_string as string) ?? ''
     if (!oldStr && !newStr) return null
@@ -27,7 +50,7 @@ function computeLineDiff(toolUse: ToolUseInfo): { added: number; removed: number
     }
   }
 
-  if (name === 'write' || name === 'writefile' || name === 'write_file') {
+  if (isWriteTool(toolUse.name)) {
     const content = (input.content as string) ?? ''
     if (!content) return null
     const lines = content.split('\n').length
@@ -37,12 +60,99 @@ function computeLineDiff(toolUse: ToolUseInfo): { added: number; removed: number
   return null
 }
 
+/**
+ * Build a minimal unified-style preview: every old_string line as `-`,
+ * every new_string line as `+`. Good enough for an inline at-a-glance read;
+ * the right-hand Monaco diff panel still owns "true" diffs.
+ */
+function buildEditPreview(oldStr: string, newStr: string): DiffLine[] {
+  const out: DiffLine[] = []
+  if (oldStr) {
+    for (const line of oldStr.split('\n')) {
+      out.push({ kind: 'remove', text: line })
+    }
+  }
+  if (newStr) {
+    for (const line of newStr.split('\n')) {
+      out.push({ kind: 'add', text: line })
+    }
+  }
+  return out
+}
+
+function buildWritePreview(content: string): DiffLine[] {
+  return content.split('\n').map((text) => ({ kind: 'add' as const, text }))
+}
+
+function buildPreviewLines(toolUse: ToolUseInfo): DiffLine[] | null {
+  const input = toolUse.input ?? {}
+  if (isEditTool(toolUse.name)) {
+    const oldStr = (input.old_string as string) ?? ''
+    const newStr = (input.new_string as string) ?? ''
+    if (!oldStr && !newStr) return null
+    return buildEditPreview(oldStr, newStr)
+  }
+  if (isWriteTool(toolUse.name)) {
+    const content = (input.content as string) ?? ''
+    if (!content) return null
+    return buildWritePreview(content)
+  }
+  return null
+}
+
+interface DiffPreviewProps {
+  lines: DiffLine[]
+}
+
+function DiffPreview({ lines }: DiffPreviewProps): React.JSX.Element {
+  const [expanded, setExpanded] = useState(false)
+  const overflow = lines.length > PREVIEW_LINE_LIMIT
+  const visible = expanded ? lines : lines.slice(0, PREVIEW_LINE_LIMIT)
+  const hiddenCount = lines.length - PREVIEW_LINE_LIMIT
+
+  return (
+    <div className="rounded border border-border/40 bg-background/60 overflow-hidden">
+      <pre className="text-[11.5px] leading-snug font-mono overflow-x-auto px-2 py-1.5 m-0">
+        {visible.map((line, i) => (
+          <div
+            key={i}
+            className={cn(
+              'whitespace-pre flex',
+              line.kind === 'add' && 'bg-celadon/10 text-celadon',
+              line.kind === 'remove' && 'bg-red-500/10 text-red-400'
+            )}
+          >
+            <span className="select-none w-4 text-muted-foreground/70 shrink-0">
+              {line.kind === 'add' ? '+' : line.kind === 'remove' ? '-' : ' '}
+            </span>
+            <span className="break-all">{line.text || ' '}</span>
+          </div>
+        ))}
+      </pre>
+      {overflow && (
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation()
+            setExpanded((v) => !v)
+          }}
+          className="w-full text-[11px] py-1 border-t border-border/40 text-muted-foreground hover:text-foreground hover:bg-muted/40 transition-colors"
+        >
+          {expanded ? '收起' : `展开全部（还有 ${hiddenCount} 行）`}
+        </button>
+      )}
+    </div>
+  )
+}
+
 export function FileWriteCard({ toolUse }: FileWriteCardProps): React.JSX.Element {
   const filePath = (toolUse.input?.file_path as string) ?? (toolUse.input?.path as string) ?? ''
   const isEdit = toolUse.name === 'Edit' || toolUse.name === 'edit'
   const isRunning = toolUse.status === 'running' || toolUse.status === 'pending'
   const isError = toolUse.status === 'error'
   const diff = computeLineDiff(toolUse)
+  const previewLines = useMemo(() => buildPreviewLines(toolUse), [toolUse])
+  const hasPreview = previewLines !== null && previewLines.length > 0
 
   return (
     <ActionCard
@@ -63,12 +173,8 @@ export function FileWriteCard({ toolUse }: FileWriteCardProps): React.JSX.Elemen
           {isError && <X className="h-3.5 w-3.5 text-red-500" />}
           {diff && toolUse.status === 'success' && (
             <div className="flex gap-1.5 font-mono text-xs font-semibold">
-              {diff.added > 0 && (
-                <span className="text-celadon">+{diff.added}</span>
-              )}
-              {diff.removed > 0 && (
-                <span className="text-red-400">-{diff.removed}</span>
-              )}
+              {diff.added > 0 && <span className="text-celadon">+{diff.added}</span>}
+              {diff.removed > 0 && <span className="text-red-400">-{diff.removed}</span>}
               {diff.added === 0 && diff.removed === 0 && (
                 <span className="text-muted-foreground">~0</span>
               )}
@@ -78,13 +184,17 @@ export function FileWriteCard({ toolUse }: FileWriteCardProps): React.JSX.Elemen
           {isError && <span>Error</span>}
         </div>
       }
+      // Default collapsed — click the header to expand the diff preview
+      // (or the error message). Errors still auto-expand so the user
+      // immediately sees what went wrong.
       defaultExpanded={isError}
     >
       {toolUse.error && (
-        <pre className="whitespace-pre-wrap break-all font-mono text-xs text-red-400 max-h-[200px] overflow-y-auto">
+        <pre className="whitespace-pre-wrap break-all font-mono text-xs text-red-400 max-h-[200px] overflow-y-auto mb-2">
           {toolUse.error}
         </pre>
       )}
+      {hasPreview && previewLines && <DiffPreview lines={previewLines} />}
     </ActionCard>
   )
 }

--- a/src/renderer/src/components/sessions/AttachmentPreview.tsx
+++ b/src/renderer/src/components/sessions/AttachmentPreview.tsx
@@ -1,5 +1,7 @@
+import { useState } from 'react'
 import { X, FileText } from 'lucide-react'
 import { Button } from '@/components/ui/button'
+import { Dialog, DialogContent } from '@/components/ui/dialog'
 
 export type Attachment =
   | { kind: 'data'; id: string; name: string; mime: string; dataUrl: string }
@@ -10,44 +12,106 @@ interface AttachmentPreviewProps {
   onRemove: (id: string) => void
 }
 
+interface PreviewTarget {
+  id: string
+  name: string
+  src: string
+}
+
 export function AttachmentPreview({ attachments, onRemove }: AttachmentPreviewProps) {
+  // v1.4.3: image attachments are now clickable. Selected item drives a
+  // simple Dialog-based lightbox so users can actually read screenshots
+  // they pasted into the Composer (the 64x64 thumb was unreadable).
+  const [previewing, setPreviewing] = useState<PreviewTarget | null>(null)
+
   if (attachments.length === 0) return null
 
   return (
-    <div className="flex gap-2 px-3 py-2 overflow-x-auto" data-testid="attachment-preview">
-      {attachments.map((attachment) => (
-        <div
-          key={attachment.id}
-          className="relative flex-shrink-0 group"
-          data-testid="attachment-item"
-          title={attachment.kind === 'path' ? attachment.filePath : undefined}
+    <>
+      <div className="flex gap-2 px-3 py-2 overflow-x-auto" data-testid="attachment-preview">
+        {attachments.map((attachment) => {
+          const isImage =
+            attachment.kind === 'data' && attachment.mime.startsWith('image/')
+
+          return (
+            <div
+              key={attachment.id}
+              className="relative flex-shrink-0 group"
+              data-testid="attachment-item"
+              title={attachment.kind === 'path' ? attachment.filePath : undefined}
+            >
+              {isImage ? (
+                <button
+                  type="button"
+                  onClick={() =>
+                    setPreviewing({
+                      id: attachment.id,
+                      name: attachment.name,
+                      src: (attachment as Extract<Attachment, { kind: 'data' }>).dataUrl
+                    })
+                  }
+                  className="block focus:outline-none focus-visible:ring-2 focus-visible:ring-primary rounded"
+                  aria-label={`Preview ${attachment.name}`}
+                  data-testid="attachment-image-preview-trigger"
+                >
+                  <img
+                    src={(attachment as Extract<Attachment, { kind: 'data' }>).dataUrl}
+                    alt={attachment.name}
+                    className="h-16 w-16 object-cover rounded border border-border cursor-zoom-in"
+                  />
+                </button>
+              ) : (
+                <div className="h-16 w-16 flex flex-col items-center justify-center gap-1 rounded border border-border bg-muted">
+                  <FileText className="h-5 w-5 text-muted-foreground" />
+                  <span className="text-[10px] text-muted-foreground truncate max-w-[56px] px-1">
+                    {attachment.name}
+                  </span>
+                </div>
+              )}
+              <Button
+                variant="ghost"
+                size="sm"
+                className="absolute -top-1.5 -right-1.5 h-5 w-5 p-0 rounded-full bg-background border border-border shadow-sm opacity-0 group-hover:opacity-100 transition-opacity"
+                onClick={() => onRemove(attachment.id)}
+                aria-label={`Remove ${attachment.name}`}
+                data-testid="attachment-remove"
+              >
+                <X className="h-3 w-3" />
+              </Button>
+            </div>
+          )
+        })}
+      </div>
+
+      {/* Lightbox — sized to 90vw / 80vh so portrait + landscape both fit
+          without distortion. Closes on overlay click, ESC, or the explicit
+          close button. */}
+      <Dialog
+        open={previewing !== null}
+        onOpenChange={(open) => {
+          if (!open) setPreviewing(null)
+        }}
+      >
+        <DialogContent
+          className="!p-0 !max-w-[90vw] w-auto bg-background/95 border-border"
+          data-testid="attachment-image-preview-dialog"
         >
-          {attachment.kind === 'data' && attachment.mime.startsWith('image/') ? (
-            <img
-              src={attachment.dataUrl}
-              alt={attachment.name}
-              className="h-16 w-16 object-cover rounded border border-border"
-            />
-          ) : (
-            <div className="h-16 w-16 flex flex-col items-center justify-center gap-1 rounded border border-border bg-muted">
-              <FileText className="h-5 w-5 text-muted-foreground" />
-              <span className="text-[10px] text-muted-foreground truncate max-w-[56px] px-1">
-                {attachment.name}
-              </span>
+          {previewing && (
+            <div className="flex flex-col">
+              <div className="flex items-center justify-between px-4 py-2 border-b border-border/50 text-xs text-muted-foreground">
+                <span className="truncate">{previewing.name}</span>
+              </div>
+              <div className="flex items-center justify-center bg-black/40 p-2">
+                <img
+                  src={previewing.src}
+                  alt={previewing.name}
+                  className="max-w-full max-h-[80vh] object-contain rounded"
+                />
+              </div>
             </div>
           )}
-          <Button
-            variant="ghost"
-            size="sm"
-            className="absolute -top-1.5 -right-1.5 h-5 w-5 p-0 rounded-full bg-background border border-border shadow-sm opacity-0 group-hover:opacity-100 transition-opacity"
-            onClick={() => onRemove(attachment.id)}
-            aria-label={`Remove ${attachment.name}`}
-            data-testid="attachment-remove"
-          >
-            <X className="h-3 w-3" />
-          </Button>
-        </div>
-      ))}
-    </div>
+        </DialogContent>
+      </Dialog>
+    </>
   )
 }


### PR DESCRIPTION
## Summary
v1.4.3 — release guardrails + UX polish。把 v1.4.0/1.4.1 那种"产物缺斤少两还是发出去了"彻底拦在 CI 里，同时给 Edit/Write tool card 和 Composer 图片附件做了体感最强的两个补强。

包含：
- **CI guardrails** — `release.yml` post-package 完整性断言（cloudflared / mobile-ui / asar.unpacked .node），改 publish-after-verify
- **Edit/Write 卡片 diff 预览** — 默认收起，点开看 `-old/+new`，超 10 行可展开全部
- **图片附件大图预览** — Composer 缩略图点开走 Dialog 灯箱
- **README.en.md** 同步 v1.4 口径
- 2 份 2026-04-23 plan docs 落档

按 `docs/plans/2026-04-25-v1.4.3-plan.md` 执行；不在本版范围的 Codex 大修 / Pinned Facts / Memory 面板未触碰。

## Test plan
- [ ] `tsc -p tsconfig.web.json` 无新增类型错误（已验证）
- [ ] `eslint` 无 warning（已验证）
- [ ] 打 tag 后 Release workflow 4 平台 verify + upload 全绿