### PR TITLE
feat(opencode): 对齐 1.4.4 codex 体验配方（工具名规范化 / Activity 持久化 / 标题生成）

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "@iconify-json/catppuccin": "^1.2.17",
     "@iconify/react": "^6.0.2",
     "@monaco-editor/react": "^4.7.0",
-    "@opencode-ai/sdk": "^1.1.51",
+    "@opencode-ai/sdk": "^1.14.29",
     "@radix-ui/react-context-menu": "^2.2.16",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,8 +75,8 @@ importers:
         specifier: ^4.7.0
         version: 4.7.0(monaco-editor@0.55.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@opencode-ai/sdk':
-        specifier: ^1.1.51
-        version: 1.1.51
+        specifier: ^1.14.29
+        version: 1.14.29
       '@radix-ui/react-context-menu':
         specifier: ^2.2.16
         version: 2.2.16(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -1768,8 +1768,8 @@ packages:
   '@open-draft/until@2.1.0':
     resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
 
-  '@opencode-ai/sdk@1.1.51':
-    resolution: {integrity: sha512-UL66X46AGgui5xURGEenXsIsgNVmgfkmJJeRtdeOMLhi/RcbTBikfPjjtmym3VLnqp855Wt7dZ/vAjOXqiUKXA==}
+  '@opencode-ai/sdk@1.14.29':
+    resolution: {integrity: sha512-y6wNTlHhgfwLdp01EwdnMFVxUS1FLgz7MZh7H3+jROG2v02GqGDy/gPH3ME0kI+sqQ4qSlk/9AJ+YbKAruPaZw==}
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -9079,7 +9079,9 @@ snapshots:
 
   '@open-draft/until@2.1.0': {}
 
-  '@opencode-ai/sdk@1.1.51': {}
+  '@opencode-ai/sdk@1.14.29':
+    dependencies:
+      cross-spawn: 7.0.6
 
   '@pkgjs/parseargs@0.11.0':
     optional: true

--- a/src/main/ipc/agent-handlers.ts
+++ b/src/main/ipc/agent-handlers.ts
@@ -227,8 +227,14 @@ export function registerAgentHandlers(
             }
           }
           const rawOptions = obj.options as Record<string, unknown> | undefined
-          if (rawOptions && typeof rawOptions.codexFastMode === 'boolean') {
-            options = { codexFastMode: rawOptions.codexFastMode }
+          if (rawOptions) {
+            options = {}
+            if (typeof rawOptions.codexFastMode === 'boolean') {
+              options.codexFastMode = rawOptions.codexFastMode
+            }
+            if (rawOptions.mode === 'build' || rawOptions.mode === 'plan') {
+              options.mode = rawOptions.mode
+            }
           }
         } else {
           // Legacy positional args: (worktreePath, sessionId, message)
@@ -248,8 +254,14 @@ export function registerAgentHandlers(
             }
           }
           const rawOptions = args[4] as Record<string, unknown> | undefined
-          if (rawOptions && typeof rawOptions.codexFastMode === 'boolean') {
-            options = { codexFastMode: rawOptions.codexFastMode }
+          if (rawOptions) {
+            options = {}
+            if (typeof rawOptions.codexFastMode === 'boolean') {
+              options.codexFastMode = rawOptions.codexFastMode
+            }
+            if (rawOptions.mode === 'build' || rawOptions.mode === 'plan') {
+              options.mode = rawOptions.mode
+            }
           }
         }
 

--- a/src/main/services/agent-runtime-types.ts
+++ b/src/main/services/agent-runtime-types.ts
@@ -16,6 +16,8 @@ export interface AgentRuntimeCapabilities {
 
 export interface PromptOptions {
   codexFastMode?: boolean
+  /** Session mode — used by OpenCode to select the agent (e.g. 'plan' → agent:'plan') */
+  mode?: 'build' | 'plan'
 }
 
 export interface AgentRuntimeAdapter {

--- a/src/main/services/opencode-activity-mapper.ts
+++ b/src/main/services/opencode-activity-mapper.ts
@@ -1,0 +1,303 @@
+/**
+ * OpenCode activity mapper — converts live OpenCode SDK events into durable
+ * `SessionActivity` records, mirroring `codex-activity-mapper.ts` so OpenCode
+ * sessions get the same history-replay treatment Codex enjoys after 1.4.4.
+ *
+ * Input shape: the same `event` object that `OpenCodeService.handleEvent`
+ * receives from the SDK iterator — `{ type, properties: { ... } }`. Only the
+ * subset that matters for activity persistence is mapped. Unknown / noisy
+ * events return `null`.
+ *
+ * Output shape: `SessionActivityCreate` consumed by
+ * `DatabaseService.upsertSessionActivity`.
+ *
+ * Mapping table:
+ *   message.part.updated (part.type === 'tool')
+ *     state.status:
+ *       running    → tool.started   (only first time we see this callID)
+ *       running    → tool.updated   (subsequent running updates)
+ *       completed  → tool.completed
+ *       error      → tool.failed
+ *       cancelled  → tool.failed (treated as failure, tone=error)
+ *   session.idle               → session.info ("Session idle")
+ *   session.error              → session.error
+ *   question.asked             → user-input.requested
+ *   permission.asked           → approval.requested
+ *   command.approval_needed    → approval.requested
+ *   anything else              → null
+ */
+import { randomUUID } from 'node:crypto'
+import type {
+  SessionActivityCreate,
+  SessionActivityKind,
+  SessionActivityTone
+} from '../db/types'
+
+// ---------------------------------------------------------------------------
+// Input contract
+// ---------------------------------------------------------------------------
+//
+// We don't import OpenCode SDK types here to keep this module renderable in
+// pure-node tests without the full SDK dependency tree. The event shape is
+// permissive: any object with a `type` and `properties` is accepted.
+
+export interface OpenCodeRawEvent {
+  type?: string
+  properties?: Record<string, unknown>
+}
+
+// Tool callIDs we've already emitted a `tool.started` for. Used to flip
+// subsequent `running` updates into `tool.updated`. The caller (per-session)
+// owns this set so it survives across many events but resets per session.
+export type ToolStartedTracker = Set<string>
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function asObject(v: unknown): Record<string, unknown> | undefined {
+  return v && typeof v === 'object' && !Array.isArray(v)
+    ? (v as Record<string, unknown>)
+    : undefined
+}
+
+function asString(v: unknown): string | undefined {
+  return typeof v === 'string' ? v : undefined
+}
+
+function stringifyPayload(payload: unknown): string | null {
+  if (payload === undefined) return null
+  try {
+    return JSON.stringify(payload)
+  } catch {
+    return null
+  }
+}
+
+function buildActivity(
+  hiveSessionId: string,
+  agentSessionId: string | null,
+  kind: SessionActivityKind,
+  tone: SessionActivityTone,
+  summary: string,
+  payload: unknown,
+  options?: {
+    id?: string
+    itemId?: string | null
+    requestId?: string | null
+    createdAt?: string
+  }
+): SessionActivityCreate {
+  return {
+    id: options?.id ?? randomUUID(),
+    session_id: hiveSessionId,
+    agent_session_id: agentSessionId,
+    thread_id: null,
+    turn_id: null,
+    item_id: options?.itemId ?? null,
+    request_id: options?.requestId ?? null,
+    kind,
+    tone,
+    summary,
+    payload_json: stringifyPayload(payload),
+    created_at: options?.createdAt ?? new Date().toISOString()
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tool-part mapping
+// ---------------------------------------------------------------------------
+
+interface ToolMappingResult {
+  kind: SessionActivityKind
+  tone: SessionActivityTone
+}
+
+function mapToolStatus(
+  status: string | undefined,
+  alreadyStarted: boolean
+): ToolMappingResult | null {
+  switch (status) {
+    case 'pending':
+    case 'running':
+      return alreadyStarted
+        ? { kind: 'tool.updated', tone: 'tool' }
+        : { kind: 'tool.started', tone: 'tool' }
+    case 'completed':
+      return { kind: 'tool.completed', tone: 'tool' }
+    case 'error':
+    case 'cancelled':
+      return { kind: 'tool.failed', tone: 'error' }
+    default:
+      return null
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Map a single OpenCode raw event to a SessionActivity record. Returns `null`
+ * when the event isn't relevant to activity persistence.
+ *
+ * `toolStartedTracker` is mutated in place when a tool transitions through
+ * `running` so subsequent updates emit `tool.updated` instead of `tool.started`.
+ * Pass a fresh `Set()` per session if you want clean replay semantics.
+ */
+export function mapOpenCodeEventToActivity(
+  hiveSessionId: string,
+  agentSessionId: string | null,
+  event: OpenCodeRawEvent,
+  toolStartedTracker: ToolStartedTracker
+): SessionActivityCreate | null {
+  const eventType = event.type
+  if (!eventType) return null
+
+  const properties = asObject(event.properties)
+
+  // ---------------------------------------------------------------------
+  // message.part.updated — tool lifecycle
+  // ---------------------------------------------------------------------
+  if (eventType === 'message.part.updated') {
+    const part = asObject(properties?.part)
+    if (!part || part.type !== 'tool') return null
+
+    const callId = asString(part.callID) ?? asString(part.id)
+    if (!callId) return null
+
+    const state = asObject(part.state) ?? {}
+    const status = asString(state.status)
+    const alreadyStarted = toolStartedTracker.has(callId)
+    const mapping = mapToolStatus(status, alreadyStarted)
+    if (!mapping) return null
+
+    if (mapping.kind === 'tool.started') {
+      toolStartedTracker.add(callId)
+    }
+    if (mapping.kind === 'tool.completed' || mapping.kind === 'tool.failed') {
+      // Free the slot so a fresh callID re-using the same string starts clean.
+      toolStartedTracker.delete(callId)
+    }
+
+    const toolName =
+      asString(part.toolDisplay) ?? asString(part.tool) ?? asString(part.name) ?? 'tool'
+
+    return buildActivity(
+      hiveSessionId,
+      agentSessionId,
+      mapping.kind,
+      mapping.tone,
+      toolName,
+      part,
+      {
+        id: `${callId}:${mapping.kind}`,
+        itemId: callId
+      }
+    )
+  }
+
+  // ---------------------------------------------------------------------
+  // session.idle — turn finished
+  // ---------------------------------------------------------------------
+  if (eventType === 'session.idle') {
+    return buildActivity(
+      hiveSessionId,
+      agentSessionId,
+      'session.info',
+      'info',
+      'Session idle',
+      properties ?? {}
+    )
+  }
+
+  // ---------------------------------------------------------------------
+  // session.error — runtime failure
+  // ---------------------------------------------------------------------
+  if (eventType === 'session.error') {
+    const errorObj = asObject(properties?.error)
+    const message =
+      asString(errorObj?.message) ??
+      asString(properties?.message) ??
+      asString(properties?.error) ??
+      'Session error'
+    return buildActivity(
+      hiveSessionId,
+      agentSessionId,
+      'session.error',
+      'error',
+      message,
+      properties ?? {}
+    )
+  }
+
+  // ---------------------------------------------------------------------
+  // question.asked — interactive question prompt
+  // ---------------------------------------------------------------------
+  if (eventType === 'question.asked') {
+    const requestId = asString(properties?.requestId) ?? asString(properties?.id)
+    const id = asString(properties?.id) ?? requestId ?? randomUUID()
+    return buildActivity(
+      hiveSessionId,
+      agentSessionId,
+      'user-input.requested',
+      'approval',
+      'User input requested',
+      properties ?? {},
+      {
+        id: `${id}:user-input.requested`,
+        itemId: id,
+        requestId: requestId ?? null
+      }
+    )
+  }
+
+  // ---------------------------------------------------------------------
+  // permission.asked — tool permission gate
+  // ---------------------------------------------------------------------
+  if (eventType === 'permission.asked') {
+    const id = asString(properties?.id) ?? randomUUID()
+    const summary =
+      asString(properties?.permission) ??
+      (Array.isArray(properties?.patterns) && (properties.patterns as unknown[]).length > 0
+        ? `Permission requested: ${(properties.patterns as unknown[]).join(', ')}`
+        : 'Permission requested')
+    return buildActivity(
+      hiveSessionId,
+      agentSessionId,
+      'approval.requested',
+      'approval',
+      summary,
+      properties ?? {},
+      {
+        id: `${id}:approval.requested`,
+        itemId: id
+      }
+    )
+  }
+
+  // ---------------------------------------------------------------------
+  // command.approval_needed — command filter approval
+  // ---------------------------------------------------------------------
+  if (eventType === 'command.approval_needed') {
+    const requestId = asString(properties?.requestId) ?? randomUUID()
+    const summary =
+      asString(properties?.commandStr) ??
+      asString(properties?.command) ??
+      'Command approval required'
+    return buildActivity(
+      hiveSessionId,
+      agentSessionId,
+      'approval.requested',
+      'approval',
+      summary,
+      properties ?? {},
+      {
+        id: `${requestId}:approval.requested`,
+        requestId
+      }
+    )
+  }
+
+  return null
+}

--- a/src/main/services/opencode-event-dumper.ts
+++ b/src/main/services/opencode-event-dumper.ts
@@ -1,0 +1,122 @@
+/**
+ * OpenCode event dumper.
+ *
+ * Purpose:
+ * - Capture enough evidence from OpenCode sessions that we can debug
+ *   plan/todo/question/approval/token/compaction behavior after a manual run
+ *   without relying on user recollection.
+ * - Keep data OUT of the regular xuanpu log file; event streams can be noisy.
+ * - Make analysis dead simple: one NDJSON line per record.
+ *
+ * Default behavior:
+ * - Enabled automatically in development (NODE_ENV === 'development')
+ * - Can be forced on/off with XUANPU_DUMP_OPENCODE_EVENTS=1/0
+ * - Output directory defaults to ~/.xuanpu/logs, overridable with
+ *   XUANPU_DUMP_OPENCODE_DIR
+ *
+ * File format:
+ *   ~/.xuanpu/logs/opencode-events-<sessionKey|boot>-<ts>.ndjson
+ *
+ * Record shapes:
+ *   { ts, kind: 'sdk_event', sessionKey, payload }
+ *   { ts, kind: 'canonical_event', sessionKey, payload }
+ *   { ts, kind: 'marker', sessionKey, payload }
+ */
+import { appendFileSync, mkdirSync, openSync, closeSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+
+const ENV_FLAG = 'XUANPU_DUMP_OPENCODE_EVENTS'
+
+function isEnabled(): boolean {
+  const value = process.env[ENV_FLAG]
+  if (value) {
+    return value !== '0' && value.toLowerCase() !== 'false'
+  }
+  return process.env.NODE_ENV === 'development'
+}
+
+function sanitizeKey(key: string | undefined): string {
+  if (!key || key.length === 0) return 'boot'
+  return key.replace(/[^a-zA-Z0-9._-]/g, '_').slice(0, 120)
+}
+
+export interface OpenCodeEventDumper {
+  recordSdkEvent(sessionKey: string | undefined, payload: unknown): void
+  recordCanonicalEvent(sessionKey: string | undefined, payload: unknown): void
+  recordMarker(sessionKey: string | undefined, payload: unknown): void
+}
+
+class FileDumper implements OpenCodeEventDumper {
+  private files = new Map<string, number>()
+  private dir: string
+
+  constructor() {
+    this.dir = process.env.XUANPU_DUMP_OPENCODE_DIR ?? join(homedir(), '.xuanpu', 'logs')
+    try {
+      mkdirSync(this.dir, { recursive: true })
+    } catch {
+      // best effort
+    }
+  }
+
+  private fdFor(key: string): number | null {
+    const sanitized = sanitizeKey(key)
+    const existing = this.files.get(sanitized)
+    if (existing !== undefined) return existing
+    const ts = new Date().toISOString().replace(/[:.]/g, '-')
+    const path = join(this.dir, `opencode-events-${sanitized}-${ts}.ndjson`)
+    try {
+      const fd = openSync(path, 'a')
+      this.files.set(sanitized, fd)
+      process.once('exit', () => {
+        try {
+          closeSync(fd)
+        } catch {
+          /* ignore */
+        }
+      })
+      return fd
+    } catch {
+      return null
+    }
+  }
+
+  private write(kind: 'sdk_event' | 'canonical_event' | 'marker', sessionKey: string | undefined, payload: unknown): void {
+    const key = sanitizeKey(sessionKey)
+    const fd = this.fdFor(key)
+    if (fd === null) return
+    try {
+      appendFileSync(
+        fd,
+        `${JSON.stringify({ ts: new Date().toISOString(), kind, sessionKey: sessionKey ?? null, payload })}\n`
+      )
+    } catch {
+      /* ignore */
+    }
+  }
+
+  recordSdkEvent(sessionKey: string | undefined, payload: unknown): void {
+    this.write('sdk_event', sessionKey, payload)
+  }
+
+  recordCanonicalEvent(sessionKey: string | undefined, payload: unknown): void {
+    this.write('canonical_event', sessionKey, payload)
+  }
+
+  recordMarker(sessionKey: string | undefined, payload: unknown): void {
+    this.write('marker', sessionKey, payload)
+  }
+}
+
+let cached: OpenCodeEventDumper | null | undefined
+
+export function getOpenCodeEventDumper(): OpenCodeEventDumper | null {
+  if (cached !== undefined) return cached
+  cached = isEnabled() ? new FileDumper() : null
+  return cached
+}
+
+export function __resetOpenCodeEventDumper(): void {
+  cached = undefined
+}

--- a/src/main/services/opencode-service.ts
+++ b/src/main/services/opencode-service.ts
@@ -8,6 +8,16 @@ import { getEventBus } from '../../server/event-bus'
 import type { AgentSdkImplementer } from './agent-runtime-types'
 import type { AgentRuntimeAdapter } from './agent-runtime-types'
 import { beginSessionRun, emitAgentEvent } from '@shared/lib/normalize-agent-event'
+import { classifyOpenCodeTool } from '@shared/lib/opencode-classify'
+import {
+  mapOpenCodeEventToActivity,
+  type ToolStartedTracker
+} from './opencode-activity-mapper'
+import {
+  generateOpenCodeSessionTitle,
+  isPlaceholderSessionTitle,
+  extractTitleSourceText
+} from './opencode-session-title'
 import {
   resolveOpenCodeLaunchSpec,
   type OpenCodeLaunchSpec
@@ -64,6 +74,14 @@ interface OpenCodeInstance {
   directorySubscriptions: Map<string, DirectorySubscription>
   // Map of directory-scoped child/subagent OpenCode session keys to parent OpenCode session IDs
   childToParentMap: Map<string, string>
+  // Phase 1.4.5 (OpenCode parity): per-Hive-session set of tool callIDs we've
+  // already emitted a `tool.started` activity for. Used by the activity mapper
+  // to flip subsequent `running` updates into `tool.updated`.
+  toolStartedTrackerByHiveSession: Map<string, Set<string>>
+  // Phase 1.4.5 (OpenCode parity): per-Hive-session flag tracking whether we
+  // have already kicked off async title generation for that session, so we
+  // only do it once (on the first user prompt).
+  titleGenerationStartedByHiveSession: Map<string, boolean>
 }
 
 function asRecord(value: unknown): Record<string, unknown> | null {
@@ -331,7 +349,9 @@ class OpenCodeService implements AgentSdkImplementer, AgentRuntimeAdapter {
           sessionMap: new Map(),
           sessionDirectories: new Map(),
           directorySubscriptions: new Map(),
-          childToParentMap: new Map()
+          childToParentMap: new Map(),
+          toolStartedTrackerByHiveSession: new Map(),
+          titleGenerationStartedByHiveSession: new Map()
         }
 
         this.instance = instance
@@ -723,6 +743,15 @@ class OpenCodeService implements AgentSdkImplementer, AgentRuntimeAdapter {
       })
 
       log.info('Prompt sent successfully', { opencodeSessionId })
+
+      // Phase 1.4.5 (OpenCode parity): kick off async title generation on the
+      // first user prompt for this session, mirroring Codex's pattern. Fire
+      // and forget — failures must never block the prompt path. The
+      // `session.updated` handler will still pick up any later, better title
+      // emitted by OpenCode's server.
+      if (hiveSessionId) {
+        this.maybeStartTitleGeneration(hiveSessionId, opencodeSessionId, worktreePath, parts)
+      }
     } catch (error) {
       log.error('Failed to send prompt', { opencodeSessionId, error })
       throw error
@@ -1002,11 +1031,17 @@ class OpenCodeService implements AgentSdkImplementer, AgentRuntimeAdapter {
     this.unsubscribeFromDirectory(this.instance, worktreePath)
 
     const scopedKey = this.getSessionMapKey(worktreePath, opencodeSessionId)
+    const trackedHiveSessionId =
+      this.instance.sessionMap.get(scopedKey) ?? this.instance.sessionMap.get(opencodeSessionId)
     this.instance.sessionMap.delete(scopedKey)
     this.instance.sessionDirectories.delete(scopedKey)
     // Legacy cleanup
     this.instance.sessionMap.delete(opencodeSessionId)
     this.instance.sessionDirectories.delete(opencodeSessionId)
+    if (trackedHiveSessionId) {
+      this.instance.toolStartedTrackerByHiveSession.delete(trackedHiveSessionId)
+      this.instance.titleGenerationStartedByHiveSession.delete(trackedHiveSessionId)
+    }
 
     // Clean up child-to-parent mappings that reference this parent
     for (const [childId, parentId] of this.instance.childToParentMap) {
@@ -1040,6 +1075,8 @@ class OpenCodeService implements AgentSdkImplementer, AgentRuntimeAdapter {
     }
     this.instance.directorySubscriptions.clear()
     this.instance.childToParentMap.clear()
+    this.instance.toolStartedTrackerByHiveSession.clear()
+    this.instance.titleGenerationStartedByHiveSession.clear()
 
     // Close the server
     try {
@@ -1288,7 +1325,30 @@ class OpenCodeService implements AgentSdkImplementer, AgentRuntimeAdapter {
         : {})
     }
 
+    // Phase 1.4.5 (OpenCode parity): rewrite tool parts so `part.tool` carries
+    // the CanonicalToolName (Bash/Read/Edit/...) the agent-protocol contract
+    // expects. Original lowercase name is preserved on `toolDisplay`. Both the
+    // live stream and the durable message snapshot benefit from canonical
+    // names; ToolCard's case-insensitive fallback remains as a safety net.
+    if (eventType === 'message.part.updated') {
+      this.canonicalizeToolPart(streamEvent.data)
+    }
+
     emitAgentEvent(this.mainWindow, streamEvent)
+
+    // Phase 1.4.5 (OpenCode parity): persist a SessionActivity row so the
+    // history view can replay this turn just like Codex does. Skip child /
+    // subagent events at this layer — only parent-session activities show up
+    // in the timeline (matches existing Phase 21.5 emit-agent-tool gating).
+    if (!isChildEvent) {
+      try {
+        this.persistOpenCodeActivity(hiveSessionId, sessionId, event)
+      } catch (err) {
+        log.debug('OpenCode activity persistence failed; continuing', {
+          error: err instanceof Error ? err.message : String(err)
+        })
+      }
+    }
 
     // Phase 21.5: emit agent.* field event when a tool part completes.
     // OpenCode streams tool parts via `message.part.updated`; we only emit
@@ -1544,6 +1604,140 @@ class OpenCodeService implements AgentSdkImplementer, AgentRuntimeAdapter {
   async cleanup(): Promise<void> {
     log.info('Cleaning up OpenCode instance')
     this.shutdownServer()
+  }
+
+  /**
+   * Phase 1.4.5 (OpenCode parity): kick off async session-title generation on
+   * the first user prompt for a Hive session, mirroring Codex's pattern in
+   * `codex-implementer.ts:760-762`.
+   *
+   * - Idempotent per Hive session (guarded by `titleGenerationStartedByHiveSession`)
+   * - Fire-and-forget: errors are logged, never thrown
+   * - Skips empty messages
+   * - Only applies the generated title when the current DB title is still a
+   *   placeholder ("Session N" / "New session 2026-..."), letting the
+   *   `session.updated` handler win if OpenCode itself produces a better
+   *   title in the meantime
+   * - Also calls `renameSession` so the OpenCode server-side title stays in
+   *   sync (best-effort)
+   */
+  private maybeStartTitleGeneration(
+    hiveSessionId: string,
+    opencodeSessionId: string,
+    worktreePath: string,
+    parts: Array<
+      | { type: 'text'; text: string }
+      | { type: 'file'; mime: string; url: string; filename?: string }
+    >
+  ): void {
+    const instance = this.instance
+    if (!instance) return
+    if (instance.titleGenerationStartedByHiveSession.get(hiveSessionId)) return
+
+    const sourceText = extractTitleSourceText(parts)
+    if (!sourceText) return
+
+    instance.titleGenerationStartedByHiveSession.set(hiveSessionId, true)
+
+    void (async () => {
+      try {
+        const title = await generateOpenCodeSessionTitle(sourceText, worktreePath)
+        if (!title) return
+
+        const db = getDatabase()
+        const current = db.getSession(hiveSessionId)?.name ?? null
+        if (!isPlaceholderSessionTitle(current)) {
+          log.info('Skipping generated title — session already has a non-placeholder name', {
+            hiveSessionId,
+            current
+          })
+          return
+        }
+
+        db.updateSession(hiveSessionId, { name: title })
+        log.info('Applied generated OpenCode session title', { hiveSessionId, title })
+
+        // Best-effort sync to OpenCode server so its session record matches.
+        try {
+          await this.renameSession(opencodeSessionId, title, worktreePath)
+        } catch (syncErr) {
+          log.warn('Failed to sync generated title to OpenCode server', {
+            opencodeSessionId,
+            error: syncErr instanceof Error ? syncErr.message : String(syncErr)
+          })
+        }
+      } catch (err) {
+        log.warn('Title generation failed', {
+          hiveSessionId,
+          error: err instanceof Error ? err.message : String(err)
+        })
+      }
+    })()
+  }
+
+  /**
+   * Phase 1.4.5 (OpenCode parity): persist a SessionActivity record for the
+   * given OpenCode event so the history pane can replay the turn (parity with
+   * Codex which goes through `mapCodexManagerEventToActivity`).
+   *
+   * - Tracker (per-Hive-session Set<callID>) lives on the instance so
+   *   `running` → `running` transitions correctly emit `tool.updated` instead
+   *   of duplicating `tool.started`.
+   * - DB writes are best-effort: caller already wraps in try/catch.
+   */
+  private persistOpenCodeActivity(
+    hiveSessionId: string,
+    agentSessionId: string,
+    event: { type?: string; properties?: Record<string, unknown> }
+  ): void {
+    const instance = this.instance
+    if (!instance) return
+
+    let tracker: ToolStartedTracker | undefined =
+      instance.toolStartedTrackerByHiveSession.get(hiveSessionId)
+    if (!tracker) {
+      tracker = new Set<string>()
+      instance.toolStartedTrackerByHiveSession.set(hiveSessionId, tracker)
+    }
+
+    const activity = mapOpenCodeEventToActivity(hiveSessionId, agentSessionId, event, tracker)
+    if (!activity) return
+
+    const db = getDatabase()
+    db.upsertSessionActivity(activity)
+  }
+
+  /**
+   * Phase 1.4.5 (OpenCode parity): rewrite a `message.part.updated` payload
+   * in place so any tool part carries a CanonicalToolName.
+   *
+   * OpenCode's SDK emits lowercase native names ('bash' / 'read' / ...) on
+   * `part.tool`. The agent-protocol contract (src/shared/types/agent-protocol.ts)
+   * requires CanonicalToolName ('Bash' / 'Read' / ...). We mutate the part
+   * object so:
+   *   - `tool`         → CanonicalToolName (Bash / Read / Edit / Grep / ...)
+   *   - `toolDisplay`  → original raw name (preserved for UI display)
+   *   - `mcpServer`    → server segment when classified as 'McpTool'
+   *
+   * Mutation is shallow and safe because `streamEvent.data` is fresh per event
+   * (event.properties from the SDK iterator). Non-tool parts are ignored.
+   */
+  private canonicalizeToolPart(data: unknown): void {
+    if (!data || typeof data !== 'object') return
+    const dataRecord = data as Record<string, unknown>
+    const part = dataRecord.part as Record<string, unknown> | undefined
+    if (!part || part.type !== 'tool') return
+    const rawName = part.tool
+    if (typeof rawName !== 'string' || rawName.length === 0) return
+
+    const classified = classifyOpenCodeTool(rawName)
+    part.tool = classified.tool
+    if (classified.toolDisplay && !part.toolDisplay) {
+      part.toolDisplay = classified.toolDisplay
+    }
+    if (classified.mcpServer && !part.mcpServer) {
+      part.mcpServer = classified.mcpServer
+    }
   }
 
   /**

--- a/src/main/services/opencode-service.ts
+++ b/src/main/services/opencode-service.ts
@@ -7,8 +7,10 @@ import { autoRenameWorktreeBranch } from './git-service'
 import { getEventBus } from '../../server/event-bus'
 import type { AgentSdkImplementer } from './agent-runtime-types'
 import type { AgentRuntimeAdapter } from './agent-runtime-types'
+import { OPENCODE_CAPABILITIES } from './agent-runtime-types'
 import { beginSessionRun, emitAgentEvent } from '@shared/lib/normalize-agent-event'
 import { classifyOpenCodeTool } from '@shared/lib/opencode-classify'
+import { stripInjectedContextEnvelope } from '@shared/lib/timeline-mappers'
 import {
   mapOpenCodeEventToActivity,
   type ToolStartedTracker
@@ -22,9 +24,11 @@ import {
   resolveOpenCodeLaunchSpec,
   type OpenCodeLaunchSpec
 } from './opencode-binary-resolver'
+import { getOpenCodeEventDumper } from './opencode-event-dumper'
 import { spawnLaunchSpec } from './command-launch-utils'
 
 const log = createLogger({ component: 'OpenCodeService' })
+const opencodeDumper = getOpenCodeEventDumper()
 
 // Default model configuration
 const DEFAULT_MODEL = {
@@ -60,6 +64,19 @@ interface DirectorySubscription {
   sessionCount: number
 }
 
+interface OpenCodeMessageBuffer {
+  /** Raw `info` object as last received from the SDK (Message metadata). */
+  info: Record<string, unknown> | null
+  /** Parts keyed by their stable id, so updates merge instead of overwrite. */
+  parts: Map<string, Record<string, unknown>>
+  /** Insertion order so the persisted JSON keeps stream-aligned ordering. */
+  partOrder: string[]
+  /** Role inferred from `info.role`; cached because some events drop it. */
+  role: string | null
+  /** Last `time.created` timestamp, used to populate created_at on the row. */
+  createdAt: string | null
+}
+
 interface OpenCodeInstance {
   client: OpencodeClient
   server: {
@@ -78,10 +95,29 @@ interface OpenCodeInstance {
   // already emitted a `tool.started` activity for. Used by the activity mapper
   // to flip subsequent `running` updates into `tool.updated`.
   toolStartedTrackerByHiveSession: Map<string, Set<string>>
-  // Phase 1.4.5 (OpenCode parity): per-Hive-session flag tracking whether we
-  // have already kicked off async title generation for that session, so we
-  // only do it once (on the first user prompt).
-  titleGenerationStartedByHiveSession: Map<string, boolean>
+  // Phase 1.4.6: remember user-message ids seen on `message.updated` so we can
+  // suppress OpenCode's later user-echo `message.part.updated` events carrying
+  // the injected Field Context envelope.
+  userMessageIdsByHiveSession: Map<string, Set<string>>
+  // Phase 1.4.7 (OpenCode persistence parity): per-Hive-session in-memory
+  // buffer of `messageId → { info, parts }` so we can flush a complete row to
+  // `session_messages` whenever a `message.updated` event arrives. Codex /
+  // Claude Code own this concept already; OpenCode used to lean on the SDK
+  // server-side transcript instead. Persisting here lets the SQLite timeline
+  // be the source of truth and removes the "history empty until first turn
+  // ends" UX hole.
+  messageBuffersByHiveSession: Map<string, Map<string, OpenCodeMessageBuffer>>
+  /** Title generation guard, see `maybeStartTitleGeneration`. */
+  titleGenerationStartedByHiveSession: Map<string, true>
+  /**
+   * Phase 1.4.8 (OpenCode plan parity): per-Hive-session set of OpenCode
+   * assistant message IDs we've already turned into a `plan.ready` event.
+   * Plan agents may emit several `message.updated` for the same message
+   * (e.g. partial → final), and we want to fire `plan.ready` exactly once
+   * per assistant turn so the renderer's pendingPlan slot doesn't clobber
+   * itself or get re-armed after the user accepts/rejects.
+   */
+  planEmittedByHiveSession: Map<string, Set<string>>
 }
 
 function asRecord(value: unknown): Record<string, unknown> | null {
@@ -94,6 +130,10 @@ function asString(value: unknown): string | undefined {
   return typeof value === 'string' ? value : undefined
 }
 
+function asNumber(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined
+}
+
 function messageInfo(message: unknown): { id?: string; role?: string; parts: unknown[] } {
   const record = asRecord(message)
   const info = asRecord(record?.info)
@@ -101,6 +141,12 @@ function messageInfo(message: unknown): { id?: string; role?: string; parts: unk
   const role = asString(info?.role) ?? asString(record?.role)
   const parts = Array.isArray(record?.parts) ? record.parts : []
   return { id, role, parts }
+}
+
+function dumpSessionKey(directory: string | undefined, sessionId: string | undefined): string {
+  const dir = directory && directory.length > 0 ? directory : 'no-dir'
+  const sid = sessionId && sessionId.length > 0 ? sessionId : 'no-session'
+  return `${dir}::${sid}`
 }
 
 function extractPromptTextFromMessage(message: unknown): string {
@@ -230,21 +276,14 @@ function spawnOpenCodeServer(
 
 class OpenCodeService implements AgentSdkImplementer, AgentRuntimeAdapter {
   readonly id = 'opencode' as const
-  readonly capabilities = {
-    supportsUndo: true,
-    supportsRedo: true,
-    supportsCommands: true,
-    supportsPermissionRequests: true,
-    supportsQuestionPrompts: true,
-    supportsModelSelection: true,
-    supportsReconnect: true,
-    supportsPartialStreaming: true
-  }
+  readonly capabilities = OPENCODE_CAPABILITIES
 
   // Single server instance (OpenCode handles multiple directories via query params)
   private instance: OpenCodeInstance | null = null
   private mainWindow: BrowserWindow | null = null
   private pendingConnection: Promise<OpenCodeInstance> | null = null
+  private pendingQuestions = new Map<string, string>()
+  private pendingApprovals = new Map<string, string>()
 
   setMainWindow(window: BrowserWindow): void {
     this.mainWindow = window
@@ -351,7 +390,10 @@ class OpenCodeService implements AgentSdkImplementer, AgentRuntimeAdapter {
           directorySubscriptions: new Map(),
           childToParentMap: new Map(),
           toolStartedTrackerByHiveSession: new Map(),
-          titleGenerationStartedByHiveSession: new Map()
+          titleGenerationStartedByHiveSession: new Map(),
+          userMessageIdsByHiveSession: new Map(),
+          messageBuffersByHiveSession: new Map(),
+          planEmittedByHiveSession: new Map()
         }
 
         this.instance = instance
@@ -545,6 +587,14 @@ class OpenCodeService implements AgentSdkImplementer, AgentRuntimeAdapter {
         })
         const revert = asRecord(asRecord(sessionResult.data)?.revert)
         const revertMessageID = asString(revert?.messageID) ?? null
+        // Phase 1.4.7: top-up SQLite even on the fast-path so user-visible
+        // history doesn't depend on whether the previous session was already
+        // registered.
+        void this.hydrateOpenCodeMessagesFromServer(
+          hiveSessionId,
+          worktreePath,
+          opencodeSessionId
+        ).catch(() => {})
         return { success: true, sessionStatus, revertMessageID }
       }
 
@@ -559,6 +609,16 @@ class OpenCodeService implements AgentSdkImplementer, AgentRuntimeAdapter {
 
         // Subscribe to events for this directory
         this.subscribeToDirectory(instance, worktreePath)
+
+        // Phase 1.4.7 (OpenCode persistence parity): right after a successful
+        // reconnect we may have missed live events between server start and
+        // the subscription returning. Hydrating once means SQLite reflects
+        // the SDK transcript before any UI refresh runs.
+        void this.hydrateOpenCodeMessagesFromServer(
+          hiveSessionId,
+          worktreePath,
+          opencodeSessionId
+        ).catch(() => {})
 
         const sessionStatus = await this.querySessionStatus(
           instance,
@@ -703,7 +763,8 @@ class OpenCodeService implements AgentSdkImplementer, AgentRuntimeAdapter {
           | { type: 'text'; text: string }
           | { type: 'file'; mime: string; url: string; filename?: string }
         >,
-    modelOverride?: { providerID: string; modelID: string; variant?: string }
+    modelOverride?: { providerID: string; modelID: string; variant?: string },
+    options?: { codexFastMode?: boolean; mode?: 'build' | 'plan' }
   ): Promise<void> {
     const parts =
       typeof messageOrParts === 'string'
@@ -713,7 +774,16 @@ class OpenCodeService implements AgentSdkImplementer, AgentRuntimeAdapter {
     log.info('Sending prompt to OpenCode', {
       worktreePath,
       opencodeSessionId,
-      partsCount: parts.length
+      partsCount: parts.length,
+      mode: options?.mode
+    })
+    opencodeDumper?.recordMarker(dumpSessionKey(worktreePath, opencodeSessionId), {
+      type: 'prompt.start',
+      worktreePath,
+      opencodeSessionId,
+      parts,
+      modelOverride: modelOverride ?? null,
+      mode: options?.mode ?? null
     })
 
     if (!this.instance) {
@@ -728,7 +798,7 @@ class OpenCodeService implements AgentSdkImplementer, AgentRuntimeAdapter {
     }
 
     const { variant, ...model } = modelOverride ?? this.getSelectedModel()
-    log.info('Using model for prompt', { model, variant })
+    log.info('Using model for prompt', { model, variant, agent: options?.mode })
 
     try {
       // Use promptAsync for non-blocking behavior - events will stream the response
@@ -738,11 +808,19 @@ class OpenCodeService implements AgentSdkImplementer, AgentRuntimeAdapter {
         body: {
           model,
           variant,
-          parts
+          parts,
+          // Pass agent name to select plan/build agent in OpenCode
+          agent: options?.mode === 'plan' ? 'plan' : undefined
         }
       })
 
-      log.info('Prompt sent successfully', { opencodeSessionId })
+      log.info('Prompt sent successfully', { opencodeSessionId, agent: options?.mode })
+      opencodeDumper?.recordMarker(dumpSessionKey(worktreePath, opencodeSessionId), {
+        type: 'prompt.accepted',
+        worktreePath,
+        opencodeSessionId,
+        agent: options?.mode ?? null
+      })
 
       // Phase 1.4.5 (OpenCode parity): kick off async title generation on the
       // first user prompt for this session, mirroring Codex's pattern. Fire
@@ -766,10 +844,37 @@ class OpenCodeService implements AgentSdkImplementer, AgentRuntimeAdapter {
       throw new Error('No OpenCode instance for worktree')
     }
 
+    const hiveSessionId =
+      this.getMappedHiveSessionId(this.instance, opencodeSessionId, worktreePath) ??
+      getDatabase().getSessionByOpenCodeSessionId(opencodeSessionId)?.id ??
+      null
+
     const result = await this.instance.client.session.abort({
       path: { id: opencodeSessionId },
       query: { directory: worktreePath }
     })
+
+    // P3: best-effort draft flush for OpenCode. Unlike Claude Code we don't
+    // own an in-memory authoritative assistant draft in the main process, but
+    // we can still materialize the latest persisted assistant message back into
+    // the renderer and force the lifecycle to idle so partial streamed content
+    // does not stay visually stuck forever after abort.
+    if (result.data === true && hiveSessionId) {
+      opencodeDumper?.recordMarker(dumpSessionKey(worktreePath, opencodeSessionId), {
+        type: 'abort.accepted',
+        worktreePath,
+        opencodeSessionId,
+        hiveSessionId
+      })
+      await this.flushAbortDraft(worktreePath, opencodeSessionId, hiveSessionId).catch((error) => {
+        log.warn('OpenCode abort draft flush failed', {
+          worktreePath,
+          opencodeSessionId,
+          hiveSessionId,
+          error
+        })
+      })
+    }
 
     return result.data === true
   }
@@ -795,6 +900,7 @@ class OpenCodeService implements AgentSdkImplementer, AgentRuntimeAdapter {
       const text = await resp.text().catch(() => '')
       throw new Error(`Question reply failed (${resp.status}): ${text}`)
     }
+    this.pendingQuestions.delete(requestId)
   }
 
   /**
@@ -813,6 +919,7 @@ class OpenCodeService implements AgentSdkImplementer, AgentRuntimeAdapter {
       const text = await resp.text().catch(() => '')
       throw new Error(`Question reject failed (${resp.status}): ${text}`)
     }
+    this.pendingQuestions.delete(requestId)
   }
 
   /**
@@ -839,6 +946,7 @@ class OpenCodeService implements AgentSdkImplementer, AgentRuntimeAdapter {
       const text = await resp.text().catch(() => '')
       throw new Error(`Permission reply failed (${resp.status}): ${text}`)
     }
+    this.pendingApprovals.delete(requestId)
   }
 
   /**
@@ -859,6 +967,14 @@ class OpenCodeService implements AgentSdkImplementer, AgentRuntimeAdapter {
     }
     const data = await resp.json()
     return Array.isArray(data) ? data : (data?.data ?? [])
+  }
+
+  hasPendingQuestion(requestId: string): boolean {
+    return this.pendingQuestions.has(requestId)
+  }
+
+  hasPendingApproval(requestId: string): boolean {
+    return this.pendingApprovals.has(requestId)
   }
 
   /**
@@ -1041,6 +1157,10 @@ class OpenCodeService implements AgentSdkImplementer, AgentRuntimeAdapter {
     if (trackedHiveSessionId) {
       this.instance.toolStartedTrackerByHiveSession.delete(trackedHiveSessionId)
       this.instance.titleGenerationStartedByHiveSession.delete(trackedHiveSessionId)
+      this.instance.userMessageIdsByHiveSession.delete(trackedHiveSessionId)
+      this.instance.messageBuffersByHiveSession.delete(trackedHiveSessionId)
+      this.instance.planEmittedByHiveSession.delete(trackedHiveSessionId)
+      this.clearPendingRequestsForSession(trackedHiveSessionId)
     }
 
     // Clean up child-to-parent mappings that reference this parent
@@ -1077,6 +1197,11 @@ class OpenCodeService implements AgentSdkImplementer, AgentRuntimeAdapter {
     this.instance.childToParentMap.clear()
     this.instance.toolStartedTrackerByHiveSession.clear()
     this.instance.titleGenerationStartedByHiveSession.clear()
+    this.instance.userMessageIdsByHiveSession.clear()
+    this.instance.messageBuffersByHiveSession.clear()
+    this.instance.planEmittedByHiveSession.clear()
+    this.pendingQuestions.clear()
+    this.pendingApprovals.clear()
 
     // Close the server
     try {
@@ -1112,6 +1237,13 @@ class OpenCodeService implements AgentSdkImplementer, AgentRuntimeAdapter {
     }
 
     const eventType = event.type || rawEvent.event
+
+    opencodeDumper?.recordSdkEvent(dumpSessionKey(eventDirectory, undefined), {
+      rawEvent,
+      unwrappedEvent: event,
+      directory: eventDirectory,
+      eventType
+    })
 
     // Skip noisy events
     if (eventType === 'server.heartbeat' || eventType === 'server.connected') {
@@ -1168,6 +1300,57 @@ class OpenCodeService implements AgentSdkImplementer, AgentRuntimeAdapter {
       return
     }
 
+    const info = asRecord(event.properties?.info)
+    if (eventType === 'message.updated' && asString(info?.role) === 'user' && asString(info?.id)) {
+      let userIds = instance.userMessageIdsByHiveSession.get(hiveSessionId)
+      if (!userIds) {
+        userIds = new Set<string>()
+        instance.userMessageIdsByHiveSession.set(hiveSessionId, userIds)
+      }
+      userIds.add(asString(info?.id)!)
+    }
+
+    const partRecord = asRecord(event.properties?.part)
+    // Phase 1.4.6: OpenCode echoes the user-message text (including the
+    // injected Field Context envelope) back as a `message.part.updated`
+    // event carrying `type: 'text'` with `messageID` belonging to the
+    // user message. We do NOT want the renderer streaming overlay to pick
+    // that up — it would leak the envelope into the chat surface. But we
+    // MUST still let the persistence pipeline see this part; otherwise the
+    // corresponding user row in `session_messages` ends up with empty
+    // content and the timeline refresh shows a phantom empty bubble next
+    // to the optimistic one.
+    const isUserEchoTextPart =
+      eventType === 'message.part.updated' &&
+      !!partRecord &&
+      partRecord.type === 'text' &&
+      typeof partRecord.messageID === 'string' &&
+      instance.userMessageIdsByHiveSession.get(hiveSessionId)?.has(partRecord.messageID)
+
+    if (isUserEchoTextPart) {
+      log.debug('Suppressing OpenCode user-echo text emit; keeping persistence', {
+        hiveSessionId,
+        sessionId,
+        messageID: partRecord!.messageID
+      })
+      opencodeDumper?.recordMarker(dumpSessionKey(eventDirectory, sessionId), {
+        type: 'skip.user_echo_part',
+        hiveSessionId,
+        messageID: asString(partRecord!.messageID) ?? null,
+        preview: asString(partRecord!.text)?.slice(0, 120) ?? null
+      })
+      // Feed the part into the persistence buffer so the durable user row
+      // eventually holds the original (envelope-stripped) prompt text.
+      try {
+        this.persistOpenCodeMessageEvent(hiveSessionId, eventType, event)
+      } catch (err) {
+        log.debug('OpenCode user-echo persistence failed; continuing', {
+          error: err instanceof Error ? err.message : String(err)
+        })
+      }
+      return
+    }
+
     // Detect child/subagent events: no direct mapping but resolved through parent
     const isChildEvent = !directHiveId && !!hiveSessionId
 
@@ -1189,6 +1372,7 @@ class OpenCodeService implements AgentSdkImplementer, AgentRuntimeAdapter {
       eventType === 'permission.asked' ||
       eventType === 'command.approval_needed'
     ) {
+      this.trackPendingRequest(hiveSessionId, eventType, event.properties)
       this.maybeNotifyPendingUserFeedback(
         hiveSessionId,
         eventType === 'question.asked' ? 'question' : 'approval'
@@ -1325,6 +1509,42 @@ class OpenCodeService implements AgentSdkImplementer, AgentRuntimeAdapter {
         : {})
     }
 
+    opencodeDumper?.recordSdkEvent(dumpSessionKey(eventDirectory, sessionId), {
+      stage: 'resolved',
+      eventType,
+      hiveSessionId,
+      directHiveId,
+      isChildEvent,
+      sessionId,
+      directory: eventDirectory,
+      properties: event.properties ?? null
+    })
+
+    // P0 (OpenCode parity): Token 用量数据已在 `message.updated.properties.info`
+    // 里存在，玄圃之前没有提取。这里在不改变原始 `message.updated` 转发的前提下，
+    // 额外发出一条 `session.context_usage` 供 Session HQ / Hub 使用。
+    if (!isChildEvent && eventType === 'message.updated') {
+      this.maybeEmitContextUsage(hiveSessionId, event)
+    }
+
+    // P0 (OpenCode parity): SDK 类型里已有 compaction part / session.compacted
+    // 事件。我们把它们映射到通用协议，供 renderer 显示「正在压缩上下文」和
+    // 「上下文已压缩」提示。
+    if (!isChildEvent && eventType === 'message.part.updated') {
+      this.maybeEmitCompactionStarted(hiveSessionId, event)
+    }
+    if (!isChildEvent && eventType === 'session.compacted') {
+      emitAgentEvent(this.mainWindow, {
+        type: 'session.context_compacted',
+        sessionId: hiveSessionId,
+        data: event.properties || {}
+      })
+      opencodeDumper?.recordMarker(dumpSessionKey(eventDirectory, sessionId), {
+        type: 'session.context_compacted',
+        properties: event.properties ?? null
+      })
+    }
+
     // Phase 1.4.5 (OpenCode parity): rewrite tool parts so `part.tool` carries
     // the CanonicalToolName (Bash/Read/Edit/...) the agent-protocol contract
     // expects. Original lowercase name is preserved on `toolDisplay`. Both the
@@ -1335,6 +1555,22 @@ class OpenCodeService implements AgentSdkImplementer, AgentRuntimeAdapter {
     }
 
     emitAgentEvent(this.mainWindow, streamEvent)
+    opencodeDumper?.recordCanonicalEvent(dumpSessionKey(eventDirectory, sessionId), streamEvent)
+
+    // Phase 1.4.7 (OpenCode persistence parity): fold every message.* event
+    // into the in-memory buffer and flush on `message.updated` so SQLite
+    // becomes the source of truth for OpenCode transcripts. We do this AFTER
+    // the canonical emit so renderers still see the same events; the DB write
+    // is best-effort.
+    if (!isChildEvent) {
+      try {
+        this.persistOpenCodeMessageEvent(hiveSessionId, eventType, event)
+      } catch (err) {
+        log.debug('OpenCode message persistence failed; continuing', {
+          error: err instanceof Error ? err.message : String(err)
+        })
+      }
+    }
 
     // Phase 1.4.5 (OpenCode parity): persist a SessionActivity row so the
     // history view can replay this turn just like Codex does. Skip child /
@@ -1676,6 +1912,261 @@ class OpenCodeService implements AgentSdkImplementer, AgentRuntimeAdapter {
   }
 
   /**
+   * P0 (OpenCode parity): extract assistant token usage from
+   * `message.updated.properties.info.tokens` and emit a canonical
+   * `session.context_usage` event.
+   *
+   * OpenCode's AssistantMessage already carries:
+   *   tokens: { input, output, reasoning, cache: { read, write } }
+   *
+   * We forward that as-is into the shared agent protocol:
+   *   tokens: { input, cacheRead, cacheWrite, output, reasoning }
+   *
+   * Notes:
+   * - user-message echoes are skipped (`role !== 'assistant'`)
+   * - child-session updates are skipped by the caller (`!isChildEvent`)
+   * - no contextWindow is available on the message object, so we omit it
+   */
+  private maybeEmitContextUsage(
+    hiveSessionId: string,
+    event: { properties?: Record<string, unknown> }
+  ): void {
+    const info = asRecord(event.properties?.info)
+    if (!info) return
+    if (asString(info.role) !== 'assistant') return
+
+    const tokens = asRecord(info.tokens)
+    if (!tokens) return
+    const cache = asRecord(tokens.cache)
+
+    const input = asNumber(tokens.input) ?? 0
+    const output = asNumber(tokens.output) ?? 0
+    const reasoning = asNumber(tokens.reasoning) ?? 0
+    const cacheRead = asNumber(cache?.read) ?? 0
+    const cacheWrite = asNumber(cache?.write) ?? 0
+
+    if (input === 0 && output === 0 && reasoning === 0 && cacheRead === 0 && cacheWrite === 0) {
+      return
+    }
+
+    const providerID = asString(info.providerID)
+    const modelID = asString(info.modelID)
+
+    emitAgentEvent(this.mainWindow, {
+      type: 'session.context_usage',
+      sessionId: hiveSessionId,
+      data: {
+        tokens: {
+          input,
+          cacheRead,
+          cacheWrite,
+          output,
+          reasoning
+        },
+        ...(providerID && modelID
+          ? {
+              model: {
+                providerID,
+                modelID
+              }
+            }
+          : {})
+      }
+    })
+    opencodeDumper?.recordMarker(dumpSessionKey(undefined, hiveSessionId), {
+      type: 'session.context_usage',
+      tokens: { input, cacheRead, cacheWrite, output, reasoning },
+      model: providerID && modelID ? { providerID, modelID } : null
+    })
+  }
+
+  /**
+   * P0 (OpenCode parity): emit `session.compaction_started` when the SDK sends
+   * a `message.part.updated` event whose part is a `compaction` marker.
+   */
+  private maybeEmitCompactionStarted(
+    hiveSessionId: string,
+    event: { properties?: Record<string, unknown> }
+  ): void {
+    const part = asRecord(event.properties?.part)
+    if (!part || part.type !== 'compaction') return
+
+    emitAgentEvent(this.mainWindow, {
+      type: 'session.compaction_started',
+      sessionId: hiveSessionId,
+      data: {
+        ...(typeof part.auto === 'boolean' ? { auto: part.auto } : {})
+      }
+    })
+    opencodeDumper?.recordMarker(dumpSessionKey(undefined, hiveSessionId), {
+      type: 'session.compaction_started',
+      auto: typeof part.auto === 'boolean' ? part.auto : null
+    })
+  }
+
+  private trackPendingRequest(
+    hiveSessionId: string,
+    eventType: string,
+    properties?: Record<string, unknown>
+  ): void {
+    const props = asRecord(properties) ?? {}
+    const requestId =
+      asString(props.requestId) ??
+      asString(props.permissionID) ??
+      asString(props.id) ??
+      asString(props.questionID)
+    if (!requestId) return
+
+    if (eventType === 'question.asked') {
+      this.pendingQuestions.set(requestId, hiveSessionId)
+      return
+    }
+
+    if (eventType === 'permission.asked' || eventType === 'command.approval_needed') {
+      this.pendingApprovals.set(requestId, hiveSessionId)
+    }
+  }
+
+  private clearPendingRequestsForSession(hiveSessionId: string): void {
+    for (const [requestId, owner] of this.pendingQuestions.entries()) {
+      if (owner === hiveSessionId) this.pendingQuestions.delete(requestId)
+    }
+    for (const [requestId, owner] of this.pendingApprovals.entries()) {
+      if (owner === hiveSessionId) this.pendingApprovals.delete(requestId)
+    }
+  }
+
+  private async flushAbortDraft(
+    worktreePath: string,
+    opencodeSessionId: string,
+    hiveSessionId: string
+  ): Promise<void> {
+    if (!this.instance) return
+
+    let latestAssistant: Record<string, unknown> | null = null
+
+    try {
+      const result = await this.instance.client.session.messages({
+        path: { id: opencodeSessionId },
+        query: { directory: worktreePath }
+      })
+      const messages = Array.isArray(result.data) ? result.data : []
+
+      for (const message of messages) {
+        const info = messageInfo(message)
+        if (info.role === 'assistant') {
+          latestAssistant = message as Record<string, unknown>
+        }
+      }
+
+      if (latestAssistant) {
+        // Phase 1.4.8 (parity with Claude Code's markRunningToolsAborted):
+        // walk the latest assistant message's parts and synthesize a
+        // `message.part.updated` for any tool that's still 'running' /
+        // 'pending'. The SDK's own `state.status: completed` may arrive
+        // moments later (or never, on hard aborts), but the renderer's
+        // streaming buffer needs an immediate transition so the tool card
+        // flips out of "Running..." right when the user clicks Stop.
+        const parts = (latestAssistant as { parts?: unknown }).parts
+        if (Array.isArray(parts)) {
+          const now = Date.now()
+          for (const rawPart of parts) {
+            if (!rawPart || typeof rawPart !== 'object') continue
+            const part = rawPart as Record<string, unknown>
+            if (part.type !== 'tool') continue
+            const state = (part.state as Record<string, unknown> | undefined) ?? {}
+            const status = state.status as string | undefined
+            if (status !== 'running' && status !== 'pending') continue
+
+            const stateTime =
+              (state.time as Record<string, unknown> | undefined) ?? {}
+            const abortedState: Record<string, unknown> = {
+              ...state,
+              status: 'error',
+              error:
+                typeof state.error === 'string' && state.error
+                  ? state.error
+                  : 'Aborted by user',
+              time: {
+                ...stateTime,
+                end: typeof stateTime.end === 'number' ? stateTime.end : now
+              }
+            }
+            const abortedPart: Record<string, unknown> = {
+              ...part,
+              state: abortedState
+            }
+            // Mutate the latestAssistant snapshot so the message.updated
+            // emit + persistence below sees the aborted status too.
+            ;(part as Record<string, unknown>).state = abortedState
+
+            const partEvent: Record<string, unknown> = {
+              sessionID: opencodeSessionId,
+              part: abortedPart
+            }
+            // canonicalizeToolPart expects the same shape as live SDK events
+            // (event.data.part). Run it so the event we synthesise carries
+            // the canonical tool name / metadata.
+            this.canonicalizeToolPart(partEvent)
+            emitAgentEvent(this.mainWindow, {
+              type: 'message.part.updated',
+              sessionId: hiveSessionId,
+              data: partEvent
+            })
+            opencodeDumper?.recordMarker(
+              dumpSessionKey(worktreePath, opencodeSessionId),
+              {
+                type: 'abort.flush.tool_aborted',
+                hiveSessionId,
+                callID: typeof part.callID === 'string' ? part.callID : null,
+                tool: typeof part.tool === 'string' ? part.tool : null
+              }
+            )
+          }
+        }
+
+        emitAgentEvent(this.mainWindow, {
+          type: 'message.updated',
+          sessionId: hiveSessionId,
+          data: latestAssistant
+        })
+        opencodeDumper?.recordMarker(dumpSessionKey(worktreePath, opencodeSessionId), {
+          type: 'abort.flush.latest_assistant',
+          hiveSessionId,
+          message: latestAssistant
+        })
+      }
+    } catch (error) {
+      log.debug('OpenCode abort draft flush: unable to read latest messages', {
+        worktreePath,
+        opencodeSessionId,
+        error
+      })
+    }
+
+    emitAgentEvent(this.mainWindow, {
+      type: 'session.status',
+      sessionId: hiveSessionId,
+      data: { status: { type: 'idle' } },
+      statusPayload: { type: 'idle' }
+    })
+    opencodeDumper?.recordMarker(dumpSessionKey(worktreePath, opencodeSessionId), {
+      type: 'abort.flush.force_idle',
+      hiveSessionId
+    })
+
+    // Phase 1.4.7: top up SQLite once the abort flush settles. The live
+    // subscription may have lost the very last `message.updated` if abort
+    // races with completion, so this hydrate guarantees the persisted row
+    // matches what the user sees post-abort.
+    void this.hydrateOpenCodeMessagesFromServer(
+      hiveSessionId,
+      worktreePath,
+      opencodeSessionId
+    ).catch(() => {})
+  }
+
+  /**
    * Phase 1.4.5 (OpenCode parity): persist a SessionActivity record for the
    * given OpenCode event so the history pane can replay the turn (parity with
    * Codex which goes through `mapCodexManagerEventToActivity`).
@@ -1708,6 +2199,57 @@ class OpenCodeService implements AgentSdkImplementer, AgentRuntimeAdapter {
   }
 
   /**
+   * Phase 1.4.7: dispatch a `message.*` SDK event into the persistence buffer.
+   *
+   * - `message.updated`            → merge info, then flush row.
+   * - `message.part.updated`       → merge part into the buffer; flush is
+   *                                  deferred to the next `message.updated`
+   *                                  to avoid write amplification.
+   * - `message.removed`            → drop both buffer entry and SQLite row.
+   *
+   * `event.properties` is the SDK's payload shape from the iterator.
+   */
+  private persistOpenCodeMessageEvent(
+    hiveSessionId: string,
+    eventType: string | undefined,
+    event: { properties?: Record<string, unknown> }
+  ): void {
+    if (!eventType) return
+    const properties = asRecord(event.properties)
+    if (!properties) return
+
+    if (eventType === 'message.updated') {
+      const info = asRecord(properties.info)
+      if (!info) return
+      const merged = this.mergeMessageInfoIntoBuffer(hiveSessionId, info)
+      if (!merged) return
+      this.persistOpenCodeMessageRow(hiveSessionId, merged.messageId)
+      // Phase 1.4.8 (OpenCode plan parity): if this is a plan-agent turn that
+      // just finished, synthesize a `plan.ready` event for the renderer.
+      // Persist first so the plan markdown is in SQLite by the time the user
+      // accepts/rejects (same ordering Codex uses).
+      this.maybeEmitPlanReady(hiveSessionId, info)
+      return
+    }
+
+    if (eventType === 'message.part.updated') {
+      const part = asRecord(properties.part)
+      if (!part) return
+      this.mergeMessagePartIntoBuffer(hiveSessionId, part)
+      return
+    }
+
+    if (eventType === 'message.removed') {
+      const messageId =
+        asString(properties.messageID) ??
+        asString(asRecord(properties.info)?.id)
+      if (!messageId) return
+      this.removeOpenCodeMessage(hiveSessionId, messageId)
+    }
+  }
+
+  // ─── Phase 1.4.5 OpenCode parity (existing helpers below) ────────────────
+  /**
    * Phase 1.4.5 (OpenCode parity): rewrite a `message.part.updated` payload
    * in place so any tool part carries a CanonicalToolName.
    *
@@ -1738,7 +2280,385 @@ class OpenCodeService implements AgentSdkImplementer, AgentRuntimeAdapter {
     if (classified.mcpServer && !part.mcpServer) {
       part.mcpServer = classified.mcpServer
     }
+
+    // Phase 1.4.8 (OpenCode parity): OpenCode's Edit/Write tools only surface
+    // the unified diff on `state.metadata.diff` / `state.metadata.filediff`,
+    // while Claude/Codex expose it directly on the tool input. The renderer's
+    // FileWriteCard already accepts `input.diff` / `input.additions` /
+    // `input.deletions`, so lifting the diff onto the input here lets the
+    // same card render OpenCode Edit cards with file path + inline diff,
+    // matching the Claude Code / Codex experience.
+    const state = asRecord(part.state)
+    if (!state) return
+    const input = asRecord(state.input)
+    if (!input) return
+    const metadata = asRecord(state.metadata)
+    if (!metadata) return
+
+    const filediff = asRecord(metadata.filediff)
+    const unifiedDiff =
+      asString(metadata.diff) ?? asString(filediff?.patch) ?? null
+    if (unifiedDiff && !asString(input.diff)) {
+      input.diff = unifiedDiff
+    }
+    const additions = asNumber(filediff?.additions)
+    if (additions !== undefined && asNumber(input.additions) === undefined) {
+      input.additions = additions
+    }
+    const deletions = asNumber(filediff?.deletions)
+    if (deletions !== undefined && asNumber(input.deletions) === undefined) {
+      input.deletions = deletions
+    }
   }
+
+  // ─── Phase 1.4.7 OpenCode persistence parity ─────────────────────────────
+  //
+  // Codex / Claude Code already shadow every assistant + user turn into the
+  // `session_messages` SQLite table so the timeline survives runtime restarts,
+  // works offline, drives usage analytics, and lets the Hub surface the same
+  // history. OpenCode used to lean on the SDK server-side transcript for that,
+  // which left the new UI staring at an empty pane until the runtime
+  // reconnected. The helpers below mirror Codex's persistence model: we keep
+  // an in-memory buffer of `messageId → { info, parts }`, fold every
+  // `message.updated` / `message.part.updated` into it, and on each
+  // `message.updated` flush the merged shape into `session_messages` via
+  // `upsertSessionMessageByOpenCodeId`.
+
+  private getMessageBuffer(hiveSessionId: string, messageId: string): OpenCodeMessageBuffer {
+    const instance = this.instance
+    if (!instance) {
+      // Caller already guarded; this only protects against late-fire from
+      // disposed listeners.
+      return { info: null, parts: new Map(), partOrder: [], role: null, createdAt: null }
+    }
+    let perSession = instance.messageBuffersByHiveSession.get(hiveSessionId)
+    if (!perSession) {
+      perSession = new Map()
+      instance.messageBuffersByHiveSession.set(hiveSessionId, perSession)
+    }
+    let buffer = perSession.get(messageId)
+    if (!buffer) {
+      buffer = { info: null, parts: new Map(), partOrder: [], role: null, createdAt: null }
+      perSession.set(messageId, buffer)
+    }
+    return buffer
+  }
+
+  private mergeMessageInfoIntoBuffer(
+    hiveSessionId: string,
+    info: Record<string, unknown>
+  ): { messageId: string; role: string; completed: boolean } | null {
+    const messageId = asString(info.id)
+    if (!messageId) return null
+    const role = asString(info.role) ?? null
+    if (role !== 'user' && role !== 'assistant' && role !== 'system') return null
+
+    const buffer = this.getMessageBuffer(hiveSessionId, messageId)
+    buffer.info = info
+    buffer.role = role
+    const time = asRecord(info.time)
+    const createdMs = asNumber(time?.created)
+    if (createdMs && !buffer.createdAt) {
+      buffer.createdAt = new Date(createdMs).toISOString()
+    }
+    const completedMs = asNumber(time?.completed)
+    return { messageId, role, completed: completedMs !== undefined }
+  }
+
+  private mergeMessagePartIntoBuffer(
+    hiveSessionId: string,
+    part: Record<string, unknown>
+  ): { messageId: string; partId: string } | null {
+    const messageId = asString(part.messageID)
+    const partId = asString(part.id)
+    if (!messageId || !partId) return null
+
+    const buffer = this.getMessageBuffer(hiveSessionId, messageId)
+    if (!buffer.parts.has(partId)) {
+      buffer.partOrder.push(partId)
+    }
+    buffer.parts.set(partId, part)
+    return { messageId, partId }
+  }
+
+  private removeOpenCodeMessage(hiveSessionId: string, messageId: string): void {
+    const instance = this.instance
+    if (!instance) return
+    const perSession = instance.messageBuffersByHiveSession.get(hiveSessionId)
+    perSession?.delete(messageId)
+    try {
+      const db = getDatabase()
+      const existing = db.getSessionMessageByOpenCodeId(hiveSessionId, messageId)
+      if (existing) db.deleteSessionMessage(existing.id)
+    } catch (error) {
+      log.warn('Failed to delete persisted OpenCode message', {
+        hiveSessionId,
+        messageId,
+        error: error instanceof Error ? error.message : String(error)
+      })
+    }
+  }
+
+  private buildPersistedRowFromBuffer(
+    hiveSessionId: string,
+    messageId: string,
+    buffer: OpenCodeMessageBuffer
+  ): {
+    rawContent: string
+    persistedContent: string
+    partsJson: unknown[]
+    role: string
+    createdAt: string
+    messageJson: unknown
+  } | null {
+    const role = buffer.role
+    if (role !== 'user' && role !== 'assistant' && role !== 'system') return null
+
+    const partsJson = buffer.partOrder
+      .map((id) => buffer.parts.get(id))
+      .filter((part): part is Record<string, unknown> => Boolean(part))
+
+    const rawContent = partsJson
+      .map((part) => {
+        if (part.type === 'text') return asString(part.text) ?? ''
+        if (part.type === 'reasoning') return asString(part.text) ?? ''
+        return ''
+      })
+      .join('')
+
+    const persistedContent =
+      role === 'user' ? stripInjectedContextEnvelope(rawContent) : rawContent
+
+    return {
+      rawContent,
+      persistedContent,
+      partsJson,
+      role,
+      createdAt: buffer.createdAt ?? new Date().toISOString(),
+      messageJson: { info: buffer.info ?? {}, parts: partsJson },
+    }
+  }
+
+  private persistOpenCodeMessageRow(hiveSessionId: string, messageId: string): void {
+    const instance = this.instance
+    if (!instance) return
+    const perSession = instance.messageBuffersByHiveSession.get(hiveSessionId)
+    const buffer = perSession?.get(messageId)
+    if (!buffer) return
+    if (!buffer.info && buffer.parts.size === 0) return
+
+    const built = this.buildPersistedRowFromBuffer(hiveSessionId, messageId, buffer)
+    if (!built) return
+
+    try {
+      const db = getDatabase()
+      db.upsertSessionMessageByOpenCodeId({
+        session_id: hiveSessionId,
+        role: built.role,
+        content: built.persistedContent,
+        opencode_message_id: messageId,
+        opencode_message_json: JSON.stringify(built.messageJson),
+        opencode_parts_json: JSON.stringify(built.partsJson),
+        created_at: built.createdAt
+      })
+    } catch (error) {
+      log.warn('Failed to persist OpenCode message', {
+        hiveSessionId,
+        messageId,
+        error: error instanceof Error ? error.message : String(error)
+      })
+    }
+  }
+
+  /**
+   * Phase 1.4.8 (OpenCode plan parity): when a plan-mode assistant turn
+   * finishes, synthesize a `plan.ready` event so the renderer's
+   * `useAgentEventBridge` arms its pendingPlan slot and the plan FAB / card
+   * appear (parity with Codex's plan-mode flow in
+   * `codex-implementer.ts:983-1015`).
+   *
+   * Detection signal (verified against the 2026-05-02T02:09 plan-mode dump):
+   *   - `info.role === 'assistant'`
+   *   - `info.agent === 'plan'`           (the plan agent is active)
+   *   - `info.finish === 'stop'`          (the model emitted a stop, not tool-calls)
+   *   - `info.time.completed != null`     (turn ended cleanly, not still streaming)
+   *   - `info.error == null`              (skip aborted / errored turns)
+   *
+   * Emitted exactly once per messageId via `planEmittedByHiveSession`. The
+   * plan content is the concatenated text of the buffered assistant parts
+   * (same source the SQLite row is built from), so any mid-turn
+   * `<proposed_plan>` block — or a free-form markdown plan — flows through.
+   *
+   * `requestId` is `opencode-plan:<hiveSessionId>:<messageId>` — stable for
+   * the same plan, distinct across plans. Renderer keeps `requestId` as the
+   * key for pendingPlan / approvals / interrupt-queue, so this lets multiple
+   * plans coexist if the user keeps asking for revisions.
+   */
+  private maybeEmitPlanReady(
+    hiveSessionId: string,
+    info: Record<string, unknown>
+  ): void {
+    const instance = this.instance
+    if (!instance) return
+
+    if (asString(info.role) !== 'assistant') return
+    if (asString(info.agent) !== 'plan') return
+    if (asString(info.finish) !== 'stop') return
+    const time = asRecord(info.time)
+    if (!time || !asNumber(time.completed)) return
+    if (asRecord(info.error)) return
+
+    const messageId = asString(info.id)
+    if (!messageId) return
+
+    let emitted = instance.planEmittedByHiveSession.get(hiveSessionId)
+    if (!emitted) {
+      emitted = new Set<string>()
+      instance.planEmittedByHiveSession.set(hiveSessionId, emitted)
+    }
+    if (emitted.has(messageId)) return
+
+    const perSession = instance.messageBuffersByHiveSession.get(hiveSessionId)
+    const buffer = perSession?.get(messageId)
+    if (!buffer) return
+
+    // Pull the plan markdown from the buffered text parts. Same source the
+    // SQLite row uses, so what users approve is what they read.
+    const planText = buffer.partOrder
+      .map((id) => buffer.parts.get(id))
+      .filter((part): part is Record<string, unknown> => Boolean(part))
+      .map((part) => (part.type === 'text' ? asString(part.text) ?? '' : ''))
+      .join('')
+      .trim()
+    if (!planText) return
+
+    emitted.add(messageId)
+
+    const requestId = `opencode-plan:${hiveSessionId}:${messageId}`
+    const opencodeSessionId = asString(info.sessionID) ?? null
+
+    // Phase 1.4.8: persist `plan.ready` SessionActivity *before* the live
+    // event fires. PlanCard rendering in the durable timeline goes through
+    // `parsePlanPartFromActivity` (timeline-mappers.ts:722), which only
+    // recognizes activity rows with kind === 'plan.ready'. Without this row,
+    // the FAB pops up (via the live event → useAgentEventBridge) but no card
+    // appears in the message stream, and a later refresh / restart loses the
+    // plan entirely. Codex does the same in `persistSyntheticActivity`
+    // (codex-implementer.ts:996-1005).
+    try {
+      const db = getDatabase()
+      db.upsertSessionActivity({
+        id: requestId,
+        session_id: hiveSessionId,
+        agent_session_id: opencodeSessionId,
+        thread_id: opencodeSessionId,
+        turn_id: null,
+        item_id: messageId,
+        request_id: requestId,
+        kind: 'plan.ready',
+        tone: 'info',
+        summary: 'Plan ready',
+        payload_json: JSON.stringify({
+          plan: planText,
+          toolUseID: messageId,
+          requestId
+        })
+      })
+    } catch (err) {
+      log.warn('Failed to persist OpenCode plan.ready activity', {
+        hiveSessionId,
+        messageId,
+        error: err instanceof Error ? err.message : String(err)
+      })
+    }
+
+    emitAgentEvent(this.mainWindow, {
+      type: 'plan.ready',
+      sessionId: hiveSessionId,
+      data: {
+        id: requestId,
+        requestId,
+        plan: planText,
+        toolUseID: messageId
+      }
+    })
+    opencodeDumper?.recordMarker(undefined, {
+      type: 'plan.ready.synth',
+      hiveSessionId,
+      messageId,
+      requestId,
+      planLength: planText.length
+    })
+    log.info('OpenCode plan.ready synthesized from plan-mode turn', {
+      hiveSessionId,
+      messageId,
+      requestId,
+      planLength: planText.length
+    })
+  }
+
+  /**
+   * Phase 1.4.7: hydrate `session_messages` from the OpenCode server-side
+   * transcript. Used right after `connect` / `reconnect` / `abort` so SQLite
+   * picks up any messages we missed (e.g. before the live event subscription
+   * was active). Best-effort; logs and swallows errors.
+   */
+  private async hydrateOpenCodeMessagesFromServer(
+    hiveSessionId: string,
+    worktreePath: string,
+    opencodeSessionId: string
+  ): Promise<void> {
+    const instance = this.instance
+    if (!instance) return
+
+    let messages: unknown[] = []
+    try {
+      const result = await instance.client.session.messages({
+        path: { id: opencodeSessionId },
+        query: { directory: worktreePath }
+      })
+      messages = Array.isArray(result.data) ? result.data : []
+    } catch (error) {
+      log.debug('hydrateOpenCodeMessagesFromServer: messages fetch failed', {
+        hiveSessionId,
+        opencodeSessionId,
+        error: error instanceof Error ? error.message : String(error)
+      })
+      return
+    }
+
+    let persisted = 0
+    for (const message of messages) {
+      const record = asRecord(message)
+      const info = asRecord(record?.info)
+      if (!info) continue
+      const merged = this.mergeMessageInfoIntoBuffer(hiveSessionId, info)
+      if (!merged) continue
+      const parts = Array.isArray(record?.parts) ? record.parts : []
+      for (const part of parts) {
+        const partRecord = asRecord(part)
+        if (!partRecord) continue
+        // Make sure the part carries the message id so the buffer keying works
+        // even if the SDK drops it on history fetches.
+        const partWithMessage =
+          asString(partRecord.messageID) === merged.messageId
+            ? partRecord
+            : { ...partRecord, messageID: merged.messageId }
+        this.mergeMessagePartIntoBuffer(hiveSessionId, partWithMessage)
+      }
+      this.persistOpenCodeMessageRow(hiveSessionId, merged.messageId)
+      persisted += 1
+    }
+
+    if (persisted > 0) {
+      log.info('Hydrated OpenCode messages into SQLite', {
+        hiveSessionId,
+        opencodeSessionId,
+        persisted
+      })
+    }
+  }
+
 
   /**
    * Phase 21.5: emit an agent.* field event when an OpenCode tool part

--- a/src/main/services/opencode-session-title.ts
+++ b/src/main/services/opencode-session-title.ts
@@ -1,0 +1,77 @@
+/**
+ * OpenCode session title generation — mirrors the Codex 1.4.4 pattern of
+ * generating a concise, human-meaningful conversation title from the first
+ * user message.
+ *
+ * **Engine**: delegates to `generateCodexSessionTitle` (GPT-5.4 via the local
+ * Codex CLI). The engine is runtime-agnostic — Codex just happens to be the
+ * fastest path to a title model already wired up. The opencode-namespaced
+ * wrapper exists so call sites in `opencode-service.ts` read clearly, and so
+ * we can swap to OpenCode's own `session.summarize` endpoint (or another
+ * provider) later without touching the caller.
+ *
+ * **Why we need this on OpenCode**: OpenCode's server eventually emits a
+ * `session.updated` event with a title, but the wait can be long and the
+ * intermediate title is often a placeholder ("New Session 2026-..."). This
+ * helper provides an immediate fast-path so the user sees a meaningful name
+ * within seconds of sending the first prompt.
+ *
+ * **Race vs server title**: the caller is responsible for only applying the
+ * generated title when the current DB title is still a placeholder. The
+ * existing `session.updated` handler in `opencode-service.ts` (which detects
+ * placeholders via `/^Session \d+$/i` and `/^New session.../i`) will pick up
+ * any later, better title from OpenCode itself.
+ */
+
+export async function generateOpenCodeSessionTitle(
+  message: string,
+  worktreePath?: string
+): Promise<string | null> {
+  // Lazy-load the Codex title generator so this module's pure helpers
+  // (`isPlaceholderSessionTitle`, `extractTitleSourceText`) can be imported
+  // and unit-tested without dragging in the Codex CLI / logger / Electron
+  // dependency chain.
+  const { generateCodexSessionTitle } = await import('./codex-session-title')
+  return generateCodexSessionTitle(message, worktreePath)
+}
+
+/**
+ * Detect placeholder titles that should be overwritten by a generated title.
+ *
+ * Matches:
+ *   - "Session 1", "Session 42" — Hive default naming
+ *   - "New Session 2026-04-29T..." — OpenCode default naming
+ *   - empty / null
+ *
+ * Mirrors the regex used in `opencode-service.ts` `session.updated` handler
+ * so both code paths agree on what counts as a placeholder.
+ */
+export function isPlaceholderSessionTitle(title: string | null | undefined): boolean {
+  if (!title) return true
+  const trimmed = title.trim()
+  if (trimmed.length === 0) return true
+  if (/^Session \d+$/i.test(trimmed)) return true
+  if (/^New session\s*-?\s*\d{4}-\d{2}-\d{2}/i.test(trimmed)) return true
+  return false
+}
+
+/**
+ * Extract a user-message text suitable for title generation from a string or
+ * a parts array (text + file). Files are skipped; text parts are concatenated
+ * with single spaces.
+ */
+export function extractTitleSourceText(
+  messageOrParts:
+    | string
+    | Array<
+        | { type: 'text'; text: string }
+        | { type: 'file'; mime: string; url: string; filename?: string }
+      >
+): string {
+  if (typeof messageOrParts === 'string') return messageOrParts.trim()
+  return messageOrParts
+    .filter((part): part is { type: 'text'; text: string } => part.type === 'text')
+    .map((part) => part.text)
+    .join(' ')
+    .trim()
+}

--- a/src/main/services/session-timeline-service.ts
+++ b/src/main/services/session-timeline-service.ts
@@ -17,7 +17,8 @@ import type { TimelineResult, TimelineMessage } from '../../shared/lib/timeline-
 import {
   mapDbRowsToTimelineMessages,
   mapRawTranscriptToTimeline,
-  deriveCodexTimeline
+  deriveCodexTimeline,
+  mergeOpenCodePlanActivities
 } from '../../shared/lib/timeline-mappers'
 import type { DbSessionMessage, DbSessionActivity } from '../../shared/lib/timeline-mappers'
 import type { SessionMessage, SessionActivity, Session } from '../db/types'
@@ -154,6 +155,22 @@ export function getSessionTimeline(sessionId: string): TimelineResult {
         // Fallback: build timeline from individual DB rows (less rich,
         // but handles cases where timeline JSON wasn't persisted).
         messages = mapDbRowsToTimelineMessages(messageRows.map(toDbSessionMessage))
+      }
+      // Phase 1.4.8 (OpenCode plan parity): plan-mode turns produce plan
+      // markdown as a regular `text` part — the only way to render a
+      // PlanCard in the durable timeline is by attaching ExitPlanMode tool
+      // parts derived from `plan.ready` activities. Merge them in here so
+      // the card appears alongside the assistant text. (Same mechanism the
+      // codex branch above relies on, but scoped to plan rows only so we
+      // don't disturb OpenCode's own tool-part stream.)
+      if (session.agent_sdk === 'opencode') {
+        const activityRows = db.getSessionActivities(sessionId)
+        if (Array.isArray(activityRows) && activityRows.length > 0) {
+          messages = mergeOpenCodePlanActivities(
+            messages,
+            activityRows.map(toDbSessionActivity)
+          )
+        }
       }
       break
     }

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -562,7 +562,7 @@ declare global {
         sessionId: string,
         messageOrParts: string | MessagePart[],
         model?: { providerID: string; modelID: string; variant?: string },
-        options?: { codexFastMode?: boolean }
+        options?: { codexFastMode?: boolean; mode?: 'build' | 'plan' }
       ) => Promise<import('../shared/types/agent-ipc').AgentIpcResult>
       // Abort a streaming session
       abort: (

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1178,7 +1178,7 @@ const agentOps = {
           | { type: 'file'; mime: string; url: string; filename?: string }
         >,
     model?: { providerID: string; modelID: string; variant?: string },
-    options?: { codexFastMode?: boolean }
+    options?: { codexFastMode?: boolean; mode?: 'build' | 'plan' }
   ): Promise<{ success: boolean; error?: string }> => {
     const parts =
       typeof messageOrParts === 'string'

--- a/src/renderer/src/components/session-hq/SessionShell.tsx
+++ b/src/renderer/src/components/session-hq/SessionShell.tsx
@@ -67,6 +67,7 @@ import {
   extractModelUsage
 } from '@/lib/token-utils'
 import { applySessionContextUsage } from '@/lib/context-usage'
+import { mapRawTranscriptToTimeline } from '@shared/lib/timeline-mappers'
 import { lastSendMode, messageSendTimes } from '@/lib/message-send-times'
 import {
   getMessageDisplayContent,
@@ -111,7 +112,14 @@ function extractMissionTasks(messages: TimelineMessage[]): MissionTask[] {
 // useTimeline hook — fetches durable timeline from main process
 // ---------------------------------------------------------------------------
 
-function useTimeline(sessionId: string) {
+function useTimeline(
+  sessionId: string,
+  options?: {
+    worktreePath?: string | null
+    opencodeSessionId?: string | null
+    agentSdk?: string | null
+  }
+) {
   // Restore optimistic messages from buffer on mount so they survive tab switches
   const initBuffer = getStreamingBuffer(sessionId)
   const [messages, setMessages] = useState<TimelineMessage[]>(
@@ -135,18 +143,59 @@ function useTimeline(sessionId: string) {
     }
     try {
       const result = await window.agentOps.getTimeline(sessionId)
+      let durableMessages = result.messages
+
+      const hasRenderableAssistant = durableMessages.some(
+        (msg) =>
+          msg.role === 'assistant' &&
+          ((typeof msg.content === 'string' && msg.content.trim().length > 0) ||
+            (Array.isArray(msg.parts) && msg.parts.length > 0))
+      )
+
+      const canFallbackToSdkMessages =
+        Boolean(window.agentOps?.getMessages) &&
+        typeof options?.worktreePath === 'string' &&
+        options.worktreePath.length > 0 &&
+        typeof options?.opencodeSessionId === 'string' &&
+        options.opencodeSessionId.length > 0 &&
+        options.agentSdk !== 'codex' &&
+        options.agentSdk !== 'terminal'
+
+      if (!hasRenderableAssistant && canFallbackToSdkMessages) {
+        try {
+          const transcript = await window.agentOps.getMessages(
+            options!.worktreePath!,
+            options!.opencodeSessionId!
+          )
+          if (transcript.success && Array.isArray(transcript.messages) && transcript.messages.length > 0) {
+            const fallbackMessages = mapRawTranscriptToTimeline(transcript.messages)
+            const fallbackHasAssistant = fallbackMessages.some(
+              (msg) =>
+                msg.role === 'assistant' &&
+                ((typeof msg.content === 'string' && msg.content.trim().length > 0) ||
+                  (Array.isArray(msg.parts) && msg.parts.length > 0))
+            )
+            if (fallbackHasAssistant) {
+              durableMessages = fallbackMessages
+            }
+          }
+        } catch (err) {
+          console.warn('[SessionShell] getMessages fallback failed:', err)
+        }
+      }
+
       // Restore cached attachments onto refreshed messages
       const cache = attachmentCacheRef.current
       const restored =
         cache.size > 0
-          ? result.messages.map((msg) => {
+          ? durableMessages.map((msg) => {
               if (msg.role === 'user' && !msg.attachments) {
                 const stored = cache.get(msg.content.trim())
                 if (stored) return { ...msg, attachments: stored }
               }
               return msg
             })
-          : result.messages
+          : durableMessages
 
       // Merge back optimistic messages not yet present in DB results.
       // Match by content — once the DB contains a user message with the same
@@ -175,7 +224,7 @@ function useTimeline(sessionId: string) {
     } finally {
       setLoading(false)
     }
-  }, [sessionId])
+  }, [sessionId, options?.worktreePath, options?.opencodeSessionId, options?.agentSdk])
 
   useEffect(() => {
     setLoading(true)
@@ -284,6 +333,15 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
   }, [worktreePathFromStore, connectionId])
 
   const worktreePath = resolvedPath
+  const opcSessionId = sessionRecord?.opencode_session_id ?? null
+  const agentSdk = sessionRecord?.agent_sdk ?? null
+
+  // We need droidSessionId before useTimeline so that, after connect/reconnect,
+  // the SDK transcript fallback can hydrate prior history even when the
+  // session record's opencode_session_id is still null on first mount.
+  const [droidSessionId, setDroidSessionId] = useState<string | null>(
+    sessionRecord?.opencode_session_id ?? null
+  )
 
   const {
     messages: timelineMessages,
@@ -292,12 +350,18 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
     refresh,
     appendOptimistic,
     optimisticRef
-  } = useTimeline(sessionId)
+  } = useTimeline(sessionId, {
+    worktreePath,
+    // After connect/reconnect we know the live OpenCode session id even if
+    // sessionRecord.opencode_session_id is still null on first mount, so
+    // fall back to droidSessionId so the SDK transcript fallback path can
+    // hydrate prior history before the first turn finishes.
+    opencodeSessionId: opcSessionId ?? droidSessionId,
+    agentSdk
+  })
   const { lifecycle, interruptQueue, pendingCount } = useSessionRuntime(sessionId)
 
   // --- Connect or reconnect to agent runtime on mount ---
-  const opcSessionId = sessionRecord?.opencode_session_id ?? null
-  const agentSdk = sessionRecord?.agent_sdk ?? null
 
   // --- Plan mode ---
   const mode = useSessionStore((s) => s.modeBySession?.get(sessionId) ?? 'build')
@@ -415,6 +479,15 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
 
     return resolvedModel ?? undefined
   }, [resolvedModel, sessionRecord?.model_provider_id, sessionRecord?.model_id])
+  // Phase 1.4.8: OpenCode's plan agent only activates when the prompt body
+  // carries `agent: 'plan'`, which opencode-service.prompt() derives from
+  // PromptOptions.mode. Build the options object here so every send path
+  // (first prompt / queued drain / follow-up / proposed-plan implement)
+  // consistently passes the live session mode.
+  const promptOptions = useMemo(
+    () => (agentSdk === 'opencode' ? { mode } : undefined),
+    [agentSdk, mode]
+  )
   const currentModelId = resolvedModel?.modelID ?? ''
   const currentProviderId = resolvedModel?.providerID ?? ''
   const skipForkFromMessageConfirm = useSettingsStore((s) => s.skipForkFromMessageConfirm)
@@ -428,9 +501,6 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
   const streamingParts = streamingMirror.parts
   const mirrorVersion = streamingMirror.mirrorVersion
   const childPartsMap = streamingMirror.childParts
-  const [droidSessionId, setDroidSessionId] = useState<string | null>(
-    sessionRecord?.opencode_session_id ?? null
-  )
   const timelineBottomAreaRef = useRef<HTMLDivElement>(null)
   const composerBarRef = useRef<HTMLDivElement>(null)
 
@@ -869,7 +939,7 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
                   if (message.attachments.length > 0) {
                     messageParts = await buildMessageParts(message.attachments as Attachment[], message.content)
                   }
-                  return window.agentOps.prompt(wp, sid, messageParts ?? message.content, requestModel)
+                  return window.agentOps.prompt(wp, sid, messageParts ?? message.content, requestModel, promptOptions)
                 },
                 worktreePath,
                 (sid, message) => useSessionRuntimeStore.getState().requeueMessageFront(sid, message)
@@ -952,6 +1022,7 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
     optimisticRef,
     currentProviderId,
     requestModel,
+    promptOptions,
     refreshUsageSummary
   ])
 
@@ -961,10 +1032,30 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
       if (!worktreePath || !droidSessionId) return false
       let optimisticMessageId: string | null = null
 
-      // Pure stop (no content) — just abort, don't clear anything
+      // Pure stop (no content) — abort, then optimistically clear the live
+      // overlay so the streaming tool / text cards disappear immediately. The
+      // committed transcript (durable timeline messages) remains. Without
+      // this, the in-flight tool card stayed visible until the next prompt,
+      // which made the user think the Stop button "didn't work" and click it
+      // 2-3 more times. Backend aborts were going through; only the optics
+      // were wrong. (See OpenCode plan-mode dump 2026-05-01T09:59 — three
+      // abort.accepted markers within ~6 s for the same idle session.)
       if (action === 'stop_and_send' && !content.trim()) {
         try {
-          await window.agentOps.abort(worktreePath, droidSessionId)
+          const result = await window.agentOps.abort(worktreePath, droidSessionId)
+          if (result.success && result.aborted !== false) {
+            resetLiveOverlay(false)
+            // Phase 1.4.8: optimistically flip lifecycle to 'idle' so the
+            // ComposerBar Stop button (red square) flips back to Send (blue
+            // arrow) immediately. Backend will eventually emit
+            // `session.status idle` via flushAbortDraft, but on slow networks
+            // or when SSE reconnects mid-abort the event can lag by seconds —
+            // long enough that users keep clicking Stop thinking it failed.
+            // Safe because the worst case (abort actually didn't take) is
+            // self-correcting: the next backend `busy` event would put us
+            // back into busy state.
+            useSessionRuntimeStore.getState().setLifecycle(sessionId, 'idle')
+          }
         } catch (err) {
           console.error('[SessionShell] abort failed:', err)
         }
@@ -1011,7 +1102,7 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
             if (attachments.length > 0) {
               messageParts = await buildMessageParts(attachments, c)
             }
-            return window.agentOps.prompt(wp, sid, messageParts ?? c, requestModel)
+            return window.agentOps.prompt(wp, sid, messageParts ?? c, requestModel, promptOptions)
           },
           steer: (wp, sid, c) => window.agentOps.steer(wp, sid, c, requestModel),
           abort: (wp, sid) => window.agentOps.abort(wp, sid),
@@ -1045,6 +1136,7 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
       appendOptimistic,
       optimisticRef,
       requestModel,
+      promptOptions,
       resetLiveOverlay,
       setMessages,
       syncOptimisticMessagesToMirror
@@ -1108,7 +1200,7 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
         const consumed = await executeSendAction('send', contentToSend, [], {
           worktreePath,
           sessionId: droidSessionId,
-          prompt: (wp, sid, content) => window.agentOps.prompt(wp, sid, content, requestModel),
+          prompt: (wp, sid, content) => window.agentOps.prompt(wp, sid, content, requestModel, promptOptions),
           abort: (wp, sid) => window.agentOps.abort(wp, sid),
           queueMessage: (sid, msg) => useSessionRuntimeStore.getState().queueMessage(sid, msg)
         })
@@ -1130,6 +1222,7 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
       setMessages,
       appendOptimistic,
       requestModel,
+      promptOptions,
       resetLiveOverlay,
       syncOptimisticMessagesToMirror,
       t,
@@ -1296,7 +1389,7 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
       await executeSendAction('send', implementPrompt, [], {
         worktreePath,
         sessionId: droidSessionId,
-        prompt: (wp, sid, c) => window.agentOps.prompt(wp, sid, c, requestModel),
+        prompt: (wp, sid, c) => window.agentOps.prompt(wp, sid, c, requestModel, promptOptions),
         abort: (wp, sid) => window.agentOps.abort(wp, sid),
         queueMessage: (sid, msg) => useSessionRuntimeStore.getState().queueMessage(sid, msg)
       })
@@ -1317,7 +1410,8 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
     resetLiveOverlay,
     syncOptimisticMessagesToMirror,
     transitionToolStatus,
-    requestModel
+    requestModel,
+    promptOptions
   ])
 
   const handlePlanHandoff = useCallback(() => {

--- a/src/renderer/src/components/session-hq/cards/FileReadCard.tsx
+++ b/src/renderer/src/components/session-hq/cards/FileReadCard.tsx
@@ -10,21 +10,60 @@ interface FileReadCardProps {
   toolUse: ToolUseInfo
 }
 
+function resolveReadFilePath(toolUse: ToolUseInfo): string {
+  const input = (toolUse.input ?? {}) as Record<string, unknown>
+  const direct =
+    (input.filePath || input.file_path || input.path || input.displayName || input.filename ||
+      '') as string
+  if (direct) return direct
+  const paths = input.paths
+  if (Array.isArray(paths) && typeof paths[0] === 'string') return paths[0]
+  return ''
+}
+
+/**
+ * Resolve the "N lines" hint for the card header.
+ *
+ * Priority:
+ * 1. `input.limit` — explicit caller-supplied chunking (e.g. claude-code Read).
+ * 2. Output text line count — OpenCode's read tool doesn't echo `limit` in its
+ *    input, so we count rendered lines from the tool output once it has been
+ *    captured. The output starts with a `<path>...` header line, so we subtract
+ *    1 to keep the count aligned with the file's line span.
+ * 3. Otherwise, undefined — header right slot stays empty during pending state.
+ */
+function resolveReadLineCount(toolUse: ToolUseInfo): number | undefined {
+  const input = (toolUse.input ?? {}) as Record<string, unknown>
+  const limit = input.limit
+  if (typeof limit === 'number' && Number.isFinite(limit) && limit > 0) {
+    return limit
+  }
+
+  const output = toolUse.output
+  if (typeof output !== 'string' || output.length === 0) return undefined
+
+  const totalLines = output.split('\n').length
+  // Strip the leading `<path>...</path>` header line OpenCode adds; underflow
+  // keeps the value sensible when the tool returned a tiny snippet without it.
+  const adjusted = output.startsWith('<path>') ? Math.max(totalLines - 1, 0) : totalLines
+  return adjusted > 0 ? adjusted : undefined
+}
+
 export function FileReadCard({ toolUse }: FileReadCardProps): React.JSX.Element {
-  const filePath = (toolUse.input?.file_path as string) ?? (toolUse.input?.path as string) ?? ''
-  const limit = toolUse.input?.limit as number | undefined
+  const filePath = resolveReadFilePath(toolUse)
+  const lineCount = resolveReadLineCount(toolUse)
 
   return (
     <ActionCard
       headerLeft={
-        <div className="flex items-center gap-2">
-          <span className="font-semibold text-foreground">Read File</span>
-          <span className="font-mono text-xs text-blue-500 bg-blue-500/10 px-1.5 py-0.5 rounded">
+        <div className="flex items-center gap-2 min-w-0">
+          <span className="font-semibold text-foreground shrink-0">Read File</span>
+          <span className="font-mono text-xs text-blue-500 bg-blue-500/10 px-1.5 py-0.5 rounded truncate min-w-0">
             {filePath}
           </span>
         </div>
       }
-      headerRight={limit ? `${limit} lines` : undefined}
+      headerRight={lineCount ? `${lineCount} lines` : undefined}
     />
   )
 }

--- a/src/renderer/src/components/session-hq/cards/FileWriteCard.tsx
+++ b/src/renderer/src/components/session-hq/cards/FileWriteCard.tsx
@@ -27,12 +27,46 @@ type DiffLine =
 
 function isEditTool(name: string | undefined): boolean {
   const n = name?.toLowerCase() ?? ''
-  return n === 'edit' || n === 'editfile' || n === 'edit_file'
+  return n === 'edit' || n === 'editfile' || n === 'edit_file' || n === 'multiedit'
 }
 
 function isWriteTool(name: string | undefined): boolean {
   const n = name?.toLowerCase() ?? ''
   return n === 'write' || n === 'writefile' || n === 'write_file'
+}
+
+/** Extract old/new string pairs, accepting both snake_case and camelCase. */
+function readEditStrings(input: Record<string, unknown>): { oldStr: string; newStr: string } {
+  const oldStr =
+    (typeof input.old_string === 'string' && input.old_string) ||
+    (typeof input.oldString === 'string' && input.oldString) ||
+    ''
+  const newStr =
+    (typeof input.new_string === 'string' && input.new_string) ||
+    (typeof input.newString === 'string' && input.newString) ||
+    ''
+  return { oldStr, newStr }
+}
+
+function readWriteContent(input: Record<string, unknown>): string {
+  if (typeof input.content === 'string') return input.content
+  if (typeof input.text === 'string') return input.text
+  return ''
+}
+
+function resolveWriteFilePath(toolUse: ToolUseInfo, fallback?: string): string {
+  const input = (toolUse.input ?? {}) as Record<string, unknown>
+  const direct =
+    (input.filePath ||
+      input.file_path ||
+      input.path ||
+      input.displayName ||
+      input.filename ||
+      '') as string
+  if (direct) return direct
+  const paths = input.paths
+  if (Array.isArray(paths) && typeof paths[0] === 'string') return paths[0]
+  return fallback ?? ''
 }
 
 interface CodexChange {
@@ -104,8 +138,7 @@ function computeLineDiff(toolUse: ToolUseInfo): { added: number; removed: number
   const input = toolUse.input ?? {}
 
   if (isEditTool(toolUse.name)) {
-    const oldStr = (input.old_string as string) ?? ''
-    const newStr = (input.new_string as string) ?? ''
+    const { oldStr, newStr } = readEditStrings(input)
     if (!oldStr && !newStr) return null
     const oldLines = oldStr ? oldStr.split('\n').length : 0
     const newLines = newStr ? newStr.split('\n').length : 0
@@ -116,10 +149,18 @@ function computeLineDiff(toolUse: ToolUseInfo): { added: number; removed: number
   }
 
   if (isWriteTool(toolUse.name)) {
-    const content = (input.content as string) ?? ''
+    const content = readWriteContent(input)
     if (!content) return null
     const lines = content.split('\n').length
     return { added: lines, removed: 0 }
+  }
+
+  // Prefer filediff-provided totals when available (OpenCode Edit tool ships
+  // `input.additions` / `input.deletions` via enrichToolPart).
+  const additions = typeof input.additions === 'number' ? input.additions : null
+  const deletions = typeof input.deletions === 'number' ? input.deletions : null
+  if (additions !== null || deletions !== null) {
+    return { added: additions ?? 0, removed: deletions ?? 0 }
   }
 
   return null
@@ -163,13 +204,12 @@ function buildPreviewLines(toolUse: ToolUseInfo): DiffLine[] | null {
 
   const input = toolUse.input ?? {}
   if (isEditTool(toolUse.name)) {
-    const oldStr = (input.old_string as string) ?? ''
-    const newStr = (input.new_string as string) ?? ''
+    const { oldStr, newStr } = readEditStrings(input)
     if (!oldStr && !newStr) return null
     return buildEditPreview(oldStr, newStr)
   }
   if (isWriteTool(toolUse.name)) {
-    const content = (input.content as string) ?? ''
+    const content = readWriteContent(input)
     if (!content) return null
     return buildWritePreview(content)
   }
@@ -224,9 +264,8 @@ function DiffPreview({ lines }: DiffPreviewProps): React.JSX.Element {
 export function FileWriteCard({ toolUse }: FileWriteCardProps): React.JSX.Element {
   const codexChanges = getCodexChanges(toolUse)
   const filePath =
-    (toolUse.input?.file_path as string) ??
-    (toolUse.input?.path as string) ??
-    codexChanges?.[0]?.path ??
+    resolveWriteFilePath(toolUse, codexChanges?.[0]?.path) ||
+    codexChanges?.[0]?.path ||
     ''
   // Codex emits 'Edit' for both pure edits and full rewrites; treat as Edit.
   const isEdit =

--- a/src/renderer/src/components/sessions/SessionView.tsx
+++ b/src/renderer/src/components/sessions/SessionView.tsx
@@ -847,9 +847,15 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
   const updateSetting = useSettingsStore((state) => state.updateSetting)
   const vimModeEnabled = useSettingsStore((s) => s.vimModeEnabled)
 
+  // Subscribe reactively so switching Build <-> Plan reruns this memo and
+  // the next prompt picks up the new mode on opencode sessions.
+  const sessionMode = useSessionStore((s) => s.modeBySession?.get(sessionId) ?? 'build')
   const codexPromptOptions = useMemo(
-    () => (sessionAgentSdk === 'codex' ? { codexFastMode } : undefined),
-    [sessionAgentSdk, codexFastMode]
+    () => ({
+      ...(sessionAgentSdk === 'codex' ? { codexFastMode } : {}),
+      ...(sessionAgentSdk === 'opencode' ? { mode: sessionMode } : {})
+    }),
+    [sessionAgentSdk, codexFastMode, sessionMode]
   )
 
   // Streaming dedup refs

--- a/src/renderer/src/components/sessions/ToolCard.tsx
+++ b/src/renderer/src/components/sessions/ToolCard.tsx
@@ -381,6 +381,16 @@ function shortenPath(filePath: string, cwd?: string | null): string {
   return parts.length > 2 ? `.../${parts.slice(-2).join('/')}` : filePath
 }
 
+function resolveToolFilePath(input: Record<string, unknown>): string {
+  const direct =
+    (input.filePath || input.file_path || input.path || input.displayName || input.filename ||
+      '') as string
+  if (direct) return direct
+  const paths = input.paths
+  if (Array.isArray(paths) && typeof paths[0] === 'string') return paths[0]
+  return ''
+}
+
 /** Renders tool-specific collapsed header content (icon + name + contextual info) */
 function CollapsedContent({
   toolUse,
@@ -435,7 +445,7 @@ function CollapsedContent({
 
   // Read / Cat / View
   if (lowerName.includes('read') || lowerName === 'cat' || lowerName === 'view') {
-    const filePath = (input.filePath || input.file_path || input.path || '') as string
+    const filePath = resolveToolFilePath(input)
     const lineCount = output ? output.trimEnd().split('\n').length : null
     return (
       <>
@@ -457,7 +467,7 @@ function CollapsedContent({
 
   // Write / Create
   if (lowerName.includes('write') || lowerName === 'create') {
-    const filePath = (input.filePath || input.file_path || input.path || '') as string
+    const filePath = resolveToolFilePath(input)
     const content = (input.content || '') as string
     const lineCount = content ? content.trimEnd().split('\n').length : null
     return (
@@ -505,7 +515,7 @@ function CollapsedContent({
 
   // Edit / Replace / Patch
   if (lowerName.includes('edit') || lowerName.includes('replace') || lowerName.includes('patch')) {
-    const filePath = (input.filePath || input.file_path || input.path || '') as string
+    const filePath = resolveToolFilePath(input)
     const oldString = (input.oldString || input.old_string || '') as string
     const newString = (input.newString || input.new_string || '') as string
     const removedLines = oldString ? oldString.split('\n').length : 0
@@ -799,10 +809,7 @@ const CompactFileToolCard = memo(function CompactFileToolCard({
   const isLsp = isLspTool(toolUse.name)
   const isFigma = isFigmaTool(toolUse.name)
   const isFileChange = isFileChangeTool(toolUse.name)
-  const filePath = (toolUse.input.filePath ||
-    toolUse.input.file_path ||
-    toolUse.input.path ||
-    '') as string
+  const filePath = resolveToolFilePath(toolUse.input)
   const shortPath = shortenPath(filePath, cwd)
   const label = isSkill ? t('toolCard.labels.skill') : t(getFileToolLabelKey(toolUse.name))
   const detail = isSkill

--- a/src/renderer/src/components/sessions/tools/ReadToolView.tsx
+++ b/src/renderer/src/components/sessions/tools/ReadToolView.tsx
@@ -132,11 +132,21 @@ function getLanguageFromPath(filePath: string): string {
   return extensionToLanguage[ext] || 'text'
 }
 
+function resolveReadFilePath(input: Record<string, unknown>): string {
+  const direct =
+    (input.file_path || input.filePath || input.path || input.displayName || input.filename ||
+      '') as string
+  if (direct) return direct
+  const paths = input.paths
+  if (Array.isArray(paths) && typeof paths[0] === 'string') return paths[0]
+  return ''
+}
+
 export function ReadToolView({ input, output, error }: ToolViewProps) {
   const { t } = useI18n()
   const [showAll, setShowAll] = useState(false)
 
-  const filePath = (input.file_path || input.filePath || input.path || '') as string
+  const filePath = resolveReadFilePath(input)
   const offset = input.offset as number | undefined
   const limit = input.limit as number | undefined
 

--- a/src/renderer/src/hooks/useAgentEventBridge.ts
+++ b/src/renderer/src/hooks/useAgentEventBridge.ts
@@ -596,6 +596,18 @@ export function useAgentEventBridge(): void {
             return
           }
 
+          // ----- session.error -----
+          // Phase 1.4.8: when the backend emits a session.error (e.g.
+          // MessageAbortedError after Stop), force the UI lifecycle back to
+          // 'idle' so the ComposerBar Stop icon flips to Send. Some abort
+          // paths land error first and idle later (or never) — without this
+          // shortcut the Stop button can stay red indefinitely.
+          if (event.type === 'session.error') {
+            runtime.setLifecycle(sessionId, 'idle')
+            runtime.setRetryInfo(sessionId, null)
+            return
+          }
+
           // ----- session.status (the main lifecycle signal) -----
           if (event.type !== 'session.status') return
 
@@ -711,7 +723,9 @@ export function useAgentEventBridge(): void {
                 const result = await window.agentOps.prompt(
                   context.worktreePath,
                   context.opencodeSessionId,
-                  [{ type: 'text', text: message }]
+                  [{ type: 'text', text: message }],
+                  undefined,
+                  { mode }
                 )
 
                 if (!result.success) {

--- a/src/shared/lib/opencode-classify.ts
+++ b/src/shared/lib/opencode-classify.ts
@@ -55,7 +55,16 @@ const OPENCODE_NATIVE_TOOLS: Record<string, CanonicalToolName> = {
   webfetch: 'WebFetch',
   websearch: 'WebSearch',
   todowrite: 'TodoWrite',
-  task: 'Task'
+  task: 'Task',
+  // Phase 1.4.8 (OpenCode AskUserQuestion parity): OpenCode wraps the
+  // `question.asked` HITL request in a tool part named `question`. Without
+  // this entry it would fall through to `Unknown`, AgentTimeline would not
+  // recognise it as the AskUser card type, and the question UI would never
+  // render even though the input bar correctly switches into reply mode.
+  // Aligns with codex-implementer.ts which emits 'AskUserQuestion' directly.
+  question: 'AskUserQuestion',
+  askuserquestion: 'AskUserQuestion',
+  ask_user: 'AskUserQuestion'
 }
 
 /**

--- a/src/shared/lib/opencode-classify.ts
+++ b/src/shared/lib/opencode-classify.ts
@@ -1,0 +1,132 @@
+/**
+ * OpenCode tool classification — shared between the live event mapper
+ * (main process: src/main/services/opencode-service.ts) and the durable
+ * timeline mapper (src/shared/lib/timeline-mappers.ts).
+ *
+ * OpenCode's SDK emits tool parts on `message.part.updated` events. Each tool
+ * part has the shape:
+ *
+ *   { type: 'tool', callID, tool: '<lowercase-name>', state: { status, input, output, error, time } }
+ *
+ * The xuanpu UI uses canonical tool names (Bash / Read / Edit / Grep / Glob /
+ * Write / WebSearch / WebFetch / TodoWrite / Task / McpTool / Unknown) so a
+ * single set of cards can render any runtime's output. OpenCode's native names
+ * are lowercase ('bash', 'read', ...). MCP tools follow various conventions
+ * but typically include a server segment.
+ *
+ * This module does ONE thing: take an OpenCode tool name (with optional
+ * companion data) and return a canonical classification:
+ *
+ *   { tool: CanonicalToolName, toolDisplay?: string, mcpServer?: string }
+ *
+ * The streaming pipeline (opencode-service.ts) and the durable read path
+ * (timeline-mappers.mapPartToStreamingPart) MUST use this same classifier so
+ * the same item renders identically in both modes.
+ *
+ * Returning `tool: 'Unknown'` signals an unrecognized tool — UI falls back to
+ * FallbackToolView.
+ */
+import type { CanonicalToolName } from '../types/agent-protocol'
+
+export interface ClassifiedOpenCodeTool {
+  tool: CanonicalToolName
+  /** Original (un-normalized) name; preserved for display and fallback lookups. */
+  toolDisplay?: string
+  /** Server segment when the tool is an MCP-routed call. */
+  mcpServer?: string
+}
+
+/**
+ * Map of OpenCode native lowercase tool names → CanonicalToolName.
+ *
+ * Add new entries here when OpenCode's SDK introduces a new built-in tool.
+ * MCP tools are NOT listed here — they are detected via prefix/separator and
+ * fall through to the McpTool branch.
+ */
+const OPENCODE_NATIVE_TOOLS: Record<string, CanonicalToolName> = {
+  bash: 'Bash',
+  read: 'Read',
+  write: 'Write',
+  edit: 'Edit',
+  multiedit: 'Edit',
+  grep: 'Grep',
+  glob: 'Glob',
+  list: 'Glob',
+  webfetch: 'WebFetch',
+  websearch: 'WebSearch',
+  todowrite: 'TodoWrite',
+  task: 'Task'
+}
+
+/**
+ * Heuristic for MCP-routed tools. OpenCode surfaces MCP tools with names that
+ * usually contain an underscore separator between the server and tool, and
+ * sometimes a leading `mcp_` / `mcp__` prefix.
+ *
+ * Examples seen in the wild:
+ *   - mcp_figma_get_file
+ *   - mcp__hive-lsp__lsp
+ *   - context7_query-docs
+ *
+ * We deliberately do NOT classify simple snake_case native names like
+ * `read_file` as MCP — those are claude-code shaped and are handled by the
+ * ToolCard renderer's case-insensitive fallback.
+ */
+function isLikelyMcpTool(rawName: string): boolean {
+  if (rawName.startsWith('mcp_') || rawName.startsWith('mcp__')) return true
+  // Multi-segment names with explicit double-underscore are MCP-shaped
+  if (rawName.includes('__')) return true
+  return false
+}
+
+function extractMcpServer(rawName: string): string | undefined {
+  // Strip leading mcp_ / mcp__
+  const stripped = rawName.replace(/^mcp__?/, '')
+  // Prefer double-underscore separator (claude-code MCP convention)
+  if (stripped.includes('__')) {
+    const [server] = stripped.split('__')
+    return server || undefined
+  }
+  // Fall back to first underscore segment
+  if (stripped.includes('_')) {
+    const [server] = stripped.split('_')
+    return server || undefined
+  }
+  return undefined
+}
+
+/**
+ * Classify a raw OpenCode tool name into a canonical record.
+ *
+ * Inputs:
+ *   - rawName: the value of `part.tool` from a `message.part.updated` event.
+ *
+ * Returns a `ClassifiedOpenCodeTool`. Always returns a value (never null) —
+ * unrecognized names map to `{ tool: 'Unknown', toolDisplay: rawName }`.
+ */
+export function classifyOpenCodeTool(rawName: unknown): ClassifiedOpenCodeTool {
+  if (typeof rawName !== 'string' || rawName.length === 0) {
+    return { tool: 'Unknown' }
+  }
+
+  const lower = rawName.toLowerCase()
+
+  // 1. Native built-in tools — exact (case-insensitive) match against the map.
+  const native = OPENCODE_NATIVE_TOOLS[lower]
+  if (native) {
+    return { tool: native, toolDisplay: rawName }
+  }
+
+  // 2. MCP-routed tools — detected via prefix/separator.
+  if (isLikelyMcpTool(rawName)) {
+    const server = extractMcpServer(rawName)
+    return {
+      tool: 'McpTool',
+      toolDisplay: rawName,
+      ...(server ? { mcpServer: server } : {})
+    }
+  }
+
+  // 3. Unknown — pass through with original display name.
+  return { tool: 'Unknown', toolDisplay: rawName }
+}

--- a/src/shared/lib/timeline-mappers.ts
+++ b/src/shared/lib/timeline-mappers.ts
@@ -1049,3 +1049,132 @@ export function deriveCodexTimeline(
     activityRows
   )
 }
+
+/**
+ * Phase 1.4.8 (OpenCode plan parity): merge `plan.ready` activity rows into
+ * an OpenCode timeline so the durable transcript shows a `ExitPlanMode`
+ * tool-use card per plan turn.
+ *
+ * OpenCode's normal timeline is built from `mapRawTranscriptToTimeline`
+ * (messages only) — activities are not consulted. Plan-mode generates the
+ * plan as a regular `text` part, so without this merge the FAB pops up but
+ * no card ever appears in the message stream.
+ *
+ * This is intentionally narrower than `mergeCodexActivityMessages`:
+ *   - Only `plan.ready` activities are merged (the others are already
+ *     captured by OpenCode's own tool parts).
+ *   - The synthetic ExitPlanMode tool-part is appended to the matching
+ *     assistant message (looked up by `item_id` === message id). If we can't
+ *     match (e.g. timeline trimmed), the part is appended as a standalone
+ *     synthetic assistant message anchored at the activity's timestamp so
+ *     the card still appears.
+ *   - Plans with a paired `plan.resolved` row render as `status: 'success'`
+ *     (greyed out, no "Requires Approval" badge), same logic Codex uses.
+ */
+export function mergeOpenCodePlanActivities(
+  messages: TimelineMessage[],
+  activityRows: DbSessionActivity[]
+): TimelineMessage[] {
+  if (activityRows.length === 0) return messages
+
+  const planReadyRows = activityRows.filter((row) => row.kind === 'plan.ready')
+  if (planReadyRows.length === 0) return messages
+
+  const resolvedRequestIds = new Set<string>()
+  for (const row of activityRows) {
+    if (row.kind === 'plan.resolved' && row.request_id) {
+      resolvedRequestIds.add(row.request_id)
+    }
+  }
+
+  // Index existing messages by id (the assistant message id == activity.item_id)
+  const messageIndex = new Map<string, number>()
+  messages.forEach((msg, idx) => messageIndex.set(msg.id, idx))
+
+  // Track tool ids already present so we don't duplicate cards if the upstream
+  // transcript ever starts surfacing ExitPlanMode itself.
+  const knownToolIds = new Set<string>()
+  for (const msg of messages) {
+    if (!Array.isArray(msg.parts)) continue
+    for (const part of msg.parts) {
+      if (part.type === 'tool_use' && part.toolUse?.id) {
+        knownToolIds.add(part.toolUse.id)
+      }
+    }
+  }
+
+  // Clone messages so we can splice parts safely
+  const next = messages.map((msg) => ({
+    ...msg,
+    parts: msg.parts ? [...msg.parts] : undefined
+  }))
+
+  const trailing: TimelineMessage[] = []
+
+  for (const row of planReadyRows) {
+    const part = parsePlanPartFromActivity(row, resolvedRequestIds)
+    if (!part?.toolUse) continue
+    if (knownToolIds.has(part.toolUse.id)) continue
+    knownToolIds.add(part.toolUse.id)
+
+    // Phase 1.4.8 follow-up: PlanCard renders the full plan markdown via its
+    // `content` prop, and `messageToNodes` ALSO renders any `text` part as a
+    // separate text card. Without de-dup, the user sees the plan twice — once
+    // in the assistant text bubble and once in the "Proposed Execution Plan"
+    // approval card. Strip text parts whose content is fully contained in the
+    // plan we're about to render so the card becomes the single source.
+    const planText =
+      typeof part.toolUse.input?.plan === 'string'
+        ? (part.toolUse.input.plan as string).trim()
+        : ''
+
+    const itemId = row.item_id ?? null
+    if (itemId && messageIndex.has(itemId)) {
+      const targetIdx = messageIndex.get(itemId)!
+      const target = next[targetIdx]
+      const existingParts = target.parts ?? []
+
+      const filteredParts = planText
+        ? existingParts.filter((p) => {
+            if (p.type !== 'text') return true
+            const partText = (p.text ?? '').trim()
+            if (!partText) return false
+            // Drop the text part if its content is identical to the plan or a
+            // strict prefix/suffix subset (covers cases where the SDK trims
+            // trailing whitespace differently than our buffer).
+            return !(planText === partText || planText.includes(partText))
+          })
+        : existingParts
+
+      next[targetIdx] = {
+        ...target,
+        // Also clear `content` if it's the same plan text — `messageToNodes`
+        // falls back to `content` when `parts` is empty (line 153).
+        content:
+          planText && (target.content ?? '').trim() === planText ? '' : target.content,
+        parts: [...filteredParts, part]
+      }
+    } else {
+      // Fallback: synthesize an assistant message wrapper so the card still
+      // shows up. Anchored at the activity's created_at so it lands in
+      // chronological order.
+      trailing.push({
+        id: row.id,
+        role: 'assistant',
+        content: '',
+        timestamp: row.created_at,
+        parts: [part]
+      })
+    }
+  }
+
+  if (trailing.length === 0) return next
+
+  // Insertion-sort trailing rows by timestamp into next[]
+  const merged = [...next, ...trailing].sort((a, b) => {
+    const ta = Date.parse(a.timestamp ?? '') || 0
+    const tb = Date.parse(b.timestamp ?? '') || 0
+    return ta - tb
+  })
+  return merged
+}

--- a/src/shared/types/agent-protocol.ts
+++ b/src/shared/types/agent-protocol.ts
@@ -91,6 +91,7 @@ export type CanonicalToolName =
   | 'WebFetch'
   | 'TodoWrite'
   | 'Task'
+  | 'AskUserQuestion'
   | 'McpTool'
   | 'Unknown'
 

--- a/test/opencode-classify.test.ts
+++ b/test/opencode-classify.test.ts
@@ -86,6 +86,28 @@ describe('classifyOpenCodeTool', () => {
         toolDisplay: 'task'
       })
     })
+
+    it('classifies question -> AskUserQuestion (Phase 1.4.8)', () => {
+      // OpenCode wraps the `question.asked` HITL request in a tool part named
+      // `question`. Without this mapping it would fall through to `Unknown`
+      // and AgentTimeline would not render AskUserCard, even though the
+      // composer correctly switches into reply mode.
+      expect(classifyOpenCodeTool('question')).toEqual({
+        tool: 'AskUserQuestion',
+        toolDisplay: 'question'
+      })
+    })
+
+    it('classifies askuserquestion / ask_user as AskUserQuestion (Claude/Codex aliases)', () => {
+      expect(classifyOpenCodeTool('askuserquestion')).toEqual({
+        tool: 'AskUserQuestion',
+        toolDisplay: 'askuserquestion'
+      })
+      expect(classifyOpenCodeTool('ask_user')).toEqual({
+        tool: 'AskUserQuestion',
+        toolDisplay: 'ask_user'
+      })
+    })
   })
 
   describe('case insensitivity', () => {

--- a/test/opencode-classify.test.ts
+++ b/test/opencode-classify.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect } from 'vitest'
+import { classifyOpenCodeTool } from '../src/shared/lib/opencode-classify'
+
+describe('classifyOpenCodeTool', () => {
+  describe('native built-in tools', () => {
+    it('classifies bash -> Bash', () => {
+      expect(classifyOpenCodeTool('bash')).toEqual({
+        tool: 'Bash',
+        toolDisplay: 'bash'
+      })
+    })
+
+    it('classifies read -> Read', () => {
+      expect(classifyOpenCodeTool('read')).toEqual({
+        tool: 'Read',
+        toolDisplay: 'read'
+      })
+    })
+
+    it('classifies write -> Write', () => {
+      expect(classifyOpenCodeTool('write')).toEqual({
+        tool: 'Write',
+        toolDisplay: 'write'
+      })
+    })
+
+    it('classifies edit -> Edit', () => {
+      expect(classifyOpenCodeTool('edit')).toEqual({
+        tool: 'Edit',
+        toolDisplay: 'edit'
+      })
+    })
+
+    it('classifies multiedit -> Edit (treated as Edit variant)', () => {
+      expect(classifyOpenCodeTool('multiedit')).toEqual({
+        tool: 'Edit',
+        toolDisplay: 'multiedit'
+      })
+    })
+
+    it('classifies grep -> Grep', () => {
+      expect(classifyOpenCodeTool('grep')).toEqual({
+        tool: 'Grep',
+        toolDisplay: 'grep'
+      })
+    })
+
+    it('classifies glob -> Glob', () => {
+      expect(classifyOpenCodeTool('glob')).toEqual({
+        tool: 'Glob',
+        toolDisplay: 'glob'
+      })
+    })
+
+    it('classifies list -> Glob (directory listing)', () => {
+      expect(classifyOpenCodeTool('list')).toEqual({
+        tool: 'Glob',
+        toolDisplay: 'list'
+      })
+    })
+
+    it('classifies webfetch -> WebFetch', () => {
+      expect(classifyOpenCodeTool('webfetch')).toEqual({
+        tool: 'WebFetch',
+        toolDisplay: 'webfetch'
+      })
+    })
+
+    it('classifies websearch -> WebSearch', () => {
+      expect(classifyOpenCodeTool('websearch')).toEqual({
+        tool: 'WebSearch',
+        toolDisplay: 'websearch'
+      })
+    })
+
+    it('classifies todowrite -> TodoWrite', () => {
+      expect(classifyOpenCodeTool('todowrite')).toEqual({
+        tool: 'TodoWrite',
+        toolDisplay: 'todowrite'
+      })
+    })
+
+    it('classifies task -> Task', () => {
+      expect(classifyOpenCodeTool('task')).toEqual({
+        tool: 'Task',
+        toolDisplay: 'task'
+      })
+    })
+  })
+
+  describe('case insensitivity', () => {
+    it('accepts uppercase canonical names (idempotent)', () => {
+      expect(classifyOpenCodeTool('Bash')).toEqual({
+        tool: 'Bash',
+        toolDisplay: 'Bash'
+      })
+    })
+
+    it('accepts mixed case (TodoWrite)', () => {
+      expect(classifyOpenCodeTool('TodoWrite')).toEqual({
+        tool: 'TodoWrite',
+        toolDisplay: 'TodoWrite'
+      })
+    })
+  })
+
+  describe('MCP tools', () => {
+    it('classifies mcp_ prefixed tool with single underscore separator', () => {
+      const result = classifyOpenCodeTool('mcp_figma_get_file')
+      expect(result).toEqual({
+        tool: 'McpTool',
+        toolDisplay: 'mcp_figma_get_file',
+        mcpServer: 'figma'
+      })
+    })
+
+    it('classifies mcp__ double-underscore prefix (claude-code shape)', () => {
+      const result = classifyOpenCodeTool('mcp__hive-lsp__lsp')
+      expect(result).toEqual({
+        tool: 'McpTool',
+        toolDisplay: 'mcp__hive-lsp__lsp',
+        mcpServer: 'hive-lsp'
+      })
+    })
+
+    it('classifies tool with double-underscore as MCP even without mcp prefix', () => {
+      const result = classifyOpenCodeTool('context7__query-docs')
+      expect(result).toEqual({
+        tool: 'McpTool',
+        toolDisplay: 'context7__query-docs',
+        mcpServer: 'context7'
+      })
+    })
+
+    it('omits mcpServer when MCP detection cannot extract a server segment', () => {
+      const result = classifyOpenCodeTool('mcp_')
+      expect(result.tool).toBe('McpTool')
+      expect(result.toolDisplay).toBe('mcp_')
+      expect(result.mcpServer).toBeUndefined()
+    })
+  })
+
+  describe('edge cases', () => {
+    it('returns Unknown for empty string', () => {
+      expect(classifyOpenCodeTool('')).toEqual({ tool: 'Unknown' })
+    })
+
+    it('returns Unknown for undefined', () => {
+      expect(classifyOpenCodeTool(undefined)).toEqual({ tool: 'Unknown' })
+    })
+
+    it('returns Unknown for null', () => {
+      expect(classifyOpenCodeTool(null)).toEqual({ tool: 'Unknown' })
+    })
+
+    it('returns Unknown for non-string input', () => {
+      expect(classifyOpenCodeTool(42)).toEqual({ tool: 'Unknown' })
+      expect(classifyOpenCodeTool({ tool: 'bash' })).toEqual({ tool: 'Unknown' })
+    })
+
+    it('returns Unknown for unrecognized snake_case (not MCP-shaped)', () => {
+      // Single underscore without mcp prefix is NOT classified as MCP — those
+      // are claude-code-shaped names handled by ToolCard fallback.
+      expect(classifyOpenCodeTool('read_file')).toEqual({
+        tool: 'Unknown',
+        toolDisplay: 'read_file'
+      })
+    })
+
+    it('returns Unknown for completely unrecognized name with display preserved', () => {
+      expect(classifyOpenCodeTool('foobar')).toEqual({
+        tool: 'Unknown',
+        toolDisplay: 'foobar'
+      })
+    })
+  })
+})

--- a/test/phase-21/opencode-activity-mapper.test.ts
+++ b/test/phase-21/opencode-activity-mapper.test.ts
@@ -1,0 +1,320 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  mapOpenCodeEventToActivity,
+  type ToolStartedTracker
+} from '../../src/main/services/opencode-activity-mapper'
+
+const HIVE = 'hive-session-1'
+const AGENT = 'opencode-session-1'
+
+function freshTracker(): ToolStartedTracker {
+  return new Set<string>()
+}
+
+describe('mapOpenCodeEventToActivity', () => {
+  let tracker: ToolStartedTracker
+
+  beforeEach(() => {
+    tracker = freshTracker()
+  })
+
+  describe('tool lifecycle (message.part.updated)', () => {
+    it('emits tool.started on first running update for a callID', () => {
+      const result = mapOpenCodeEventToActivity(
+        HIVE,
+        AGENT,
+        {
+          type: 'message.part.updated',
+          properties: {
+            part: {
+              type: 'tool',
+              callID: 'call-1',
+              tool: 'Bash',
+              toolDisplay: 'bash',
+              state: { status: 'running', input: { command: 'ls' } }
+            }
+          }
+        },
+        tracker
+      )
+      expect(result?.kind).toBe('tool.started')
+      expect(result?.tone).toBe('tool')
+      expect(result?.summary).toBe('bash')
+      expect(result?.item_id).toBe('call-1')
+      expect(tracker.has('call-1')).toBe(true)
+    })
+
+    it('emits tool.updated on subsequent running updates for the same callID', () => {
+      tracker.add('call-2')
+      const result = mapOpenCodeEventToActivity(
+        HIVE,
+        AGENT,
+        {
+          type: 'message.part.updated',
+          properties: {
+            part: {
+              type: 'tool',
+              callID: 'call-2',
+              tool: 'Read',
+              state: { status: 'running' }
+            }
+          }
+        },
+        tracker
+      )
+      expect(result?.kind).toBe('tool.updated')
+      expect(result?.tone).toBe('tool')
+    })
+
+    it('emits tool.completed and clears tracker on completed', () => {
+      tracker.add('call-3')
+      const result = mapOpenCodeEventToActivity(
+        HIVE,
+        AGENT,
+        {
+          type: 'message.part.updated',
+          properties: {
+            part: {
+              type: 'tool',
+              callID: 'call-3',
+              tool: 'Edit',
+              state: { status: 'completed', output: 'done' }
+            }
+          }
+        },
+        tracker
+      )
+      expect(result?.kind).toBe('tool.completed')
+      expect(result?.tone).toBe('tool')
+      expect(tracker.has('call-3')).toBe(false)
+    })
+
+    it('emits tool.failed on error status with error tone', () => {
+      tracker.add('call-4')
+      const result = mapOpenCodeEventToActivity(
+        HIVE,
+        AGENT,
+        {
+          type: 'message.part.updated',
+          properties: {
+            part: {
+              type: 'tool',
+              callID: 'call-4',
+              tool: 'Bash',
+              state: { status: 'error', error: 'oops' }
+            }
+          }
+        },
+        tracker
+      )
+      expect(result?.kind).toBe('tool.failed')
+      expect(result?.tone).toBe('error')
+      expect(tracker.has('call-4')).toBe(false)
+    })
+
+    it('treats cancelled status as tool.failed', () => {
+      const result = mapOpenCodeEventToActivity(
+        HIVE,
+        AGENT,
+        {
+          type: 'message.part.updated',
+          properties: {
+            part: {
+              type: 'tool',
+              callID: 'call-5',
+              tool: 'Grep',
+              state: { status: 'cancelled' }
+            }
+          }
+        },
+        tracker
+      )
+      expect(result?.kind).toBe('tool.failed')
+      expect(result?.tone).toBe('error')
+    })
+
+    it('returns null when part type is not tool', () => {
+      const result = mapOpenCodeEventToActivity(
+        HIVE,
+        AGENT,
+        {
+          type: 'message.part.updated',
+          properties: { part: { type: 'text', text: 'hi' } }
+        },
+        tracker
+      )
+      expect(result).toBeNull()
+    })
+
+    it('returns null when callID is missing', () => {
+      const result = mapOpenCodeEventToActivity(
+        HIVE,
+        AGENT,
+        {
+          type: 'message.part.updated',
+          properties: { part: { type: 'tool', state: { status: 'running' } } }
+        },
+        tracker
+      )
+      expect(result).toBeNull()
+    })
+
+    it('returns null on unknown tool status (e.g. pending without callID flow)', () => {
+      const result = mapOpenCodeEventToActivity(
+        HIVE,
+        AGENT,
+        {
+          type: 'message.part.updated',
+          properties: {
+            part: { type: 'tool', callID: 'x', state: { status: 'foo' } }
+          }
+        },
+        tracker
+      )
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('session lifecycle', () => {
+    it('maps session.idle to session.info', () => {
+      const result = mapOpenCodeEventToActivity(
+        HIVE,
+        AGENT,
+        { type: 'session.idle', properties: { sessionID: AGENT } },
+        tracker
+      )
+      expect(result?.kind).toBe('session.info')
+      expect(result?.tone).toBe('info')
+      expect(result?.summary).toBe('Session idle')
+    })
+
+    it('maps session.error with extracted message', () => {
+      const result = mapOpenCodeEventToActivity(
+        HIVE,
+        AGENT,
+        { type: 'session.error', properties: { error: { message: 'boom' } } },
+        tracker
+      )
+      expect(result?.kind).toBe('session.error')
+      expect(result?.tone).toBe('error')
+      expect(result?.summary).toBe('boom')
+    })
+
+    it('falls back to default summary for session.error without message', () => {
+      const result = mapOpenCodeEventToActivity(
+        HIVE,
+        AGENT,
+        { type: 'session.error', properties: {} },
+        tracker
+      )
+      expect(result?.kind).toBe('session.error')
+      expect(result?.summary).toBe('Session error')
+    })
+  })
+
+  describe('HITL events', () => {
+    it('maps question.asked to user-input.requested', () => {
+      const result = mapOpenCodeEventToActivity(
+        HIVE,
+        AGENT,
+        {
+          type: 'question.asked',
+          properties: { id: 'q-1', requestId: 'req-1', questions: [] }
+        },
+        tracker
+      )
+      expect(result?.kind).toBe('user-input.requested')
+      expect(result?.tone).toBe('approval')
+      expect(result?.item_id).toBe('q-1')
+      expect(result?.request_id).toBe('req-1')
+    })
+
+    it('maps permission.asked to approval.requested', () => {
+      const result = mapOpenCodeEventToActivity(
+        HIVE,
+        AGENT,
+        {
+          type: 'permission.asked',
+          properties: { id: 'p-1', permission: 'execute(rm)', patterns: ['rm *'] }
+        },
+        tracker
+      )
+      expect(result?.kind).toBe('approval.requested')
+      expect(result?.tone).toBe('approval')
+      expect(result?.summary).toBe('execute(rm)')
+    })
+
+    it('maps command.approval_needed to approval.requested', () => {
+      const result = mapOpenCodeEventToActivity(
+        HIVE,
+        AGENT,
+        {
+          type: 'command.approval_needed',
+          properties: { requestId: 'cmd-1', commandStr: 'git push --force' }
+        },
+        tracker
+      )
+      expect(result?.kind).toBe('approval.requested')
+      expect(result?.tone).toBe('approval')
+      expect(result?.summary).toBe('git push --force')
+      expect(result?.request_id).toBe('cmd-1')
+    })
+  })
+
+  describe('noisy events', () => {
+    it('returns null for unknown event types', () => {
+      expect(
+        mapOpenCodeEventToActivity(HIVE, AGENT, { type: 'server.heartbeat' }, tracker)
+      ).toBeNull()
+      expect(
+        mapOpenCodeEventToActivity(HIVE, AGENT, { type: 'message.updated' }, tracker)
+      ).toBeNull()
+    })
+
+    it('returns null for events without a type', () => {
+      expect(mapOpenCodeEventToActivity(HIVE, AGENT, {}, tracker)).toBeNull()
+    })
+  })
+
+  describe('payload preservation', () => {
+    it('serializes raw event properties into payload_json', () => {
+      const result = mapOpenCodeEventToActivity(
+        HIVE,
+        AGENT,
+        { type: 'session.idle', properties: { sessionID: 'opencode-x', extra: 1 } },
+        tracker
+      )
+      expect(result?.payload_json).not.toBeNull()
+      const parsed = JSON.parse(result!.payload_json!)
+      expect(parsed).toMatchObject({ sessionID: 'opencode-x', extra: 1 })
+    })
+
+    it('produces deterministic id for tool transitions (callID:kind)', () => {
+      const a = mapOpenCodeEventToActivity(
+        HIVE,
+        AGENT,
+        {
+          type: 'message.part.updated',
+          properties: {
+            part: { type: 'tool', callID: 'fixed-id', tool: 'Bash', state: { status: 'completed' } }
+          }
+        },
+        tracker
+      )
+      // Re-run with a fresh tracker — same id should be generated.
+      const b = mapOpenCodeEventToActivity(
+        HIVE,
+        AGENT,
+        {
+          type: 'message.part.updated',
+          properties: {
+            part: { type: 'tool', callID: 'fixed-id', tool: 'Bash', state: { status: 'completed' } }
+          }
+        },
+        freshTracker()
+      )
+      expect(a?.id).toBe('fixed-id:tool.completed')
+      expect(b?.id).toBe('fixed-id:tool.completed')
+    })
+  })
+})

--- a/test/phase-21/opencode-session-title.test.ts
+++ b/test/phase-21/opencode-session-title.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest'
+import {
+  isPlaceholderSessionTitle,
+  extractTitleSourceText
+} from '../../src/main/services/opencode-session-title'
+
+describe('isPlaceholderSessionTitle', () => {
+  it('treats null/undefined/empty as placeholder', () => {
+    expect(isPlaceholderSessionTitle(null)).toBe(true)
+    expect(isPlaceholderSessionTitle(undefined)).toBe(true)
+    expect(isPlaceholderSessionTitle('')).toBe(true)
+    expect(isPlaceholderSessionTitle('   ')).toBe(true)
+  })
+
+  it('matches Hive default "Session N"', () => {
+    expect(isPlaceholderSessionTitle('Session 1')).toBe(true)
+    expect(isPlaceholderSessionTitle('Session 42')).toBe(true)
+    expect(isPlaceholderSessionTitle('session 7')).toBe(true) // case-insensitive
+  })
+
+  it('matches OpenCode "New Session YYYY-MM-DD..." default', () => {
+    expect(isPlaceholderSessionTitle('New Session 2026-04-29T11:00:00.000Z')).toBe(true)
+    expect(isPlaceholderSessionTitle('new session 2025-12-01T00:00:00Z')).toBe(true)
+    expect(isPlaceholderSessionTitle('New Session-2026-04-29')).toBe(true)
+  })
+
+  it('does NOT match meaningful titles', () => {
+    expect(isPlaceholderSessionTitle('Debugging production 500 errors')).toBe(false)
+    expect(isPlaceholderSessionTitle('Refactoring user service')).toBe(false)
+    expect(isPlaceholderSessionTitle('Session about debugging')).toBe(false) // not "Session N"
+    expect(isPlaceholderSessionTitle('My Session')).toBe(false)
+  })
+})
+
+describe('extractTitleSourceText', () => {
+  it('returns the trimmed string when given a string', () => {
+    expect(extractTitleSourceText('  hello world  ')).toBe('hello world')
+  })
+
+  it('joins text parts with spaces and skips file parts', () => {
+    expect(
+      extractTitleSourceText([
+        { type: 'text', text: 'first' },
+        { type: 'file', mime: 'image/png', url: 'data:...' },
+        { type: 'text', text: 'second' }
+      ])
+    ).toBe('first second')
+  })
+
+  it('returns empty string when only files are passed', () => {
+    expect(
+      extractTitleSourceText([
+        { type: 'file', mime: 'image/png', url: 'a' },
+        { type: 'file', mime: 'image/png', url: 'b' }
+      ])
+    ).toBe('')
+  })
+
+  it('handles empty arrays and empty strings', () => {
+    expect(extractTitleSourceText('')).toBe('')
+    expect(extractTitleSourceText([])).toBe('')
+  })
+
+  it('preserves single text content', () => {
+    expect(
+      extractTitleSourceText([{ type: 'text', text: 'Add dark mode toggle' }])
+    ).toBe('Add dark mode toggle')
+  })
+})

--- a/test/phase-23/session-timeline-service.test.ts
+++ b/test/phase-23/session-timeline-service.test.ts
@@ -247,6 +247,201 @@ describe('getSessionTimeline', () => {
       expect(result.compactionMarkers).toHaveLength(1)
       expect(result.compactionMarkers[0]).toBe('msg-2')
     })
+
+    it('attaches plan.ready activity as ExitPlanMode tool_use part on matching opencode message', () => {
+      const rawTimeline = [
+        {
+          info: { id: 'msg-plan-1', role: 'assistant', createdAt: '2024-01-01T00:00:00.000Z' },
+          parts: [{ type: 'text', text: '## Plan\n- step 1' }]
+        }
+      ]
+      mockGetSession.mockReturnValue(makeSession({ agent_sdk: 'opencode' }))
+      mockGetSessionMessages.mockReturnValue([
+        makeMessageRow({
+          opencode_timeline_json: JSON.stringify(rawTimeline)
+        })
+      ])
+      mockGetSessionActivities.mockReturnValue([
+        {
+          id: 'opencode-plan:sess-1:msg-plan-1',
+          session_id: 'sess-1',
+          agent_session_id: 'opc-1',
+          thread_id: null,
+          turn_id: null,
+          item_id: 'msg-plan-1',
+          request_id: 'opencode-plan:sess-1:msg-plan-1',
+          kind: 'plan.ready',
+          tone: 'info',
+          summary: 'Plan ready',
+          payload_json: JSON.stringify({
+            plan: '## Plan\n- step 1',
+            toolUseID: 'msg-plan-1',
+            requestId: 'opencode-plan:sess-1:msg-plan-1'
+          }),
+          sequence: null,
+          created_at: '2024-01-01T00:00:01.000Z'
+        }
+      ])
+
+      const result = getSessionTimeline('sess-1')
+      expect(result.messages).toHaveLength(1)
+      const parts = result.messages[0].parts
+      expect(parts).toBeDefined()
+      // text part stays + ExitPlanMode tool part appended
+      const planPart = parts!.find((p) => p.type === 'tool_use' && p.toolUse?.name === 'ExitPlanMode')
+      expect(planPart).toBeDefined()
+      expect(planPart?.toolUse?.input).toMatchObject({ plan: '## Plan\n- step 1' })
+      // Pending status because no plan.resolved row yet
+      expect(planPart?.toolUse?.status).toBe('pending')
+    })
+
+    it('marks plan card as resolved when matching plan.resolved activity exists', () => {
+      const rawTimeline = [
+        {
+          info: { id: 'msg-plan-1', role: 'assistant', createdAt: '2024-01-01T00:00:00.000Z' },
+          parts: [{ type: 'text', text: '## Plan' }]
+        }
+      ]
+      const reqId = 'opencode-plan:sess-1:msg-plan-1'
+      mockGetSession.mockReturnValue(makeSession({ agent_sdk: 'opencode' }))
+      mockGetSessionMessages.mockReturnValue([
+        makeMessageRow({
+          opencode_timeline_json: JSON.stringify(rawTimeline)
+        })
+      ])
+      mockGetSessionActivities.mockReturnValue([
+        {
+          id: reqId,
+          session_id: 'sess-1',
+          agent_session_id: 'opc-1',
+          thread_id: null,
+          turn_id: null,
+          item_id: 'msg-plan-1',
+          request_id: reqId,
+          kind: 'plan.ready',
+          tone: 'info',
+          summary: 'Plan ready',
+          payload_json: JSON.stringify({ plan: '## Plan', toolUseID: 'msg-plan-1' }),
+          sequence: null,
+          created_at: '2024-01-01T00:00:01.000Z'
+        },
+        {
+          id: `${reqId}:resolved`,
+          session_id: 'sess-1',
+          agent_session_id: 'opc-1',
+          thread_id: null,
+          turn_id: null,
+          item_id: null,
+          request_id: reqId,
+          kind: 'plan.resolved',
+          tone: 'info',
+          summary: 'Plan rejected by user',
+          payload_json: JSON.stringify({ resolution: 'rejected' }),
+          sequence: null,
+          created_at: '2024-01-01T00:00:02.000Z'
+        }
+      ])
+
+      const result = getSessionTimeline('sess-1')
+      const planPart = result.messages[0].parts?.find(
+        (p) => p.type === 'tool_use' && p.toolUse?.name === 'ExitPlanMode'
+      )
+      expect(planPart?.toolUse?.status).toBe('success')
+    })
+
+    it('strips text part whose content matches the plan to avoid double-rendering', () => {
+      // Symptom (2026-05-02 test): user saw the plan markdown twice — once as
+      // an assistant text bubble and once as the "Proposed Execution Plan"
+      // approval card. The merge now drops the assistant text part when its
+      // content is fully contained in the plan we're rendering.
+      const planText = '## My Plan\n- step 1\n- step 2'
+      const rawTimeline = [
+        {
+          info: { id: 'msg-plan-2', role: 'assistant', createdAt: '2024-01-01T00:00:00.000Z' },
+          parts: [{ type: 'text', text: planText }]
+        }
+      ]
+      const reqId = 'opencode-plan:sess-1:msg-plan-2'
+      mockGetSession.mockReturnValue(makeSession({ agent_sdk: 'opencode' }))
+      mockGetSessionMessages.mockReturnValue([
+        makeMessageRow({ opencode_timeline_json: JSON.stringify(rawTimeline) })
+      ])
+      mockGetSessionActivities.mockReturnValue([
+        {
+          id: reqId,
+          session_id: 'sess-1',
+          agent_session_id: 'opc-1',
+          thread_id: null,
+          turn_id: null,
+          item_id: 'msg-plan-2',
+          request_id: reqId,
+          kind: 'plan.ready',
+          tone: 'info',
+          summary: 'Plan ready',
+          payload_json: JSON.stringify({ plan: planText, toolUseID: 'msg-plan-2' }),
+          sequence: null,
+          created_at: '2024-01-01T00:00:01.000Z'
+        }
+      ])
+
+      const result = getSessionTimeline('sess-1')
+      const parts = result.messages[0].parts ?? []
+      // No more `text` part — it was duplicated by the plan card and got stripped
+      const textParts = parts.filter((p) => p.type === 'text')
+      expect(textParts).toHaveLength(0)
+      // Plan card is still there
+      const planPart = parts.find(
+        (p) => p.type === 'tool_use' && p.toolUse?.name === 'ExitPlanMode'
+      )
+      expect(planPart?.toolUse?.input).toMatchObject({ plan: planText })
+    })
+
+    it('keeps text part if it does NOT match the plan content (e.g. preamble)', () => {
+      // Defensive: only strip when content is duplicated. A legitimate
+      // pre-plan preamble like "Here is my analysis..." must survive.
+      const planText = '## Plan\n- step 1'
+      const preamble = 'Here is my analysis based on the codebase.'
+      const rawTimeline = [
+        {
+          info: { id: 'msg-plan-3', role: 'assistant', createdAt: '2024-01-01T00:00:00.000Z' },
+          parts: [{ type: 'text', text: preamble }]
+        }
+      ]
+      const reqId = 'opencode-plan:sess-1:msg-plan-3'
+      mockGetSession.mockReturnValue(makeSession({ agent_sdk: 'opencode' }))
+      mockGetSessionMessages.mockReturnValue([
+        makeMessageRow({ opencode_timeline_json: JSON.stringify(rawTimeline) })
+      ])
+      mockGetSessionActivities.mockReturnValue([
+        {
+          id: reqId,
+          session_id: 'sess-1',
+          agent_session_id: 'opc-1',
+          thread_id: null,
+          turn_id: null,
+          item_id: 'msg-plan-3',
+          request_id: reqId,
+          kind: 'plan.ready',
+          tone: 'info',
+          summary: 'Plan ready',
+          payload_json: JSON.stringify({ plan: planText, toolUseID: 'msg-plan-3' }),
+          sequence: null,
+          created_at: '2024-01-01T00:00:01.000Z'
+        }
+      ])
+
+      const result = getSessionTimeline('sess-1')
+      const parts = result.messages[0].parts ?? []
+      const textParts = parts.filter((p) => p.type === 'text')
+      // Preamble survives
+      expect(textParts).toHaveLength(1)
+      expect(textParts[0].text).toBe(preamble)
+      // Plan card still present
+      const planPart = parts.find(
+        (p) => p.type === 'tool_use' && p.toolUse?.name === 'ExitPlanMode'
+      )
+      expect(planPart).toBeDefined()
+    })
   })
 
   describe('codex sessions', () => {
@@ -299,13 +494,23 @@ describe('getSessionTimeline', () => {
       expect(mockGetSessionActivities).toHaveBeenCalledWith('sess-1')
     })
 
-    it('does NOT fetch activities for non-codex sessions', () => {
-      mockGetSession.mockReturnValue(makeSession({ agent_sdk: 'opencode' }))
+    it('does NOT fetch activities for claude-code sessions', () => {
+      mockGetSession.mockReturnValue(makeSession({ agent_sdk: 'claude-code' }))
       mockGetSessionMessages.mockReturnValue([])
 
       getSessionTimeline('sess-1')
 
       expect(mockGetSessionActivities).not.toHaveBeenCalled()
+    })
+
+    it('fetches activities for opencode sessions (plan-card merge, Phase 1.4.8)', () => {
+      mockGetSession.mockReturnValue(makeSession({ agent_sdk: 'opencode' }))
+      mockGetSessionMessages.mockReturnValue([])
+      mockGetSessionActivities.mockReturnValue([])
+
+      getSessionTimeline('sess-1')
+
+      expect(mockGetSessionActivities).toHaveBeenCalledWith('sess-1')
     })
   })
 

--- a/test/phase-5/session-9/opencode-routing.test.ts
+++ b/test/phase-5/session-9/opencode-routing.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, test, vi } from 'vitest'
 const mockDb = {
   getSessionMessageByOpenCodeId: vi.fn(),
   upsertSessionMessageByOpenCodeId: vi.fn(),
+  upsertSessionActivity: vi.fn(),
   updateSession: vi.fn(),
   getWorktreeBySessionId: vi.fn(),
   updateWorktree: vi.fn(),
@@ -20,16 +21,61 @@ vi.mock('../../../src/main/db', () => ({
   getDatabase: () => mockDb
 }))
 
+import { OPENCODE_CAPABILITIES } from '../../../src/main/services/agent-runtime-types'
 import { openCodeService } from '../../../src/main/services/opencode-service'
+
+function createInstance() {
+  return {
+    client: {
+      session: {
+        get: vi.fn().mockResolvedValue({ data: {} })
+      }
+    },
+    server: { url: 'http://localhost', close: vi.fn() },
+    sessionMap: new Map<string, string>([
+      ['/repo/a::opc-session-1', 'hive-session-a'],
+      ['/repo/b::opc-session-1', 'hive-session-b']
+    ]),
+    sessionDirectories: new Map<string, string>(),
+    directorySubscriptions: new Map(),
+    childToParentMap: new Map<string, string>(),
+    toolStartedTrackerByHiveSession: new Map(),
+    titleGenerationStartedByHiveSession: new Map(),
+    userMessageIdsByHiveSession: new Map(),
+    messageBuffersByHiveSession: new Map(),
+    planEmittedByHiveSession: new Map()
+  }
+}
+
+async function invokeHandleEvent(instance: unknown, rawEvent: unknown, directory?: string) {
+  return (
+    openCodeService as never as {
+      handleEvent: (instance: unknown, rawEvent: unknown, directory?: string) => Promise<void>
+    }
+  ).handleEvent(instance, rawEvent, directory)
+}
 
 describe('Session 9: OpenCode session routing', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockDb.getSessionMessageByOpenCodeId.mockReturnValue(null)
     mockDb.getWorktreeBySessionId.mockReturnValue(null)
+    mockDb.getSession.mockReturnValue(null)
+    mockDb.upsertSessionActivity.mockReturnValue(undefined)
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ data: [] }),
+        text: async () => ''
+      })
+    )
   })
 
   test('routes event to correct hive session when opencode session IDs collide across directories', async () => {
+    expect(openCodeService.capabilities).toEqual(OPENCODE_CAPABILITIES)
+    expect(openCodeService.capabilities.supportsSteer).toBe(false)
+
     const send = vi.fn()
 
     openCodeService.setMainWindow({
@@ -37,33 +83,9 @@ describe('Session 9: OpenCode session routing', () => {
       webContents: { send }
     } as never)
 
-    const instance = {
-      client: {
-        session: {
-          get: vi.fn().mockResolvedValue({ data: {} })
-        }
-      },
-      server: { url: 'http://localhost', close: vi.fn() },
-      sessionMap: new Map<string, string>([
-        ['/repo/a::opc-session-1', 'hive-session-a'],
-        ['/repo/b::opc-session-1', 'hive-session-b']
-      ]),
-      sessionDirectories: new Map<string, string>(),
-      directorySubscriptions: new Map(),
-      childToParentMap: new Map<string, string>()
-    }
+    const instance = createInstance()
 
-    await (
-      openCodeService as never as {
-        handleEvent: (
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          instance: any,
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          rawEvent: any,
-          directory?: string
-        ) => Promise<void>
-      }
-    ).handleEvent(
+    await invokeHandleEvent(
       instance,
       {
         data: {
@@ -91,33 +113,9 @@ describe('Session 9: OpenCode session routing', () => {
       webContents: { send }
     } as never)
 
-    const instance = {
-      client: {
-        session: {
-          get: vi.fn().mockResolvedValue({ data: {} })
-        }
-      },
-      server: { url: 'http://localhost', close: vi.fn() },
-      sessionMap: new Map<string, string>([
-        ['/repo/a::opc-session-1', 'hive-session-a'],
-        ['/repo/b::opc-session-1', 'hive-session-b']
-      ]),
-      sessionDirectories: new Map<string, string>(),
-      directorySubscriptions: new Map(),
-      childToParentMap: new Map<string, string>()
-    }
+    const instance = createInstance()
 
-    await (
-      openCodeService as never as {
-        handleEvent: (
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          instance: any,
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          rawEvent: any,
-          directory?: string
-        ) => Promise<void>
-      }
-    ).handleEvent(
+    await invokeHandleEvent(
       instance,
       {
         data: {
@@ -139,5 +137,421 @@ describe('Session 9: OpenCode session routing', () => {
     )
     expect(mockDb.getSessionMessageByOpenCodeId).not.toHaveBeenCalled()
     expect(mockDb.upsertSessionMessageByOpenCodeId).not.toHaveBeenCalled()
+  })
+
+  test('message.updated emits session.context_usage when assistant tokens are present', async () => {
+    const send = vi.fn()
+
+    openCodeService.setMainWindow({
+      isDestroyed: () => false,
+      isFocused: () => true,
+      webContents: { send }
+    } as never)
+
+    const instance = createInstance()
+
+    await invokeHandleEvent(
+      instance,
+      {
+        data: {
+          type: 'message.updated',
+          properties: {
+            sessionID: 'opc-session-1',
+            info: {
+              id: 'msg-ctx-1',
+              sessionID: 'opc-session-1',
+              role: 'assistant',
+              providerID: 'anthropic',
+              modelID: 'claude-opus-4-5-20251101',
+              tokens: {
+                input: 100,
+                output: 50,
+                reasoning: 20,
+                cache: { read: 10, write: 5 }
+              }
+            }
+          }
+        }
+      },
+      '/repo/b'
+    )
+
+    const streamCalls = send.mock.calls.filter((call) => call[0] === 'agent:stream')
+    expect(streamCalls).toEqual(
+      expect.arrayContaining([
+        [
+          'agent:stream',
+          expect.objectContaining({
+            type: 'message.updated',
+            sessionId: 'hive-session-b'
+          })
+        ],
+        [
+          'agent:stream',
+          expect.objectContaining({
+            type: 'session.context_usage',
+            sessionId: 'hive-session-b',
+            data: expect.objectContaining({
+              tokens: {
+                input: 100,
+                output: 50,
+                reasoning: 20,
+                cacheRead: 10,
+                cacheWrite: 5
+              },
+              model: {
+                providerID: 'anthropic',
+                modelID: 'claude-opus-4-5-20251101'
+              }
+            })
+          })
+        ]
+      ])
+    )
+  })
+
+  test('message.part.updated compaction emits session.compaction_started', async () => {
+    const send = vi.fn()
+
+    openCodeService.setMainWindow({
+      isDestroyed: () => false,
+      isFocused: () => true,
+      webContents: { send }
+    } as never)
+
+    const instance = createInstance()
+
+    await invokeHandleEvent(
+      instance,
+      {
+        data: {
+          type: 'message.part.updated',
+          properties: {
+            part: {
+              id: 'cmp-1',
+              sessionID: 'opc-session-1',
+              messageID: 'msg-1',
+              type: 'compaction',
+              auto: true
+            }
+          }
+        }
+      },
+      '/repo/b'
+    )
+
+    expect(send).toHaveBeenCalledWith(
+      'agent:stream',
+      expect.objectContaining({
+        type: 'session.compaction_started',
+        sessionId: 'hive-session-b',
+        data: { auto: true }
+      })
+    )
+  })
+
+  test('session.compacted emits session.context_compacted', async () => {
+    const send = vi.fn()
+
+    openCodeService.setMainWindow({
+      isDestroyed: () => false,
+      isFocused: () => true,
+      webContents: { send }
+    } as never)
+
+    const instance = createInstance()
+
+    await invokeHandleEvent(
+      instance,
+      {
+        data: {
+          type: 'session.compacted',
+          properties: {
+            sessionID: 'opc-session-1'
+          }
+        }
+      },
+      '/repo/b'
+    )
+
+    expect(send).toHaveBeenCalledWith(
+      'agent:stream',
+      expect.objectContaining({
+        type: 'session.context_compacted',
+        sessionId: 'hive-session-b'
+      })
+    )
+  })
+
+  test('tracks and clears pending question / approval ownership by request id', async () => {
+    const instance = createInstance()
+
+    await invokeHandleEvent(
+      instance,
+      {
+        data: {
+          type: 'question.asked',
+          properties: { id: 'q-1', requestId: 'q-1', sessionID: 'opc-session-1' }
+        }
+      },
+      '/repo/b'
+    )
+    await invokeHandleEvent(
+      instance,
+      {
+        data: {
+          type: 'permission.asked',
+          properties: { id: 'perm-1', sessionID: 'opc-session-1' }
+        }
+      },
+      '/repo/b'
+    )
+    await invokeHandleEvent(
+      instance,
+      {
+        data: {
+          type: 'command.approval_needed',
+          properties: { requestId: 'cmd-1', sessionID: 'opc-session-1' }
+        }
+      },
+      '/repo/b'
+    )
+
+    expect(openCodeService.hasPendingQuestion?.('q-1')).toBe(true)
+    expect(openCodeService.hasPendingApproval?.('perm-1')).toBe(true)
+    expect(openCodeService.hasPendingApproval?.('cmd-1')).toBe(true)
+
+    await openCodeService.questionReply('q-1', [['ok']], '/repo/b')
+    await openCodeService.permissionReply('perm-1', 'once', '/repo/b')
+    await openCodeService.permissionReply('cmd-1', 'reject', '/repo/b')
+
+    expect(openCodeService.hasPendingQuestion?.('q-1')).toBe(false)
+    expect(openCodeService.hasPendingApproval?.('perm-1')).toBe(false)
+    expect(openCodeService.hasPendingApproval?.('cmd-1')).toBe(false)
+  })
+
+  test('abort flushes latest assistant snapshot and forces idle status', async () => {
+    const send = vi.fn()
+    openCodeService.setMainWindow({
+      isDestroyed: () => false,
+      isFocused: () => true,
+      webContents: { send }
+    } as never)
+
+    const instance = createInstance()
+    instance.client.session.abort = vi.fn().mockResolvedValue({ data: true })
+    instance.client.session.messages = vi.fn().mockResolvedValue({
+      data: [
+        {
+          info: {
+            id: 'assistant-1',
+            sessionID: 'opc-session-1',
+            role: 'assistant'
+          },
+          parts: [{ type: 'text', text: 'partial answer' }]
+        }
+      ]
+    })
+
+    ;(openCodeService as never as { instance: unknown }).instance = instance
+
+    const ok = await openCodeService.abort('/repo/b', 'opc-session-1')
+
+    expect(ok).toBe(true)
+    expect(send).toHaveBeenCalledWith(
+      'agent:stream',
+      expect.objectContaining({ type: 'message.updated', sessionId: 'hive-session-b' })
+    )
+    expect(send).toHaveBeenCalledWith(
+      'agent:stream',
+      expect.objectContaining({
+        type: 'session.status',
+        sessionId: 'hive-session-b',
+        statusPayload: { type: 'idle' }
+      })
+    )
+  })
+
+  test('plan-mode assistant turn end synthesizes a plan.ready event', async () => {
+    const send = vi.fn()
+    openCodeService.setMainWindow({
+      isDestroyed: () => false,
+      isFocused: () => true,
+      webContents: { send }
+    } as never)
+
+    const instance = createInstance()
+    ;(openCodeService as never as { instance: unknown }).instance = instance
+
+    // First: a part with the plan markdown (so the buffer has the text)
+    await invokeHandleEvent(
+      instance,
+      {
+        data: {
+          type: 'message.part.updated',
+          properties: {
+            sessionID: 'opc-session-1',
+            part: {
+              type: 'text',
+              id: 'prt-plan-text-1',
+              messageID: 'msg-plan-1',
+              text: '## Plan\n- step 1\n- step 2'
+            }
+          }
+        }
+      },
+      '/repo/b'
+    )
+
+    // Then: message.updated with finish:stop / agent:plan completes the turn
+    await invokeHandleEvent(
+      instance,
+      {
+        data: {
+          type: 'message.updated',
+          properties: {
+            sessionID: 'opc-session-1',
+            info: {
+              id: 'msg-plan-1',
+              sessionID: 'opc-session-1',
+              role: 'assistant',
+              agent: 'plan',
+              mode: 'plan',
+              finish: 'stop',
+              time: { created: 1000, completed: 2000 }
+            }
+          }
+        }
+      },
+      '/repo/b'
+    )
+
+    const planReadyCall = send.mock.calls.find(
+      (call) => call[0] === 'agent:stream' && call[1]?.type === 'plan.ready'
+    )
+    expect(planReadyCall).toBeDefined()
+    expect(planReadyCall![1]).toMatchObject({
+      type: 'plan.ready',
+      sessionId: 'hive-session-b',
+      data: {
+        plan: '## Plan\n- step 1\n- step 2',
+        toolUseID: 'msg-plan-1'
+      }
+    })
+    // requestId is stable + namespaced so multiple plans don't collide
+    expect(planReadyCall![1].data.requestId).toBe(
+      'opencode-plan:hive-session-b:msg-plan-1'
+    )
+
+    // The matching `plan.ready` SessionActivity row must also be persisted —
+    // PlanCard rendering in the durable timeline goes through
+    // parsePlanPartFromActivity, which only sees activity rows. Without this
+    // row the FAB pops up but no card appears in the message stream.
+    const planActivityCall = mockDb.upsertSessionActivity.mock.calls.find(
+      (call) => call[0]?.kind === 'plan.ready'
+    )
+    expect(planActivityCall).toBeDefined()
+    expect(planActivityCall![0]).toMatchObject({
+      id: 'opencode-plan:hive-session-b:msg-plan-1',
+      session_id: 'hive-session-b',
+      agent_session_id: 'opc-session-1',
+      kind: 'plan.ready',
+      tone: 'info',
+      request_id: 'opencode-plan:hive-session-b:msg-plan-1',
+      item_id: 'msg-plan-1'
+    })
+    const persistedPayload = JSON.parse(planActivityCall![0].payload_json as string)
+    expect(persistedPayload).toMatchObject({
+      plan: '## Plan\n- step 1\n- step 2',
+      toolUseID: 'msg-plan-1',
+      requestId: 'opencode-plan:hive-session-b:msg-plan-1'
+    })
+
+    // Idempotent: a re-emitted message.updated for the same id should NOT fire
+    // a second plan.ready (the renderer guards on requestId, but defense in depth).
+    send.mockClear()
+    await invokeHandleEvent(
+      instance,
+      {
+        data: {
+          type: 'message.updated',
+          properties: {
+            sessionID: 'opc-session-1',
+            info: {
+              id: 'msg-plan-1',
+              sessionID: 'opc-session-1',
+              role: 'assistant',
+              agent: 'plan',
+              mode: 'plan',
+              finish: 'stop',
+              time: { created: 1000, completed: 2000 }
+            }
+          }
+        }
+      },
+      '/repo/b'
+    )
+    const repeated = send.mock.calls.find(
+      (call) => call[0] === 'agent:stream' && call[1]?.type === 'plan.ready'
+    )
+    expect(repeated).toBeUndefined()
+  })
+
+  test('non-plan agent turn does NOT synthesize plan.ready', async () => {
+    const send = vi.fn()
+    openCodeService.setMainWindow({
+      isDestroyed: () => false,
+      isFocused: () => true,
+      webContents: { send }
+    } as never)
+
+    const instance = createInstance()
+    ;(openCodeService as never as { instance: unknown }).instance = instance
+
+    await invokeHandleEvent(
+      instance,
+      {
+        data: {
+          type: 'message.part.updated',
+          properties: {
+            sessionID: 'opc-session-1',
+            part: {
+              type: 'text',
+              id: 'prt-build-text-1',
+              messageID: 'msg-build-1',
+              text: 'Done.'
+            }
+          }
+        }
+      },
+      '/repo/b'
+    )
+
+    await invokeHandleEvent(
+      instance,
+      {
+        data: {
+          type: 'message.updated',
+          properties: {
+            sessionID: 'opc-session-1',
+            info: {
+              id: 'msg-build-1',
+              sessionID: 'opc-session-1',
+              role: 'assistant',
+              agent: 'build',
+              mode: 'build',
+              finish: 'stop',
+              time: { created: 1000, completed: 2000 }
+            }
+          }
+        }
+      },
+      '/repo/b'
+    )
+
+    const planReadyCall = send.mock.calls.find(
+      (call) => call[0] === 'agent:stream' && call[1]?.type === 'plan.ready'
+    )
+    expect(planReadyCall).toBeUndefined()
   })
 })


### PR DESCRIPTION
## Summary

1.4.4 让 Codex 在 Xuanpu 内基本追平 Claude Code，本 PR 把同一套对齐配方应用到 **OpenCode**。三条主线一次性补齐：

- **工具名规范化**：OpenCode SDK 的小写原名（bash/read/edit/grep/...）→ `CanonicalToolName`（Bash/Read/Edit/Grep/...），让 ToolCard 走通用渲染路径，履行 `agent-protocol.ts` 的类型契约。
- **Activity 持久化**：OpenCode 的 `message.part.updated` / `session.idle` / `session.error` / `question.asked` / `permission.asked` / `command.approval_needed` 持久化为 `SessionActivity`，与 Codex 历史回放体验对齐。
- **会话标题生成**：首次用户消息后异步生成有意义的会话标题（GPT-5.4 引擎，复用 codex 已有 generator），仅在 DB title 仍为 placeholder 时覆盖，并同步到 OpenCode server 端。

## 实现要点

### 新建文件

| 文件 | 职责 |
| --- | --- |
| `src/shared/lib/opencode-classify.ts` | OpenCode tool 名 → CanonicalToolName 分类器 |
| `src/main/services/opencode-activity-mapper.ts` | OpenCode 事件 → SessionActivityCreate（含 per-session toolStartedTracker） |
| `src/main/services/opencode-session-title.ts` | 标题生成入口（lazy-import codex-session-title 复用 GPT-5.4） + 纯函数 helpers |

### 修改文件

| 文件 | 改动 |
| --- | --- |
| `src/main/services/opencode-service.ts` | OpenCodeInstance 加 toolStartedTrackerByHiveSession + titleGenerationStartedByHiveSession；handleEvent emit 边界 canonicalize part.tool；handleEvent 调用 persistOpenCodeActivity；prompt() 首消息后触发 maybeStartTitleGeneration；disconnect/cleanup 同步清理 |

### 关键设计决策

1. **类型契约对齐 + UI 安全网**：classifier 仅在 emit 边界改写 part.tool，不动 `timeline-mappers.ts`，避免误伤 claude-code 的 `mcp__hive-lsp__lsp` 等专门 ToolCard entry。老 DB 数据继续走 ToolCard 现有 case-insensitive fallback。
2. **Activity Mapper 不引入持久化失败传染**：`persistOpenCodeActivity` 全程 try/catch，落库失败仅 log，不影响事件流。
3. **Title 不与 OpenCode 服务器抢权**：仅在当前 DB title 是 placeholder（`Session N` / `New Session 2026-...`）时应用我们生成的标题；OpenCode 自身后续的 `session.updated` title 仍可覆盖。
4. **Title 生成 Lazy import**：`opencode-session-title.ts` 通过 dynamic import 隔离 codex-session-title → codex-app-server-manager → logger（依赖 Electron）的链路，让纯函数 helpers 在 jsdom workspace 也可单测。

## Test plan

新增单测 **51 个**全过：
- [x] `test/opencode-classify.test.ts` (24 cases，native / case-insensitive / MCP / edge)
- [x] `test/phase-21/opencode-activity-mapper.test.ts` (18 cases，tool lifecycle / session / HITL / payload)
- [x] `test/phase-21/opencode-session-title.test.ts` (9 cases，placeholder 检测 / 文本提取)

冒烟回归：
- [x] `test/phase-21/session-11/{opencode,codex}-canonical-routing.test.ts` 仍通过（15 tests），未破坏既有 OpenCode/Codex 路由
- [x] `pnpm lint` — 0 errors（新增文件零 warning）

待手动验证（合入后跑 `pnpm dev`）：
- [ ] OpenCode 会话发 prompt 触发 bash / read / edit / grep / mcp 工具，ToolCard 正确渲染（PR-A1）
- [ ] 关掉 worktree 再开，会话历史完整回放（PR-A2）
- [ ] 第一条 prompt 后会话标题在数秒内变成有意义短语（PR-A3）
- [ ] Codex / Claude Code 会话不退化

🤖 Generated with [Claude Code](https://claude.com/claude-code)