### PR TITLE
feat(onboarding): 单页 wizard + keymap 预设 + VS Code/Cursor 导入

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -39,6 +39,10 @@ import {
   openCommandInSystemTerminal,
   runOnboardingDoctor
 } from './services/onboarding-doctor'
+import {
+  detectImportSources,
+  parseImportSource
+} from './services/keybinding-import'
 import { createResponseLog, appendResponseLog } from './services/response-logger'
 import { notificationService } from './services/notification-service'
 import { updaterService } from './services/updater'
@@ -472,6 +476,17 @@ function registerSystemHandlers(): void {
   ipcMain.handle('system:runOnboardingDoctor', () => {
     return runOnboardingDoctor()
   })
+
+  ipcMain.handle('system:detectKeybindingImportSources', () => {
+    return detectImportSources()
+  })
+
+  ipcMain.handle(
+    'system:parseKeybindingImportSource',
+    async (_event, source: 'vscode' | 'cursor') => {
+      return parseImportSource(source)
+    }
+  )
 
   ipcMain.handle(
     'system:openCommandInTerminal',

--- a/src/main/services/keybinding-import.ts
+++ b/src/main/services/keybinding-import.ts
@@ -1,0 +1,346 @@
+import * as fs from 'node:fs/promises'
+import * as path from 'node:path'
+import * as os from 'node:os'
+
+import { createLogger } from './logger'
+import type {
+  KeybindingImportBinding,
+  KeybindingImportEntry,
+  KeybindingImportResult,
+  KeybindingImportSourceId,
+  KeybindingImportSourceInfo,
+  KeybindingModifier
+} from '@shared/types/keybinding-import'
+
+const log = createLogger({ component: 'KeybindingImport' })
+
+// ============================================================================
+// Mapping: VS Code / Cursor command ID  →  Xuanpu shortcut id.
+//
+// We intentionally only map app-level shortcuts that have a direct Xuanpu
+// counterpart. Editor-internal commands (cursorMove, etc.) are out of scope
+// and will land in `unmapped` so the user understands why they were skipped.
+// ============================================================================
+
+export const VSCODE_COMMAND_TO_SHORTCUT: Record<string, string> = {
+  // Navigation
+  'workbench.action.showCommands': 'nav:command-palette',
+  'workbench.action.quickOpen': 'nav:file-search',
+  'workbench.action.openRecent': 'nav:session-history',
+
+  // Sidebars
+  'workbench.action.toggleSidebarVisibility': 'sidebar:toggle-left',
+  'workbench.action.toggleAuxiliaryBar': 'sidebar:toggle-right',
+  'workbench.action.focusFirstEditorGroup': 'focus:main-pane',
+  'workbench.action.focusSideBar': 'focus:left-sidebar',
+
+  // Terminal
+  'workbench.action.terminal.new': 'terminal:new-tab',
+  'workbench.action.terminal.kill': 'terminal:close-tab',
+  'workbench.action.terminal.focusNext': 'terminal:next-tab',
+  'workbench.action.terminal.focusPrevious': 'terminal:prev-tab',
+
+  // Git (VS Code's Source Control panel)
+  'workbench.scm.focus': 'git:commit',
+  'git.commit': 'git:commit',
+  'git.commitStaged': 'git:commit',
+  'git.push': 'git:push',
+  'git.pull': 'git:pull',
+
+  // Settings
+  'workbench.action.openSettings': 'settings:open',
+  'workbench.action.openSettingsJson': 'settings:open'
+}
+
+// ============================================================================
+// Source path resolution
+// ============================================================================
+
+function getKeybindingsPath(
+  source: KeybindingImportSourceId,
+  platform: NodeJS.Platform = process.platform
+): string {
+  const home = os.homedir()
+  const folder = source === 'vscode' ? 'Code' : 'Cursor'
+
+  if (platform === 'darwin') {
+    return path.join(home, 'Library', 'Application Support', folder, 'User', 'keybindings.json')
+  }
+  if (platform === 'win32') {
+    const appData = process.env.APPDATA || path.join(home, 'AppData', 'Roaming')
+    return path.join(appData, folder, 'User', 'keybindings.json')
+  }
+  // linux + everything else
+  return path.join(home, '.config', folder, 'User', 'keybindings.json')
+}
+
+export async function detectImportSources(): Promise<KeybindingImportSourceInfo[]> {
+  const sources: KeybindingImportSourceId[] = ['vscode', 'cursor']
+  const platform = process.platform
+
+  return Promise.all(
+    sources.map(async (id) => {
+      const filepath = getKeybindingsPath(id, platform)
+      let exists = false
+      try {
+        await fs.access(filepath)
+        exists = true
+      } catch {
+        // not present
+      }
+      return {
+        id,
+        path: filepath,
+        exists,
+        available: exists
+      }
+    })
+  )
+}
+
+// ============================================================================
+// JSONC parser — VS Code allows // comments, slash-star block comments, and
+// trailing commas in keybindings.json / settings.json.
+// ============================================================================
+
+/**
+ * Strip `//` line comments and slash-star block comments while preserving
+ * string literals (so a `// not a comment` substring inside quotes survives).
+ */
+export function stripJsonc(input: string): string {
+  let out = ''
+  let i = 0
+  let inString = false
+  let stringQuote = ''
+  let inLineComment = false
+  let inBlockComment = false
+
+  while (i < input.length) {
+    const ch = input[i]
+    const next = input[i + 1]
+
+    if (inLineComment) {
+      if (ch === '\n') {
+        inLineComment = false
+        out += ch
+      }
+      i++
+      continue
+    }
+    if (inBlockComment) {
+      if (ch === '*' && next === '/') {
+        inBlockComment = false
+        i += 2
+      } else {
+        i++
+      }
+      continue
+    }
+    if (inString) {
+      if (ch === '\\') {
+        out += ch
+        if (next !== undefined) out += next
+        i += 2
+        continue
+      }
+      if (ch === stringQuote) {
+        inString = false
+      }
+      out += ch
+      i++
+      continue
+    }
+
+    if (ch === '"') {
+      inString = true
+      stringQuote = ch
+      out += ch
+      i++
+      continue
+    }
+    if (ch === '/' && next === '/') {
+      inLineComment = true
+      i += 2
+      continue
+    }
+    if (ch === '/' && next === '*') {
+      inBlockComment = true
+      i += 2
+      continue
+    }
+    out += ch
+    i++
+  }
+  return out
+}
+
+/** Strip trailing commas before `]` or `}` (legal in JSONC, illegal in JSON). */
+export function stripTrailingCommas(input: string): string {
+  return input.replace(/,(\s*[}\]])/g, '$1')
+}
+
+// ============================================================================
+// Key-string parser — normalize "cmd+shift+p" into our KeyBinding shape.
+// ============================================================================
+
+const KEY_NAME_OVERRIDES: Record<string, string> = {
+  enter: 'Enter',
+  return: 'Enter',
+  tab: 'Tab',
+  escape: 'Escape',
+  esc: 'Escape',
+  space: ' ',
+  backspace: 'Backspace',
+  delete: 'Delete',
+  up: 'ArrowUp',
+  down: 'ArrowDown',
+  left: 'ArrowLeft',
+  right: 'ArrowRight',
+  home: 'Home',
+  end: 'End',
+  pageup: 'PageUp',
+  pagedown: 'PageDown'
+}
+
+export function parseKeyString(keyString: string): KeybindingImportBinding | null {
+  if (!keyString) return null
+  // VS Code allows chord shortcuts: "ctrl+k ctrl+s". We only honor the first
+  // chord — Xuanpu doesn't support chord bindings yet, and silently dropping
+  // the second half is friendlier than refusing the whole import.
+  const firstChord = keyString.split(/\s+/)[0]?.trim()
+  if (!firstChord) return null
+
+  const parts = firstChord
+    .toLowerCase()
+    .split('+')
+    .map((p) => p.trim())
+    .filter(Boolean)
+  if (parts.length === 0) return null
+
+  const modifiers: KeybindingModifier[] = []
+  let key: string | null = null
+
+  for (const part of parts) {
+    if (part === 'cmd' || part === 'meta' || part === 'win' || part === 'super') {
+      if (!modifiers.includes('meta')) modifiers.push('meta')
+    } else if (part === 'ctrl' || part === 'control') {
+      if (!modifiers.includes('ctrl')) modifiers.push('ctrl')
+    } else if (part === 'alt' || part === 'option' || part === 'opt') {
+      if (!modifiers.includes('alt')) modifiers.push('alt')
+    } else if (part === 'shift') {
+      if (!modifiers.includes('shift')) modifiers.push('shift')
+    } else {
+      key = part
+    }
+  }
+
+  if (!key) return null
+
+  // Normalize special keys to the names `event.key` would produce at runtime.
+  const overridden = KEY_NAME_OVERRIDES[key]
+  if (overridden) key = overridden
+
+  return { key, modifiers }
+}
+
+// ============================================================================
+// Top-level parse — read keybindings.json, map, and return entries.
+// ============================================================================
+
+interface RawKeybinding {
+  key?: string
+  command?: string
+  when?: string
+}
+
+export async function parseImportSource(
+  source: KeybindingImportSourceId
+): Promise<KeybindingImportResult> {
+  const filepath = getKeybindingsPath(source)
+  const result: KeybindingImportResult = {
+    source,
+    path: filepath,
+    parsedRows: 0,
+    entries: [],
+    unmapped: [],
+    contextScoped: 0,
+    errors: []
+  }
+
+  let raw: string
+  try {
+    raw = await fs.readFile(filepath, 'utf-8')
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    log.warn(`Failed to read ${filepath}: ${message}`)
+    result.errors.push(`Failed to read ${filepath}: ${message}`)
+    return result
+  }
+
+  let parsed: unknown
+  try {
+    const cleaned = stripTrailingCommas(stripJsonc(raw))
+    parsed = JSON.parse(cleaned)
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    log.warn(`JSONC parse error in ${filepath}: ${message}`)
+    result.errors.push(`Could not parse keybindings.json: ${message}`)
+    return result
+  }
+
+  if (!Array.isArray(parsed)) {
+    result.errors.push('keybindings.json is not a JSON array')
+    return result
+  }
+
+  result.parsedRows = parsed.length
+  const unmappedSet = new Set<string>()
+
+  for (const item of parsed as RawKeybinding[]) {
+    if (!item || typeof item !== 'object') continue
+    if (!item.command || !item.key) continue
+
+    // VS Code uses "-command" prefix to delete a default binding. We have no
+    // notion of un-binding (we only set custom overrides), so skip these.
+    if (item.command.startsWith('-')) continue
+
+    const shortcutId = VSCODE_COMMAND_TO_SHORTCUT[item.command]
+    if (!shortcutId) {
+      unmappedSet.add(item.command)
+      continue
+    }
+
+    // `when` clauses scope a binding to a specific UI context (editor focus,
+    // terminal focus, etc.). Xuanpu shortcuts are global, so honoring them
+    // would silently change behavior — skip and surface the count.
+    if (item.when) {
+      result.contextScoped++
+      continue
+    }
+
+    const binding = parseKeyString(item.key)
+    if (!binding) {
+      result.errors.push(`Could not parse key "${item.key}" for ${item.command}`)
+      continue
+    }
+
+    result.entries.push({
+      shortcutId,
+      binding,
+      sourceCommand: item.command,
+      sourceKey: item.key
+    })
+  }
+
+  // Deduplicate entries by shortcutId — if the user customized the same
+  // command twice in their keybindings.json, the *last* one wins (matches
+  // VS Code's own resolution order).
+  const finalById = new Map<string, KeybindingImportEntry>()
+  for (const entry of result.entries) {
+    finalById.set(entry.shortcutId, entry)
+  }
+  result.entries = Array.from(finalById.values())
+  result.unmapped = Array.from(unmappedSet).sort()
+
+  return result
+}

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -500,6 +500,30 @@ declare global {
       setKeepAwakeEnabled: (enabled: boolean) => Promise<{ success: boolean }>
       setSessionQueuedState: (sessionId: string, queued: boolean) => Promise<{ success: boolean }>
       runOnboardingDoctor: () => Promise<OnboardingDoctorResult>
+      detectKeybindingImportSources: () => Promise<
+        Array<{
+          id: 'vscode' | 'cursor'
+          path: string
+          exists: boolean
+          available: boolean
+        }>
+      >
+      parseKeybindingImportSource: (
+        source: 'vscode' | 'cursor'
+      ) => Promise<{
+        source: 'vscode' | 'cursor'
+        path: string
+        parsedRows: number
+        entries: Array<{
+          shortcutId: string
+          binding: { key: string; modifiers: Array<'ctrl' | 'meta' | 'alt' | 'shift'> }
+          sourceCommand: string
+          sourceKey: string
+        }>
+        unmapped: string[]
+        contextScoped: number
+        errors: string[]
+      }>
       checkFullDiskAccess: (force?: boolean) => Promise<{ supported: boolean; granted: boolean }>
       openFullDiskAccessSettings: () => Promise<{ success: boolean; error?: string }>
       openCommandInTerminal: (

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -454,6 +454,34 @@ const systemOps = {
   runOnboardingDoctor: (): Promise<OnboardingDoctorResult> =>
     ipcRenderer.invoke('system:runOnboardingDoctor'),
 
+  // Detect available VS Code / Cursor keybindings.json files for import
+  detectKeybindingImportSources: (): Promise<
+    Array<{
+      id: 'vscode' | 'cursor'
+      path: string
+      exists: boolean
+      available: boolean
+    }>
+  > => ipcRenderer.invoke('system:detectKeybindingImportSources'),
+
+  // Parse a VS Code / Cursor keybindings.json into Xuanpu shortcut entries
+  parseKeybindingImportSource: (
+    source: 'vscode' | 'cursor'
+  ): Promise<{
+    source: 'vscode' | 'cursor'
+    path: string
+    parsedRows: number
+    entries: Array<{
+      shortcutId: string
+      binding: { key: string; modifiers: Array<'ctrl' | 'meta' | 'alt' | 'shift'> }
+      sourceCommand: string
+      sourceKey: string
+    }>
+    unmapped: string[]
+    contextScoped: number
+    errors: string[]
+  }> => ipcRenderer.invoke('system:parseKeybindingImportSource', source),
+
   checkFullDiskAccess: (force?: boolean): Promise<{ supported: boolean; granted: boolean }> =>
     ipcRenderer.invoke('system:checkFullDiskAccess', force ?? false),
 

--- a/src/renderer/src/components/settings/SettingsGeneral.tsx
+++ b/src/renderer/src/components/settings/SettingsGeneral.tsx
@@ -1,6 +1,6 @@
 import { useThemeStore } from '@/stores/useThemeStore'
 import { useSettingsStore } from '@/stores/useSettingsStore'
-import { RotateCcw } from 'lucide-react'
+import { RotateCcw, Sparkles } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
 import { useShortcutStore } from '@/stores/useShortcutStore'
@@ -35,6 +35,11 @@ export function SettingsGeneral(): React.JSX.Element {
     resetShortcuts()
     setTheme(DEFAULT_THEME_ID)
     toast.success(t('settings.general.resetAll.success'))
+  }
+
+  const handleReopenOnboarding = (): void => {
+    updateSetting('initialSetupComplete', false)
+    toast.success(t('settings.general.reopenOnboarding.toast'))
   }
 
   return (
@@ -422,6 +427,29 @@ export function SettingsGeneral(): React.JSX.Element {
               )}
             />
           </button>
+        </div>
+      </div>
+
+      {/* Reopen welcome wizard */}
+      <div className="pt-4 border-t">
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0">
+            <div className="text-sm font-medium">
+              {t('settings.general.reopenOnboarding.label')}
+            </div>
+            <p className="mt-0.5 text-xs text-muted-foreground">
+              {t('settings.general.reopenOnboarding.description')}
+            </p>
+          </div>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={handleReopenOnboarding}
+            data-testid="reopen-onboarding"
+          >
+            <Sparkles className="h-3.5 w-3.5 mr-1.5" />
+            {t('settings.general.reopenOnboarding.button')}
+          </Button>
         </div>
       </div>
 

--- a/src/renderer/src/components/settings/SettingsShortcuts.tsx
+++ b/src/renderer/src/components/settings/SettingsShortcuts.tsx
@@ -1,17 +1,20 @@
-import { useState, useCallback } from 'react'
+import { useState, useCallback, useEffect } from 'react'
 import { useShortcutStore } from '@/stores/useShortcutStore'
 import {
   DEFAULT_SHORTCUTS,
+  KEYMAP_PRESETS,
+  KEYMAP_PRESET_ORDER,
   shortcutCategoryLabels,
   shortcutCategoryOrder,
   formatBinding,
   type KeyBinding,
+  type KeymapPresetId,
   type ModifierKey,
   type ShortcutCategory,
   getShortcutsByCategory
 } from '@/lib/keyboard-shortcuts'
 import { Button } from '@/components/ui/button'
-import { RotateCcw, AlertTriangle } from 'lucide-react'
+import { Check, Download, Loader2, RotateCcw, AlertTriangle } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { toast } from '@/lib/toast'
 import { useI18n } from '@/i18n/useI18n'
@@ -19,6 +22,8 @@ import { useI18n } from '@/i18n/useI18n'
 export function SettingsShortcuts(): React.JSX.Element {
   const {
     customBindings,
+    activePreset,
+    setActivePreset,
     setCustomBinding,
     removeCustomBinding,
     resetToDefaults,
@@ -83,6 +88,29 @@ export function SettingsShortcuts(): React.JSX.Element {
     toast.success(t('settings.shortcuts.resetAllSuccess'))
   }
 
+  const handleSelectPreset = (id: KeymapPresetId): void => {
+    if (id === activePreset) return
+    const { customCollisions } = setActivePreset(id)
+    const presetLabel = t(KEYMAP_PRESETS[id].labelKey)
+    if (customCollisions.length === 0) {
+      toast.success(t('onboardingWizard.keymap.toast.switched', { preset: presetLabel }))
+    } else {
+      toast.warning(
+        t('onboardingWizard.keymap.toast.conflicts', {
+          preset: presetLabel,
+          count: customCollisions.length
+        })
+      )
+    }
+  }
+
+  // Count of custom bindings that are masking the active preset's overrides on
+  // the same shortcut id. Surfaced as a "FYI" line under the preset chips.
+  const customOverridingCount = Object.keys(customBindings).filter((id) => {
+    const presetBinding = KEYMAP_PRESETS[activePreset]?.overrides[id]
+    return presetBinding !== undefined
+  }).length
+
   return (
     <div className="space-y-6" onKeyDown={handleKeyDown}>
       <div className="flex items-center justify-between">
@@ -100,6 +128,15 @@ export function SettingsShortcuts(): React.JSX.Element {
           {t('settings.shortcuts.resetAll')}
         </Button>
       </div>
+
+      <PresetSwitcher
+        activePreset={activePreset}
+        onSelect={handleSelectPreset}
+        customOverridingCount={customOverridingCount}
+        t={t}
+      />
+
+      <ImportFromEditorRow />
 
       {conflicts.length > 0 && (
         <div className="flex items-start gap-2 p-3 rounded-md bg-destructive/10 border border-destructive/30 text-sm">
@@ -134,6 +171,212 @@ export function SettingsShortcuts(): React.JSX.Element {
           t={t}
         />
       ))}
+    </div>
+  )
+}
+
+interface PresetSwitcherProps {
+  activePreset: KeymapPresetId
+  onSelect: (id: KeymapPresetId) => void
+  customOverridingCount: number
+  t: (key: string, params?: Record<string, string | number | boolean>) => string
+}
+
+function PresetSwitcher({
+  activePreset,
+  onSelect,
+  customOverridingCount,
+  t
+}: PresetSwitcherProps): React.JSX.Element {
+  return (
+    <div className="rounded-xl border border-border/70 bg-card/40 px-4 py-3">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="min-w-0">
+          <div className="text-sm font-medium text-foreground">
+            {t('settings.shortcuts.preset.label')}
+          </div>
+          <div className="mt-0.5 text-xs leading-5 text-muted-foreground">
+            {t('settings.shortcuts.preset.description')}
+          </div>
+        </div>
+
+        <div className="flex flex-wrap items-center gap-1.5">
+          {KEYMAP_PRESET_ORDER.map((presetId) => {
+            const meta = KEYMAP_PRESETS[presetId]
+            const isActive = presetId === activePreset
+            return (
+              <button
+                key={presetId}
+                type="button"
+                onClick={() => onSelect(presetId)}
+                className={cn(
+                  'inline-flex items-center gap-1 rounded-full border px-3 py-1 text-xs font-medium transition-colors',
+                  isActive
+                    ? 'border-primary/50 bg-primary/10 text-primary'
+                    : 'border-border/70 bg-background text-muted-foreground hover:text-foreground hover:border-border'
+                )}
+              >
+                {isActive && <Check className="h-3 w-3" />}
+                {t(meta.labelKey)}
+              </button>
+            )
+          })}
+        </div>
+      </div>
+
+      {customOverridingCount > 0 && (
+        <div className="mt-2 text-[11px] leading-5 text-muted-foreground">
+          {t('settings.shortcuts.preset.customNotice', { count: customOverridingCount })}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function ImportFromEditorRow(): React.JSX.Element {
+  const { t } = useI18n()
+  const applyImportEntries = useShortcutStore((s) => s.applyImportEntries)
+  const [sources, setSources] = useState<
+    Array<{
+      id: 'vscode' | 'cursor'
+      path: string
+      exists: boolean
+      available: boolean
+    }>
+  >([])
+  const [busySource, setBusySource] = useState<'vscode' | 'cursor' | null>(null)
+  const [loaded, setLoaded] = useState(false)
+
+  useEffect(() => {
+    let cancelled = false
+    void window.systemOps
+      .detectKeybindingImportSources()
+      .then((result) => {
+        if (cancelled) return
+        setSources(result)
+        setLoaded(true)
+      })
+      .catch(() => {
+        if (cancelled) return
+        setLoaded(true)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  const sourceLabels: Record<'vscode' | 'cursor', string> = {
+    vscode: t('onboardingWizard.keymap.importSourceVscode'),
+    cursor: t('onboardingWizard.keymap.importSourceCursor')
+  }
+
+  async function handleImport(sourceId: 'vscode' | 'cursor'): Promise<void> {
+    setBusySource(sourceId)
+    try {
+      const parsed = await window.systemOps.parseKeybindingImportSource(sourceId)
+      const sourceLabel = sourceLabels[sourceId]
+
+      if (parsed.errors.length > 0 && parsed.entries.length === 0) {
+        const message = parsed.errors[0]
+        if (message?.startsWith('Failed to read')) {
+          toast.warning(t('onboardingWizard.keymap.importToast.notFound', { source: sourceLabel }))
+        } else {
+          toast.error(
+            t('onboardingWizard.keymap.importToast.error', {
+              source: sourceLabel,
+              message: message ?? ''
+            })
+          )
+        }
+        return
+      }
+
+      if (parsed.entries.length === 0) {
+        toast.warning(t('onboardingWizard.keymap.importToast.empty', { source: sourceLabel }))
+        return
+      }
+
+      const { applied, conflicts } = applyImportEntries(parsed.entries)
+
+      if (conflicts.length === 0) {
+        toast.success(
+          t('onboardingWizard.keymap.importToast.success', {
+            source: sourceLabel,
+            count: applied
+          })
+        )
+      } else {
+        toast.warning(
+          t('onboardingWizard.keymap.importToast.partial', {
+            source: sourceLabel,
+            applied,
+            skipped: conflicts.length
+          })
+        )
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      toast.error(
+        t('onboardingWizard.keymap.importToast.error', {
+          source: sourceLabels[sourceId],
+          message
+        })
+      )
+    } finally {
+      setBusySource(null)
+    }
+  }
+
+  if (!loaded) return <></>
+
+  const anyAvailable = sources.some((s) => s.available)
+
+  return (
+    <div className="rounded-xl border border-border/70 bg-card/40 px-4 py-3">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="min-w-0">
+          <div className="text-sm font-medium text-foreground">
+            {t('onboardingWizard.keymap.importTitle')}
+          </div>
+          <div className="mt-0.5 text-xs leading-5 text-muted-foreground">
+            {anyAvailable
+              ? t('onboardingWizard.keymap.importDescription')
+              : t('onboardingWizard.keymap.importEmpty')}
+          </div>
+        </div>
+
+        <div className="flex flex-wrap items-center gap-1.5">
+          {sources.map((source) => {
+            const label = sourceLabels[source.id]
+            const isBusy = busySource === source.id
+            const disabled = !source.available || busySource !== null
+            return (
+              <Button
+                key={source.id}
+                size="sm"
+                variant="outline"
+                disabled={disabled}
+                onClick={() => handleImport(source.id)}
+                title={
+                  source.available
+                    ? source.path
+                    : t('onboardingWizard.keymap.importNotFound', { path: source.path })
+                }
+                className="rounded-full"
+              >
+                {isBusy ? (
+                  <Loader2 className="h-3.5 w-3.5 mr-1.5 animate-spin" />
+                ) : (
+                  <Download className="h-3.5 w-3.5 mr-1.5" />
+                )}
+                {isBusy
+                  ? t('onboardingWizard.keymap.importBusy')
+                  : t('onboardingWizard.keymap.importApply', { source: label })}
+              </Button>
+            )
+          })}
+        </div>
+      </div>
     </div>
   )
 }

--- a/src/renderer/src/components/setup/AgentSetupGuard.tsx
+++ b/src/renderer/src/components/setup/AgentSetupGuard.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useState } from 'react'
 import { useSettingsStore } from '@/stores/useSettingsStore'
+import { useShortcutStore } from '@/stores/useShortcutStore'
+import { useThemeStore } from '@/stores/useThemeStore'
 import { AgentSetupWizard } from './AgentSetupWizard'
-
-type WizardAgentId = 'opencode' | 'claude-code' | 'codex' | 'terminal'
 
 export function AgentSetupGuard(): React.JSX.Element | null {
   const initialSetupComplete = useSettingsStore((s) => s.initialSetupComplete)
@@ -49,17 +49,29 @@ export function AgentSetupGuard(): React.JSX.Element | null {
     return null
   }
 
-  function completeSetup(sdk: WizardAgentId): void {
-    updateSetting('defaultAgentSdk', sdk)
+  function completeSetup(): void {
+    // The wizard has already persisted every other choice (default agent,
+    // keymap preset, theme) the moment the user made them. Flipping
+    // `initialSetupComplete` is the only thing left to do here.
     updateSetting('initialSetupComplete', true)
 
+    const settings = useSettingsStore.getState()
+    const shortcuts = useShortcutStore.getState()
+    const theme = useThemeStore.getState()
     const readyAgents = doctorResult?.agents.filter((agent) => agent.selectable).length ?? 0
 
     window.analyticsOps.track('onboarding_completed', {
-      sdk,
+      // Original schema (kept stable for downstream BI)
+      sdk: settings.defaultAgentSdk,
       auto_selected: false,
       wizard: true,
-      ready_agents: readyAgents
+      ready_agents: readyAgents,
+      // Schema v2 additions
+      event_version: 2,
+      default_runtime: settings.defaultAgentSdk,
+      keymap_preset: shortcuts.activePreset,
+      theme_id: theme.themeId,
+      theme_follow_system: theme.followSystem
     })
   }
 

--- a/src/renderer/src/components/setup/AgentSetupWizard.tsx
+++ b/src/renderer/src/components/setup/AgentSetupWizard.tsx
@@ -1,19 +1,21 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useState, useRef } from 'react'
 import type { LucideIcon } from 'lucide-react'
 import {
   AlertTriangle,
-  ArrowRight,
   Bot,
+  Check,
   CheckCircle2,
-  ChevronLeft,
+  ChevronDown,
+  ChevronRight,
   Command,
   Copy,
+  Download,
   ExternalLink,
   GitBranch,
   Hammer,
   Loader2,
+  Monitor,
   Package,
-  Play,
   RefreshCw,
   Sparkles,
   TerminalSquare,
@@ -24,18 +26,29 @@ import { toast } from '@/lib/toast'
 import { useI18n } from '@/i18n/useI18n'
 import { Button } from '@/components/ui/button'
 import { AlertDialog, AlertDialogContent } from '@/components/ui/alert-dialog'
+import { useShortcutStore } from '@/stores/useShortcutStore'
+import { useThemeStore } from '@/stores/useThemeStore'
+import { useSettingsStore } from '@/stores/useSettingsStore'
+import {
+  DEFAULT_SHORTCUTS,
+  KEYMAP_PRESETS,
+  KEYMAP_PRESET_ORDER,
+  type KeyBinding,
+  type KeymapPresetId,
+  type ShortcutCategory
+} from '@/lib/keyboard-shortcuts'
+import { THEME_PRESETS, type ThemePreset } from '@/lib/themes'
 import onboardingBg from '@/assets/onboarding-bg.png'
 import onboardingBgDark from '@/assets/onboarding-bg-dark.png'
 
 type WizardAgentId = 'claude-code' | 'codex' | 'opencode' | 'terminal'
-type WizardStepId = 'environment' | 'agent'
 
 interface AgentSetupWizardProps {
   result: OnboardingDoctorResult | null
   loading: boolean
   error: string | null
   onRefresh: () => void
-  onComplete: (sdk: WizardAgentId) => void
+  onComplete: () => void
 }
 
 interface AgentMeta {
@@ -45,9 +58,9 @@ interface AgentMeta {
   launchCommand?: string
 }
 
-const AGENT_ORDER: WizardAgentId[] = ['claude-code', 'codex', 'opencode', 'terminal']
+const AGENT_ORDER: Exclude<WizardAgentId, 'terminal'>[] = ['claude-code', 'codex', 'opencode']
 
-const AGENT_META: Record<WizardAgentId, AgentMeta> = {
+const AGENT_META: Record<Exclude<WizardAgentId, 'terminal'>, AgentMeta> = {
   'claude-code': {
     icon: Sparkles,
     docsUrl: 'https://docs.anthropic.com/en/docs/claude-code/getting-started',
@@ -65,34 +78,28 @@ const AGENT_META: Record<WizardAgentId, AgentMeta> = {
     docsUrl: 'https://opencode.ai/docs/',
     installCommand: 'curl -fsSL https://opencode.ai/install | bash',
     launchCommand: 'opencode'
-  },
-  terminal: {
-    icon: TerminalSquare,
-    docsUrl: 'https://github.com/slicenferqin/xuanpu'
   }
 }
+
+const TERMINAL_DOCS_URL = 'https://github.com/slicenferqin/xuanpu'
 
 const ENVIRONMENT_META: Record<
   OnboardingEnvironmentCheck['id'],
   { icon: LucideIcon; titleKey: string }
 > = {
-  git: {
-    icon: GitBranch,
-    titleKey: 'onboardingWizard.environment.git.title'
-  },
-  node: {
-    icon: Command,
-    titleKey: 'onboardingWizard.environment.node.title'
-  },
-  homebrew: {
-    icon: Package,
-    titleKey: 'onboardingWizard.environment.homebrew.title'
-  },
-  'xcode-cli': {
-    icon: Hammer,
-    titleKey: 'onboardingWizard.environment.xcodeCli.title'
-  }
+  git: { icon: GitBranch, titleKey: 'onboardingWizard.environment.git.title' },
+  node: { icon: Command, titleKey: 'onboardingWizard.environment.node.title' },
+  homebrew: { icon: Package, titleKey: 'onboardingWizard.environment.homebrew.title' },
+  'xcode-cli': { icon: Hammer, titleKey: 'onboardingWizard.environment.xcodeCli.title' }
 }
+
+const REFRESH_DELAY_MS = 5_000
+
+// Shortcuts surfaced inline on each preset card to convey "what's different".
+const PRESET_SAMPLE_SHORTCUTS: Array<{ id: string; labelKey: string }> = [
+  { id: 'nav:command-palette', labelKey: 'onboardingWizard.keymap.samples.commandPalette' },
+  { id: 'nav:file-search', labelKey: 'onboardingWizard.keymap.samples.fileSearch' }
+]
 
 export function AgentSetupWizard({
   result,
@@ -102,62 +109,83 @@ export function AgentSetupWizard({
   onComplete
 }: AgentSetupWizardProps): React.JSX.Element {
   const { t } = useI18n()
-  const [currentStep, setCurrentStep] = useState<WizardStepId>('environment')
-  const [focusedAgentId, setFocusedAgentId] = useState<WizardAgentId>('claude-code')
-  const [selectedAgentId, setSelectedAgentId] = useState<WizardAgentId | null>(null)
+
+  const defaultAgentSdk = useSettingsStore((s) => s.defaultAgentSdk)
+  const updateSetting = useSettingsStore((s) => s.updateSetting)
+
+  const activePreset = useShortcutStore((s) => s.activePreset)
+  const setActivePreset = useShortcutStore((s) => s.setActivePreset)
+
+  const themeId = useThemeStore((s) => s.themeId)
+  const followSystem = useThemeStore((s) => s.followSystem)
+  const setTheme = useThemeStore((s) => s.setTheme)
+  const setFollowSystem = useThemeStore((s) => s.setFollowSystem)
+  const previewTheme = useThemeStore((s) => s.previewTheme)
+  const cancelPreview = useThemeStore((s) => s.cancelPreview)
+
   const [busyAction, setBusyAction] = useState<string | null>(null)
+  const [environmentExpanded, setEnvironmentExpanded] = useState(false)
+  const refreshTimerRef = useRef<number | null>(null)
 
   const agentsById = useMemo(() => {
     return new Map((result?.agents ?? []).map((agent) => [agent.id, agent]))
   }, [result])
 
-  useEffect(() => {
-    if (!result) return
-
-    const firstSelectable =
-      AGENT_ORDER.find(
-        (id) =>
-          id !== 'terminal' &&
-          agentsById.get(id as Exclude<WizardAgentId, 'terminal'>)?.selectable === true
-      ) ?? null
-
-    setFocusedAgentId((current) => {
-      if (current === 'terminal') return current
-      if (agentsById.has(current)) return current
-      return result.recommendedAgent
-    })
-
-    setSelectedAgentId((current) => {
-      if (current === 'terminal') return current
-      if (current && current !== 'terminal' && agentsById.get(current)?.selectable) {
-        return current
-      }
-      return firstSelectable
-    })
-  }, [agentsById, result])
-
   const environmentChecks = result?.environmentChecks ?? []
   const environmentIssues = environmentChecks.filter((item) => item.status !== 'ready')
 
-  const canStart =
-    selectedAgentId === 'terminal' ||
-    (!!selectedAgentId &&
-      selectedAgentId !== 'terminal' &&
-      agentsById.get(selectedAgentId)?.selectable === true)
+  // Open the environment block automatically when the doctor reports issues.
+  useEffect(() => {
+    if (!result) return
+    setEnvironmentExpanded(environmentIssues.length > 0)
+  }, [result, environmentIssues.length])
 
-  const selectedAgentTitle =
-    selectedAgentId === 'terminal'
-      ? t('onboardingWizard.agents.terminal.title')
-      : selectedAgentId
-        ? t(getAgentTitleKey(selectedAgentId))
-        : null
+  // At-least-one-ready OR terminal fallback already chosen.
+  const hasReadyAgent = useMemo(
+    () =>
+      AGENT_ORDER.some((id) => agentsById.get(id)?.status === 'ready') ||
+      defaultAgentSdk === 'terminal',
+    [agentsById, defaultAgentSdk]
+  )
+  const canFinish = hasReadyAgent
+
+  // Cmd+Enter completes the wizard when allowed.
+  useEffect(() => {
+    function handleKey(e: KeyboardEvent): void {
+      if ((e.metaKey || e.ctrlKey) && e.key === 'Enter' && canFinish) {
+        e.preventDefault()
+        onComplete()
+      }
+    }
+    window.addEventListener('keydown', handleKey)
+    return () => window.removeEventListener('keydown', handleKey)
+  }, [canFinish, onComplete])
+
+  // Cleanup any pending auto-refresh.
+  useEffect(() => {
+    return () => {
+      if (refreshTimerRef.current !== null) {
+        window.clearTimeout(refreshTimerRef.current)
+      }
+    }
+  }, [])
+
+  function scheduleAutoRefresh(): void {
+    if (refreshTimerRef.current !== null) {
+      window.clearTimeout(refreshTimerRef.current)
+    }
+    refreshTimerRef.current = window.setTimeout(() => {
+      refreshTimerRef.current = null
+      onRefresh()
+    }, REFRESH_DELAY_MS)
+  }
 
   async function copyCommand(command: string): Promise<void> {
     try {
       await window.projectOps.copyToClipboard(command)
       toast.success(t('onboardingWizard.toasts.commandCopied'))
-    } catch (error) {
-      toast.error(resolveActionError(t, error))
+    } catch (err) {
+      toast.error(resolveActionError(t, err))
     }
   }
 
@@ -168,12 +196,12 @@ export function AgentSetupWizard({
         throw new Error(response.error || 'Failed to open docs')
       }
       toast.success(t('onboardingWizard.toasts.docsOpened'))
-    } catch (error) {
-      toast.error(resolveActionError(t, error))
+    } catch (err) {
+      toast.error(resolveActionError(t, err))
     }
   }
 
-  async function runCommand(command: string): Promise<void> {
+  async function runCommand(command: string, autoRefresh: boolean): Promise<void> {
     setBusyAction(command)
     try {
       const response = await window.systemOps.openCommandInTerminal(command)
@@ -181,56 +209,48 @@ export function AgentSetupWizard({
         throw new Error(response.error || 'Failed to open terminal')
       }
       toast.success(t('onboardingWizard.toasts.terminalOpened'))
-    } catch (error) {
-      toast.error(resolveActionError(t, error))
+      if (autoRefresh) scheduleAutoRefresh()
+    } catch (err) {
+      toast.error(resolveActionError(t, err))
     } finally {
       setBusyAction(null)
     }
   }
 
-  function handleFocusAgent(id: WizardAgentId): void {
-    setFocusedAgentId(id)
-
+  function handleSetDefault(id: WizardAgentId): void {
+    updateSetting('defaultAgentSdk', id)
     if (id === 'terminal') {
-      setSelectedAgentId('terminal')
-      return
-    }
-
-    if (agentsById.get(id)?.selectable) {
-      setSelectedAgentId(id)
+      toast.success(t('onboardingWizard.toasts.terminalFallbackSet'))
+    } else {
+      toast.success(
+        t('onboardingWizard.toasts.defaultAgentSet', {
+          agent: t(getAgentTitleKey(id))
+        })
+      )
     }
   }
 
-  function handlePrimaryAction(): void {
-    if (currentStep === 'environment') {
-      setCurrentStep('agent')
-      return
+  function handleSelectPreset(id: KeymapPresetId): void {
+    if (id === activePreset) return
+    const { customCollisions } = setActivePreset(id)
+    const presetLabel = t(KEYMAP_PRESETS[id].labelKey)
+    if (customCollisions.length === 0) {
+      toast.success(t('onboardingWizard.keymap.toast.switched', { preset: presetLabel }))
+    } else {
+      toast.warning(
+        t('onboardingWizard.keymap.toast.conflicts', {
+          preset: presetLabel,
+          count: customCollisions.length
+        })
+      )
     }
-
-    if (!canStart || !selectedAgentId) {
-      toast.warning(t('onboardingWizard.toasts.selectedAgentRequired'))
-      return
-    }
-
-    onComplete(selectedAgentId)
   }
-
-  const footerHint =
-    currentStep === 'environment'
-      ? environmentIssues.length === 0
-        ? t('onboardingWizard.helper.environmentReady')
-        : t('onboardingWizard.helper.environmentNeedsAttention', {
-            count: environmentIssues.length
-          })
-      : selectedAgentTitle
-        ? t('onboardingWizard.helper.selectedReady', { agent: selectedAgentTitle })
-        : t('onboardingWizard.summary.pendingDescription')
 
   return (
     <AlertDialog open={true}>
       <AlertDialogContent
         size="lg"
-        className="h-[calc(100vh-2rem)] max-h-[760px] overflow-hidden border border-border/70 bg-background p-0 shadow-[0_24px_80px_-40px_rgba(15,23,42,0.35)] sm:max-w-[1040px]"
+        className="h-[calc(100vh-2rem)] max-h-[860px] overflow-hidden border border-border/70 bg-background p-0 shadow-[0_24px_80px_-40px_rgba(15,23,42,0.35)] sm:max-w-[1080px]"
       >
         <img
           src={onboardingBg}
@@ -244,9 +264,10 @@ export function AgentSetupWizard({
           aria-hidden="true"
           className="pointer-events-none absolute inset-0 hidden h-full w-full object-cover opacity-50 dark:block"
         />
+
         <div className="relative flex h-full min-h-0 flex-col">
           <header className="flex items-start justify-between gap-4 border-b border-border/60 px-6 py-5">
-            <div>
+            <div className="min-w-0">
               <div className="text-[22px] font-semibold tracking-tight text-foreground">
                 {t('onboardingWizard.headerTitle')}
               </div>
@@ -255,435 +276,196 @@ export function AgentSetupWizard({
               </div>
             </div>
 
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={onRefresh}
-              disabled={loading}
-              className="rounded-xl border-border/70 bg-background"
-            >
-              <RefreshCw className={cn('size-4', loading && 'animate-spin')} />
-              {t('onboardingWizard.actions.refresh')}
-            </Button>
+            <div className="flex shrink-0 items-center gap-2">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={onRefresh}
+                disabled={loading}
+                className="rounded-xl border-border/70 bg-background"
+              >
+                <RefreshCw className={cn('size-4', loading && 'animate-spin')} />
+                {t('onboardingWizard.actions.refresh')}
+              </Button>
+
+              <Button
+                size="sm"
+                onClick={onComplete}
+                disabled={!canFinish}
+                title={
+                  canFinish
+                    ? t('onboardingWizard.actions.finishHint')
+                    : t('onboardingWizard.actions.finishDisabledHint')
+                }
+                className="rounded-xl"
+              >
+                {t('onboardingWizard.actions.finish')}
+                <span className="ml-2 rounded-md border border-border/40 bg-background/40 px-1.5 py-0.5 text-[10px] font-medium tracking-wide text-muted-foreground">
+                  {'⌘⏎'}
+                </span>
+              </Button>
+            </div>
           </header>
 
-          <div className="border-b border-border/60 px-6 py-4">
-            <WizardStepper
-              currentStep={currentStep}
-              onStepChange={setCurrentStep}
-              disabled={loading || !!error || !result}
-            />
+          <div className="flex-1 min-h-0 overflow-y-auto">
+            <div className="space-y-5 px-6 py-5">
+              <EnvironmentSection
+                checks={environmentChecks}
+                issues={environmentIssues}
+                expanded={environmentExpanded}
+                onToggle={() => setEnvironmentExpanded((value) => !value)}
+                loading={loading}
+              />
+
+              <ProvidersSection
+                result={result}
+                loading={loading}
+                error={error}
+                defaultAgentSdk={defaultAgentSdk}
+                busyAction={busyAction}
+                onSetDefault={handleSetDefault}
+                onRunCommand={runCommand}
+                onCopyCommand={copyCommand}
+                onOpenDocs={openDocs}
+                onRefresh={onRefresh}
+              />
+
+              <KeymapPresetSection activePreset={activePreset} onSelect={handleSelectPreset} />
+
+              <AppearanceSection
+                themeId={themeId}
+                followSystem={followSystem}
+                onSelect={setTheme}
+                onPreview={previewTheme}
+                onCancelPreview={cancelPreview}
+                onToggleFollowSystem={setFollowSystem}
+              />
+            </div>
           </div>
 
-          {loading ? (
-            <div className="flex flex-1 items-center justify-center px-6 py-10">
-              <div className="flex max-w-md flex-col items-center rounded-3xl border border-border/70 bg-card px-8 py-10 text-center">
-                <div className="flex size-14 items-center justify-center rounded-full bg-primary/10 text-primary">
-                  <Loader2 className="size-6 animate-spin" />
-                </div>
-                <div className="mt-4 text-lg font-medium text-foreground">
-                  {t('onboardingWizard.loading.title')}
-                </div>
-                <div className="mt-2 text-sm leading-6 text-muted-foreground">
-                  {t('onboardingWizard.loading.description')}
-                </div>
-              </div>
+          <footer className="flex flex-wrap items-center justify-between gap-3 border-t border-border/60 px-6 py-4">
+            <div className="text-sm text-muted-foreground">
+              {canFinish
+                ? t('onboardingWizard.actions.finishHint')
+                : t('onboardingWizard.actions.finishDisabledHint')}
             </div>
-          ) : error ? (
-            <div className="flex flex-1 items-center justify-center px-6 py-10">
-              <div className="max-w-xl rounded-3xl border border-amber-300/60 bg-card p-6">
-                <div className="flex items-start gap-3">
-                  <div className="flex size-10 items-center justify-center rounded-2xl bg-amber-500/10 text-amber-600">
-                    <AlertTriangle className="size-5" />
-                  </div>
-                  <div>
-                    <div className="text-base font-medium text-foreground">
-                      {t('onboardingWizard.error.title')}
-                    </div>
-                    <div className="mt-1 text-sm leading-6 text-muted-foreground">
-                      {t('onboardingWizard.error.description')}
-                    </div>
-                  </div>
-                </div>
 
-                <div className="mt-4 rounded-2xl border border-border/70 bg-background px-4 py-3 text-sm text-muted-foreground">
-                  {error}
-                </div>
-
-                <div className="mt-5 flex flex-wrap items-center gap-2">
-                  <Button onClick={onRefresh} className="rounded-xl">
-                    <RefreshCw className="size-4" />
-                    {t('onboardingWizard.actions.retry')}
-                  </Button>
-                  <Button
-                    variant="outline"
-                    onClick={() => onComplete('terminal')}
-                    className="rounded-xl border-border/70 bg-background"
-                  >
-                    <TerminalSquare className="size-4" />
-                    {t('onboardingWizard.actions.useTerminal')}
-                  </Button>
-                </div>
-              </div>
+            <div className="flex flex-wrap items-center gap-2">
+              <Button
+                variant="ghost"
+                onClick={() => window.systemOps.quitApp()}
+                className="rounded-xl text-muted-foreground"
+              >
+                {t('onboardingWizard.actions.quit')}
+              </Button>
+              <Button
+                variant="outline"
+                onClick={() => handleSetDefault('terminal')}
+                className="rounded-xl border-border/70 bg-background"
+                disabled={defaultAgentSdk === 'terminal'}
+              >
+                <TerminalSquare className="size-4" />
+                {defaultAgentSdk === 'terminal'
+                  ? t('onboardingWizard.providers.terminal.isFallback')
+                  : t('onboardingWizard.actions.useTerminal')}
+              </Button>
+              <Button onClick={onComplete} disabled={!canFinish} className="rounded-xl">
+                {t('onboardingWizard.actions.finish')}
+                <Check className="size-4" />
+              </Button>
             </div>
-          ) : result ? (
-            <>
-              <div className="flex-1 min-h-0 overflow-y-auto px-6 py-5">
-                {currentStep === 'environment' ? (
-                  <EnvironmentStep checks={environmentChecks} issues={environmentIssues} />
-                ) : (
-                  <AgentStep
-                    result={result}
-                    focusedAgentId={focusedAgentId}
-                    selectedAgentId={selectedAgentId}
-                    busyAction={busyAction}
-                    onFocusAgent={handleFocusAgent}
-                    onCopyCommand={copyCommand}
-                    onRunCommand={runCommand}
-                    onOpenDocs={openDocs}
-                  />
-                )}
-              </div>
-
-              <footer className="flex flex-wrap items-center justify-between gap-3 border-t border-border/60 px-6 py-4">
-                <div className="text-sm text-muted-foreground">{footerHint}</div>
-
-                <div className="flex flex-wrap items-center gap-2">
-                  <Button
-                    variant="ghost"
-                    onClick={() => window.systemOps.quitApp()}
-                    className="rounded-xl text-muted-foreground"
-                  >
-                    {t('onboardingWizard.actions.quit')}
-                  </Button>
-
-                  {currentStep === 'agent' && (
-                    <Button
-                      variant="outline"
-                      onClick={() => setCurrentStep('environment')}
-                      className="rounded-xl border-border/70 bg-background"
-                    >
-                      <ChevronLeft className="size-4" />
-                      {t('onboardingWizard.actions.back')}
-                    </Button>
-                  )}
-
-                  {currentStep === 'agent' && (
-                    <Button
-                      variant="outline"
-                      onClick={() => handleFocusAgent('terminal')}
-                      className="rounded-xl border-border/70 bg-background"
-                    >
-                      <TerminalSquare className="size-4" />
-                      {t('onboardingWizard.actions.useTerminal')}
-                    </Button>
-                  )}
-
-                  <Button
-                    onClick={handlePrimaryAction}
-                    disabled={currentStep === 'agent' && !canStart}
-                    className="rounded-xl"
-                  >
-                    {currentStep === 'environment' ? (
-                      <>
-                        {t('onboardingWizard.actions.next')}
-                        <ArrowRight className="size-4" />
-                      </>
-                    ) : (
-                      <>
-                        {t('onboardingWizard.actions.start')}
-                        <ArrowRight className="size-4" />
-                      </>
-                    )}
-                  </Button>
-                </div>
-              </footer>
-            </>
-          ) : null}
+          </footer>
         </div>
       </AlertDialogContent>
     </AlertDialog>
   )
 }
 
-function WizardStepper({
-  currentStep,
-  onStepChange,
-  disabled
-}: {
-  currentStep: WizardStepId
-  onStepChange: (step: WizardStepId) => void
-  disabled: boolean
-}): React.JSX.Element {
-  const { t } = useI18n()
+// ============================================================================
+// Section: Environment (collapsible bar)
+// ============================================================================
 
-  const steps: Array<{ id: WizardStepId; title: string; description: string }> = [
-    {
-      id: 'environment',
-      title: t('onboardingWizard.steps.inspect'),
-      description: t('onboardingWizard.steps.inspectDescription')
-    },
-    {
-      id: 'agent',
-      title: t('onboardingWizard.steps.choose'),
-      description: t('onboardingWizard.steps.chooseDescription')
-    }
-  ]
-
-  return (
-    <div className="grid gap-3 sm:grid-cols-2">
-      {steps.map((step, index) => {
-        const isActive = step.id === currentStep
-
-        return (
-          <button
-            key={step.id}
-            type="button"
-            disabled={disabled}
-            onClick={() => onStepChange(step.id)}
-            className={cn(
-              'flex items-start gap-3 rounded-2xl border px-4 py-3 text-left transition-colors',
-              isActive
-                ? 'border-primary/35 bg-primary/6'
-                : 'border-border/70 bg-background hover:border-border hover:bg-accent/20',
-              disabled && 'cursor-default opacity-80'
-            )}
-          >
-            <div
-              className={cn(
-                'flex size-7 shrink-0 items-center justify-center rounded-full text-xs font-semibold',
-                isActive ? 'bg-primary text-primary-foreground' : 'bg-muted text-muted-foreground'
-              )}
-            >
-              {index + 1}
-            </div>
-
-            <div className="min-w-0">
-              <div className="text-sm font-medium text-foreground">{step.title}</div>
-              <div className="mt-1 text-xs leading-5 text-muted-foreground">
-                {step.description}
-              </div>
-            </div>
-          </button>
-        )
-      })}
-    </div>
-  )
-}
-
-function EnvironmentStep({
+function EnvironmentSection({
   checks,
-  issues
+  issues,
+  expanded,
+  onToggle,
+  loading
 }: {
   checks: OnboardingEnvironmentCheck[]
   issues: OnboardingEnvironmentCheck[]
+  expanded: boolean
+  onToggle: () => void
+  loading: boolean
 }): React.JSX.Element {
   const { t } = useI18n()
+  const ready = issues.length === 0
+  const total = checks.length
 
   return (
-    <div className="space-y-5">
-      <section className="rounded-3xl border border-border/70 bg-card p-5">
-        <div className="flex items-start justify-between gap-3">
-          <div>
-            <h3 className="text-base font-medium text-foreground">
-              {t('onboardingWizard.environment.title')}
-            </h3>
-            <p className="mt-1 text-sm leading-6 text-muted-foreground">
-              {t('onboardingWizard.environment.description')}
-            </p>
-          </div>
-          <span className="rounded-full border border-border/70 bg-background px-3 py-1 text-xs font-medium text-muted-foreground">
-            {checks.length - issues.length}/{checks.length}
-          </span>
-        </div>
-
-        <div className="mt-4 grid gap-3 sm:grid-cols-2">
-          {checks.map((item) => (
-            <EnvironmentCard key={item.id} item={item} />
-          ))}
-        </div>
-      </section>
-
-      <div
+    <section className="rounded-3xl border border-border/70 bg-card">
+      <button
+        type="button"
+        onClick={onToggle}
+        disabled={loading || total === 0}
         className={cn(
-          'rounded-2xl border px-4 py-3 text-sm',
-          issues.length === 0
-            ? 'border-emerald-300/60 bg-emerald-500/8 text-emerald-700 dark:border-emerald-400/30 dark:text-emerald-200'
-            : 'border-amber-300/60 bg-amber-500/8 text-amber-700 dark:border-amber-400/30 dark:text-amber-200'
+          'flex w-full items-center gap-3 rounded-3xl px-5 py-4 text-left transition-colors',
+          'hover:bg-accent/15 disabled:cursor-default disabled:opacity-70'
         )}
       >
-        <div className="flex items-start gap-2">
-          {issues.length === 0 ? (
-            <CheckCircle2 className="mt-0.5 size-4 shrink-0" />
-          ) : (
-            <AlertTriangle className="mt-0.5 size-4 shrink-0" />
+        <div
+          className={cn(
+            'flex size-9 shrink-0 items-center justify-center rounded-2xl',
+            ready
+              ? 'bg-emerald-500/10 text-emerald-600 dark:text-emerald-300'
+              : 'bg-amber-500/10 text-amber-600 dark:text-amber-300'
           )}
-          <div>
-            <div className="font-medium">
-              {issues.length === 0
-                ? t('onboardingWizard.helper.environmentReady')
-                : t('onboardingWizard.helper.environmentNeedsAttention', { count: issues.length })}
+        >
+          {ready ? <CheckCircle2 className="size-5" /> : <AlertTriangle className="size-5" />}
+        </div>
+
+        <div className="min-w-0 flex-1">
+          <div className="text-sm font-medium text-foreground">
+            {loading
+              ? t('onboardingWizard.loading.title')
+              : ready
+                ? t('onboardingWizard.environment.collapsed.allReady', {
+                    count: total - issues.length,
+                    total
+                  })
+                : t('onboardingWizard.environment.collapsed.needsAttention', {
+                    count: issues.length
+                  })}
+          </div>
+          {!loading && !ready && (
+            <div className="mt-1 text-xs leading-5 text-muted-foreground">
+              {issues.map((item) => t(ENVIRONMENT_META[item.id].titleKey)).join(' / ')}
             </div>
-            {issues.length > 0 && (
-              <div className="mt-1 leading-6">
-                {issues.map((item) => t(ENVIRONMENT_META[item.id].titleKey)).join(' / ')}
-              </div>
-            )}
-          </div>
-        </div>
-      </div>
-    </div>
-  )
-}
-
-function AgentStep({
-  result,
-  focusedAgentId,
-  selectedAgentId,
-  busyAction,
-  onFocusAgent,
-  onCopyCommand,
-  onRunCommand,
-  onOpenDocs
-}: {
-  result: OnboardingDoctorResult
-  focusedAgentId: WizardAgentId
-  selectedAgentId: WizardAgentId | null
-  busyAction: string | null
-  onFocusAgent: (id: WizardAgentId) => void
-  onCopyCommand: (command: string) => Promise<void>
-  onRunCommand: (command: string) => Promise<void>
-  onOpenDocs: (url: string) => Promise<void>
-}): React.JSX.Element {
-  const { t } = useI18n()
-  const agentsById = new Map(result.agents.map((agent) => [agent.id, agent]))
-  const activeAgent =
-    focusedAgentId === 'terminal'
-      ? null
-      : agentsById.get(focusedAgentId as Exclude<WizardAgentId, 'terminal'>) ?? null
-
-  return (
-    <div className="grid gap-5 lg:grid-cols-[minmax(0,1fr)_320px] lg:items-start">
-      <section className="rounded-3xl border border-border/70 bg-card p-5">
-        <div className="flex items-start justify-between gap-3">
-          <div>
-            <h3 className="text-base font-medium text-foreground">
-              {t('onboardingWizard.agents.title')}
-            </h3>
-            <p className="mt-1 text-sm leading-6 text-muted-foreground">
-              {t('onboardingWizard.agents.description')}
-            </p>
-          </div>
-          <span className="rounded-full border border-border/70 bg-background px-3 py-1 text-xs font-medium text-muted-foreground">
-            {result.agents.filter((agent) => agent.selectable).length}/{result.agents.length}
-          </span>
+          )}
         </div>
 
-        <div className="mt-4 space-y-3">
-          {AGENT_ORDER.map((agentId) => {
-            const agent = agentId === 'terminal' ? null : agentsById.get(agentId)
-            const meta = AGENT_META[agentId]
-            const Icon = meta.icon
-            const isFocused = focusedAgentId === agentId
-            const isSelected = selectedAgentId === agentId
-            const isSelectable = agentId === 'terminal' || agent?.selectable === true
-            const status = agentId === 'terminal' ? 'ready' : agent?.status ?? 'missing'
-
-            return (
-              <button
-                key={agentId}
-                type="button"
-                onClick={() => onFocusAgent(agentId)}
-                className={cn(
-                  'flex w-full items-start gap-4 rounded-2xl border px-4 py-4 text-left transition-colors',
-                  isFocused
-                    ? 'border-primary/35 bg-primary/6'
-                    : 'border-border/70 bg-background hover:border-border hover:bg-accent/20',
-                  isSelected && 'border-emerald-300/65 bg-emerald-500/8'
-                )}
-              >
-                <div className="flex size-10 shrink-0 items-center justify-center rounded-2xl border border-border/70 bg-card">
-                  <Icon className="size-[18px] text-foreground" />
-                </div>
-
-                <div className="min-w-0 flex-1">
-                  <div className="flex flex-wrap items-center gap-2">
-                    <span className="text-sm font-medium text-foreground">
-                      {t(getAgentTitleKey(agentId))}
-                    </span>
-                    <StatusPill className={getStatusBadgeClass(status)}>
-                      {t(getStatusLabelKey(status))}
-                    </StatusPill>
-                    {result.recommendedAgent === agentId && (
-                      <StatusPill className="border-primary/25 bg-primary/8 text-primary">
-                        {t('onboardingWizard.badges.recommended')}
-                      </StatusPill>
-                    )}
-                    {isSelected && (
-                      <StatusPill className="border-emerald-300/70 bg-emerald-500/10 text-emerald-700 dark:border-emerald-400/30 dark:text-emerald-200">
-                        {t('onboardingWizard.badges.selected')}
-                      </StatusPill>
-                    )}
-                    {agentId !== 'terminal' && agent?.version && (
-                      <span className="rounded-full border border-border/65 bg-background px-2.5 py-1 text-[11px] font-medium text-muted-foreground">
-                        {agent.version}
-                      </span>
-                    )}
-                  </div>
-
-                  <div className="mt-2 text-sm leading-6 text-muted-foreground">
-                    {resolveAgentStatusText(t, agentId, agent)}
-                  </div>
-
-                  {!isSelectable && (
-                    <div className="mt-2 text-xs text-muted-foreground">
-                      {t('onboardingWizard.helper.agentNotReady')}
-                    </div>
-                  )}
-                </div>
-              </button>
-            )
-          })}
+        <div className="flex shrink-0 items-center text-xs text-muted-foreground">
+          {expanded
+            ? t('onboardingWizard.environment.collapsed.collapse')
+            : t('onboardingWizard.environment.collapsed.expand')}
+          {expanded ? (
+            <ChevronDown className="ml-1 size-4" />
+          ) : (
+            <ChevronRight className="ml-1 size-4" />
+          )}
         </div>
-      </section>
+      </button>
 
-      <section className="rounded-3xl border border-border/70 bg-card p-5 lg:sticky lg:top-0">
-        <div className="flex items-center gap-3">
-          <div className="flex size-10 items-center justify-center rounded-2xl border border-border/70 bg-background">
-            {(() => {
-              const Icon = AGENT_META[focusedAgentId].icon
-              return <Icon className="size-[18px] text-foreground" />
-            })()}
-          </div>
-          <div>
-            <div className="text-base font-medium text-foreground">
-              {focusedAgentId === 'terminal'
-                ? t('onboardingWizard.agents.terminal.title')
-                : t(getAgentTitleKey(focusedAgentId))}
-            </div>
-            <div className="mt-1 text-sm text-muted-foreground">
-              {resolveHelperDescription(t, focusedAgentId, activeAgent)}
-            </div>
+      {expanded && total > 0 && (
+        <div className="border-t border-border/60 px-5 py-4">
+          <div className="grid gap-3 sm:grid-cols-2">
+            {checks.map((item) => (
+              <EnvironmentCard key={item.id} item={item} />
+            ))}
           </div>
         </div>
-
-        {focusedAgentId === 'terminal' ? (
-          <div className="mt-4 rounded-2xl border border-border/70 bg-background px-4 py-4 text-sm leading-6 text-muted-foreground">
-            {t('onboardingWizard.agents.terminal.detail')}
-          </div>
-        ) : (
-          renderCommandBlock(
-            t,
-            focusedAgentId,
-            activeAgent,
-            busyAction,
-            onCopyCommand,
-            onRunCommand,
-            onOpenDocs
-          )
-        )}
-      </section>
-    </div>
+      )}
+    </section>
   )
 }
 
@@ -714,6 +496,770 @@ function EnvironmentCard({ item }: { item: OnboardingEnvironmentCheck }): React.
   )
 }
 
+// ============================================================================
+// Section: AI providers (parallel cards, no longer single-select radio)
+// ============================================================================
+
+function ProvidersSection({
+  result,
+  loading,
+  error,
+  defaultAgentSdk,
+  busyAction,
+  onSetDefault,
+  onRunCommand,
+  onCopyCommand,
+  onOpenDocs,
+  onRefresh
+}: {
+  result: OnboardingDoctorResult | null
+  loading: boolean
+  error: string | null
+  defaultAgentSdk: WizardAgentId
+  busyAction: string | null
+  onSetDefault: (id: WizardAgentId) => void
+  onRunCommand: (command: string, autoRefresh: boolean) => Promise<void>
+  onCopyCommand: (command: string) => Promise<void>
+  onOpenDocs: (url: string) => Promise<void>
+  onRefresh: () => void
+}): React.JSX.Element {
+  const { t } = useI18n()
+  const agentsById = new Map(result?.agents.map((agent) => [agent.id, agent]) ?? [])
+
+  const defaultLabel =
+    defaultAgentSdk === 'terminal'
+      ? t('onboardingWizard.agents.terminal.title')
+      : t(getAgentTitleKey(defaultAgentSdk))
+
+  return (
+    <section className="rounded-3xl border border-border/70 bg-card p-5">
+      <header className="flex flex-wrap items-start justify-between gap-3">
+        <div className="min-w-0">
+          <h3 className="text-base font-medium text-foreground">
+            {t('onboardingWizard.providers.title')}
+          </h3>
+          <p className="mt-1 text-sm leading-6 text-muted-foreground">
+            {t('onboardingWizard.providers.description')}
+          </p>
+        </div>
+        <span className="rounded-full border border-border/70 bg-background px-3 py-1 text-xs font-medium text-muted-foreground">
+          {t('onboardingWizard.providers.defaultRuntimeReadout', { agent: defaultLabel })}
+        </span>
+      </header>
+
+      {error ? (
+        <div className="mt-4 rounded-2xl border border-amber-300/60 bg-amber-500/8 p-4 text-sm text-amber-700 dark:border-amber-400/30 dark:text-amber-200">
+          <div className="flex items-start gap-2">
+            <AlertTriangle className="mt-0.5 size-4 shrink-0" />
+            <div className="min-w-0">
+              <div className="font-medium">{t('onboardingWizard.providers.errorBanner.title')}</div>
+              <div className="mt-1 text-xs leading-5 opacity-90">{error}</div>
+              <div className="mt-3 flex flex-wrap gap-2">
+                <Button size="sm" onClick={onRefresh} className="rounded-xl">
+                  <RefreshCw className="size-4" />
+                  {t('onboardingWizard.providers.errorBanner.retry')}
+                </Button>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={() => onSetDefault('terminal')}
+                  className="rounded-xl border-border/70 bg-background"
+                >
+                  <TerminalSquare className="size-4" />
+                  {t('onboardingWizard.providers.errorBanner.fallback')}
+                </Button>
+              </div>
+            </div>
+          </div>
+        </div>
+      ) : (
+        <div className="mt-4 grid gap-3 lg:grid-cols-2">
+          {AGENT_ORDER.map((id) => (
+            <ProviderCard
+              key={id}
+              id={id}
+              agent={agentsById.get(id)}
+              isDefault={defaultAgentSdk === id}
+              loading={loading}
+              busyAction={busyAction}
+              onSetDefault={onSetDefault}
+              onRunCommand={onRunCommand}
+              onCopyCommand={onCopyCommand}
+              onOpenDocs={onOpenDocs}
+              onRefresh={onRefresh}
+            />
+          ))}
+
+          <TerminalProviderCard
+            isDefault={defaultAgentSdk === 'terminal'}
+            onSetDefault={() => onSetDefault('terminal')}
+            onOpenDocs={onOpenDocs}
+          />
+        </div>
+      )}
+    </section>
+  )
+}
+
+function ProviderCard({
+  id,
+  agent,
+  isDefault,
+  loading,
+  busyAction,
+  onSetDefault,
+  onRunCommand,
+  onCopyCommand,
+  onOpenDocs,
+  onRefresh
+}: {
+  id: Exclude<WizardAgentId, 'terminal'>
+  agent: OnboardingAgentStatus | undefined
+  isDefault: boolean
+  loading: boolean
+  busyAction: string | null
+  onSetDefault: (id: WizardAgentId) => void
+  onRunCommand: (command: string, autoRefresh: boolean) => Promise<void>
+  onCopyCommand: (command: string) => Promise<void>
+  onOpenDocs: (url: string) => Promise<void>
+  onRefresh: () => void
+}): React.JSX.Element {
+  const { t } = useI18n()
+  const meta = AGENT_META[id]
+  const Icon = meta.icon
+  const status = agent?.status ?? 'missing'
+  const reason = agent?.reason
+
+  const showSetDefault = status === 'ready' || reason === 'auth_unknown'
+
+  return (
+    <div
+      className={cn(
+        'flex flex-col gap-3 rounded-2xl border bg-background p-4',
+        isDefault ? 'border-primary/45 bg-primary/5' : 'border-border/70'
+      )}
+    >
+      <div className="flex items-start gap-3">
+        <div className="flex size-10 shrink-0 items-center justify-center rounded-2xl border border-border/70 bg-card">
+          <Icon className="size-[18px] text-foreground" />
+        </div>
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="text-sm font-medium text-foreground">
+              {t(getAgentTitleKey(id))}
+            </span>
+            {!loading && (
+              <StatusPill className={getStatusBadgeClass(status)}>
+                {t(getStatusLabelKey(status))}
+              </StatusPill>
+            )}
+            {isDefault && (
+              <StatusPill className="border-primary/30 bg-primary/10 text-primary">
+                {t('onboardingWizard.providers.actions.isDefault')}
+              </StatusPill>
+            )}
+            {agent?.version && (
+              <span className="rounded-full border border-border/65 bg-background px-2.5 py-0.5 text-[11px] font-medium text-muted-foreground">
+                {agent.version}
+              </span>
+            )}
+          </div>
+
+          <p className="mt-1.5 text-sm leading-6 text-muted-foreground">
+            {loading
+              ? t('onboardingWizard.providers.loading.message')
+              : resolveAgentStatusText(t, id, agent)}
+          </p>
+        </div>
+      </div>
+
+      <div className="mt-1 flex flex-wrap items-center gap-2">
+        <ProviderPrimaryAction
+          id={id}
+          status={status}
+          reason={reason}
+          loading={loading}
+          busyAction={busyAction}
+          onRunCommand={onRunCommand}
+          onRefresh={onRefresh}
+        />
+
+        {showSetDefault && !loading && (
+          <Button
+            size="sm"
+            variant={isDefault ? 'outline' : 'default'}
+            onClick={() => onSetDefault(id)}
+            disabled={isDefault}
+            className="rounded-xl"
+            title={
+              reason === 'auth_unknown'
+                ? t('onboardingWizard.agents.claudeCode.authUnknown')
+                : undefined
+            }
+          >
+            {isDefault
+              ? t('onboardingWizard.providers.actions.isDefault')
+              : t('onboardingWizard.providers.actions.setDefault')}
+          </Button>
+        )}
+
+        <Button
+          size="sm"
+          variant="ghost"
+          onClick={() => onOpenDocs(meta.docsUrl)}
+          className="rounded-xl text-muted-foreground"
+        >
+          <ExternalLink className="size-4" />
+          {t('onboardingWizard.providers.actions.docs')}
+        </Button>
+
+        {(status === 'missing' || reason === 'login_required') && meta.installCommand && (
+          <Button
+            size="sm"
+            variant="ghost"
+            onClick={() =>
+              onCopyCommand(
+                status === 'missing' ? meta.installCommand! : meta.launchCommand ?? meta.installCommand!
+              )
+            }
+            className="rounded-xl text-muted-foreground"
+          >
+            <Copy className="size-4" />
+            {t('onboardingWizard.actions.copyCommand')}
+          </Button>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function ProviderPrimaryAction({
+  id,
+  status,
+  reason,
+  loading,
+  busyAction,
+  onRunCommand,
+  onRefresh
+}: {
+  id: Exclude<WizardAgentId, 'terminal'>
+  status: 'ready' | 'warning' | 'missing'
+  reason?: 'ready' | 'missing' | 'login_required' | 'auth_unknown'
+  loading: boolean
+  busyAction: string | null
+  onRunCommand: (command: string, autoRefresh: boolean) => Promise<void>
+  onRefresh: () => void
+}): React.JSX.Element {
+  const { t } = useI18n()
+  const meta = AGENT_META[id]
+
+  if (loading) {
+    return (
+      <Button size="sm" disabled className="rounded-xl">
+        <Loader2 className="size-4 animate-spin" />
+        {t('onboardingWizard.actions.refresh')}
+      </Button>
+    )
+  }
+
+  if (status === 'ready' && reason !== 'auth_unknown') {
+    return (
+      <Button size="sm" disabled className="rounded-xl">
+        <CheckCircle2 className="size-4" />
+        {t('onboardingWizard.badges.ready')}
+      </Button>
+    )
+  }
+
+  if (status === 'missing' && meta.installCommand) {
+    const cmd = meta.installCommand
+    return (
+      <Button
+        size="sm"
+        onClick={() => onRunCommand(cmd, true)}
+        disabled={busyAction === cmd}
+        className="rounded-xl"
+      >
+        {busyAction === cmd ? (
+          <Loader2 className="size-4 animate-spin" />
+        ) : (
+          <Package className="size-4" />
+        )}
+        {t('onboardingWizard.providers.actions.install')}
+      </Button>
+    )
+  }
+
+  if (reason === 'login_required' && meta.launchCommand) {
+    const cmd = meta.launchCommand
+    return (
+      <Button
+        size="sm"
+        onClick={() => onRunCommand(cmd, true)}
+        disabled={busyAction === cmd}
+        className="rounded-xl"
+      >
+        {busyAction === cmd ? (
+          <Loader2 className="size-4 animate-spin" />
+        ) : (
+          <ExternalLink className="size-4" />
+        )}
+        {t('onboardingWizard.providers.actions.login')}
+      </Button>
+    )
+  }
+
+  if (reason === 'auth_unknown') {
+    return (
+      <Button size="sm" variant="outline" onClick={onRefresh} className="rounded-xl border-border/70 bg-background">
+        <RefreshCw className="size-4" />
+        {t('onboardingWizard.providers.actions.recheck')}
+      </Button>
+    )
+  }
+
+  return (
+    <Button size="sm" variant="outline" onClick={onRefresh} className="rounded-xl border-border/70 bg-background">
+      <RefreshCw className="size-4" />
+      {t('onboardingWizard.providers.actions.recheck')}
+    </Button>
+  )
+}
+
+function TerminalProviderCard({
+  isDefault,
+  onSetDefault,
+  onOpenDocs
+}: {
+  isDefault: boolean
+  onSetDefault: () => void
+  onOpenDocs: (url: string) => Promise<void>
+}): React.JSX.Element {
+  const { t } = useI18n()
+
+  return (
+    <div
+      className={cn(
+        'flex flex-col gap-3 rounded-2xl border bg-background p-4',
+        isDefault ? 'border-primary/45 bg-primary/5' : 'border-border/70'
+      )}
+    >
+      <div className="flex items-start gap-3">
+        <div className="flex size-10 shrink-0 items-center justify-center rounded-2xl border border-border/70 bg-card">
+          <TerminalSquare className="size-[18px] text-foreground" />
+        </div>
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="text-sm font-medium text-foreground">
+              {t('onboardingWizard.providers.terminal.fallbackTitle')}
+            </span>
+            {isDefault && (
+              <StatusPill className="border-primary/30 bg-primary/10 text-primary">
+                {t('onboardingWizard.providers.terminal.isFallback')}
+              </StatusPill>
+            )}
+          </div>
+          <p className="mt-1.5 text-sm leading-6 text-muted-foreground">
+            {t('onboardingWizard.providers.terminal.fallbackDescription')}
+          </p>
+        </div>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-2">
+        <Button
+          size="sm"
+          variant={isDefault ? 'outline' : 'default'}
+          disabled={isDefault}
+          onClick={onSetDefault}
+          className="rounded-xl"
+        >
+          <TerminalSquare className="size-4" />
+          {isDefault
+            ? t('onboardingWizard.providers.terminal.isFallback')
+            : t('onboardingWizard.providers.terminal.setFallback')}
+        </Button>
+        <Button
+          size="sm"
+          variant="ghost"
+          onClick={() => onOpenDocs(TERMINAL_DOCS_URL)}
+          className="rounded-xl text-muted-foreground"
+        >
+          <ExternalLink className="size-4" />
+          {t('onboardingWizard.providers.actions.docs')}
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+// ============================================================================
+// Section: Keymap presets
+// ============================================================================
+
+function KeymapPresetSection({
+  activePreset,
+  onSelect
+}: {
+  activePreset: KeymapPresetId
+  onSelect: (id: KeymapPresetId) => void
+}): React.JSX.Element {
+  const { t } = useI18n()
+
+  return (
+    <section className="rounded-3xl border border-border/70 bg-card p-5">
+      <header>
+        <h3 className="text-base font-medium text-foreground">
+          {t('onboardingWizard.keymap.title')}
+        </h3>
+        <p className="mt-1 text-sm leading-6 text-muted-foreground">
+          {t('onboardingWizard.keymap.description')}
+        </p>
+      </header>
+
+      <div className="mt-4 grid gap-3 sm:grid-cols-3">
+        {KEYMAP_PRESET_ORDER.map((presetId) => {
+          const meta = KEYMAP_PRESETS[presetId]
+          const isActive = presetId === activePreset
+          const samples = PRESET_SAMPLE_SHORTCUTS.map(({ id, labelKey }) => {
+            // Always show the preset's *native* binding for the sample shortcut,
+            // ignoring custom overrides. Custom bindings keep winning at runtime,
+            // but the card is meant to convey "what this preset would change."
+            const presetBinding = meta.overrides[id]
+            const fallback = DEFAULT_SHORTCUTS.find((s) => s.id === id)?.defaultBinding ?? null
+            const binding = presetBinding ?? fallback
+            return {
+              id,
+              label: t(labelKey),
+              display: binding ? formatBindingForPreview(binding) : ''
+            }
+          })
+
+          return (
+            <button
+              key={presetId}
+              type="button"
+              onClick={() => onSelect(presetId)}
+              className={cn(
+                'flex flex-col gap-3 rounded-2xl border p-4 text-left transition-colors',
+                isActive
+                  ? 'border-primary/45 bg-primary/8'
+                  : 'border-border/70 bg-background hover:border-border hover:bg-accent/15'
+              )}
+            >
+              <div className="flex items-start justify-between gap-2">
+                <div className="text-sm font-medium text-foreground">{t(meta.labelKey)}</div>
+                {isActive && <Check className="size-4 text-primary" />}
+              </div>
+              <div className="text-xs leading-5 text-muted-foreground">{t(meta.descriptionKey)}</div>
+              <div className="mt-auto flex flex-col gap-1">
+                {samples.map((s) => (
+                  <div
+                    key={s.id}
+                    className="flex items-center justify-between gap-2 rounded-lg border border-border/60 bg-card px-2 py-1 text-[11px]"
+                  >
+                    <span className="truncate text-muted-foreground">{s.label}</span>
+                    <span className="font-mono text-foreground/80">{s.display}</span>
+                  </div>
+                ))}
+              </div>
+            </button>
+          )
+        })}
+      </div>
+
+      <ImportFromEditor />
+    </section>
+  )
+}
+
+function ImportFromEditor(): React.JSX.Element {
+  const { t } = useI18n()
+  const applyImportEntries = useShortcutStore((s) => s.applyImportEntries)
+  const [sources, setSources] = useState<
+    Array<{
+      id: 'vscode' | 'cursor'
+      path: string
+      exists: boolean
+      available: boolean
+    }>
+  >([])
+  const [busySource, setBusySource] = useState<'vscode' | 'cursor' | null>(null)
+  const [loaded, setLoaded] = useState(false)
+
+  useEffect(() => {
+    let cancelled = false
+    void window.systemOps
+      .detectKeybindingImportSources()
+      .then((result) => {
+        if (cancelled) return
+        setSources(result)
+        setLoaded(true)
+      })
+      .catch(() => {
+        if (cancelled) return
+        setLoaded(true)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  const sourceLabels: Record<'vscode' | 'cursor', string> = {
+    vscode: t('onboardingWizard.keymap.importSourceVscode'),
+    cursor: t('onboardingWizard.keymap.importSourceCursor')
+  }
+
+  async function handleImport(sourceId: 'vscode' | 'cursor'): Promise<void> {
+    setBusySource(sourceId)
+    try {
+      const parsed = await window.systemOps.parseKeybindingImportSource(sourceId)
+      const sourceLabel = sourceLabels[sourceId]
+
+      if (parsed.errors.length > 0 && parsed.entries.length === 0) {
+        const message = parsed.errors[0]
+        if (message?.startsWith('Failed to read')) {
+          toast.warning(t('onboardingWizard.keymap.importToast.notFound', { source: sourceLabel }))
+        } else {
+          toast.error(
+            t('onboardingWizard.keymap.importToast.error', {
+              source: sourceLabel,
+              message: message ?? ''
+            })
+          )
+        }
+        return
+      }
+
+      if (parsed.entries.length === 0) {
+        toast.warning(t('onboardingWizard.keymap.importToast.empty', { source: sourceLabel }))
+        return
+      }
+
+      const { applied, conflicts } = applyImportEntries(parsed.entries)
+
+      if (conflicts.length === 0) {
+        toast.success(
+          t('onboardingWizard.keymap.importToast.success', {
+            source: sourceLabel,
+            count: applied
+          })
+        )
+      } else {
+        toast.warning(
+          t('onboardingWizard.keymap.importToast.partial', {
+            source: sourceLabel,
+            applied,
+            skipped: conflicts.length
+          })
+        )
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      toast.error(
+        t('onboardingWizard.keymap.importToast.error', {
+          source: sourceLabels[sourceId],
+          message
+        })
+      )
+    } finally {
+      setBusySource(null)
+    }
+  }
+
+  if (!loaded) return <></>
+
+  const anyAvailable = sources.some((s) => s.available)
+
+  return (
+    <div className="mt-4 rounded-2xl border border-border/60 bg-background/40 px-4 py-3">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="min-w-0">
+          <div className="text-sm font-medium text-foreground">
+            {t('onboardingWizard.keymap.importTitle')}
+          </div>
+          <div className="mt-0.5 text-xs leading-5 text-muted-foreground">
+            {anyAvailable
+              ? t('onboardingWizard.keymap.importDescription')
+              : t('onboardingWizard.keymap.importEmpty')}
+          </div>
+        </div>
+
+        <div className="flex flex-wrap gap-2">
+          {sources.map((source) => {
+            const label = sourceLabels[source.id]
+            const isBusy = busySource === source.id
+            const disabled = !source.available || busySource !== null
+
+            return (
+              <Button
+                key={source.id}
+                size="sm"
+                variant="outline"
+                disabled={disabled}
+                onClick={() => handleImport(source.id)}
+                title={
+                  source.available
+                    ? source.path
+                    : t('onboardingWizard.keymap.importNotFound', { path: source.path })
+                }
+                className="rounded-xl border-border/70 bg-background"
+              >
+                {isBusy ? (
+                  <Loader2 className="size-4 animate-spin" />
+                ) : (
+                  <Download className="size-4" />
+                )}
+                {isBusy
+                  ? t('onboardingWizard.keymap.importBusy')
+                  : t('onboardingWizard.keymap.importApply', { source: label })}
+              </Button>
+            )
+          })}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// ============================================================================
+// Section: Appearance
+// ============================================================================
+
+function AppearanceSection({
+  themeId,
+  followSystem,
+  onSelect,
+  onPreview,
+  onCancelPreview,
+  onToggleFollowSystem
+}: {
+  themeId: string
+  followSystem: boolean
+  onSelect: (id: string) => void
+  onPreview: (id: string) => void
+  onCancelPreview: () => void
+  onToggleFollowSystem: (follow: boolean) => void
+}): React.JSX.Element {
+  const { t } = useI18n()
+
+  return (
+    <section className="rounded-3xl border border-border/70 bg-card p-5">
+      <header className="flex flex-wrap items-start justify-between gap-3">
+        <div className="min-w-0">
+          <h3 className="text-base font-medium text-foreground">
+            {t('onboardingWizard.appearance.title')}
+          </h3>
+          <p className="mt-1 text-sm leading-6 text-muted-foreground">
+            {t('onboardingWizard.appearance.description')}
+          </p>
+        </div>
+
+        <button
+          type="button"
+          onClick={() => onToggleFollowSystem(!followSystem)}
+          className={cn(
+            'inline-flex items-center gap-2 rounded-full border px-3 py-1.5 text-xs font-medium transition-colors',
+            followSystem
+              ? 'border-primary/35 bg-primary/10 text-primary'
+              : 'border-border/70 bg-background text-muted-foreground hover:bg-accent/20'
+          )}
+        >
+          <Monitor className="size-3.5" />
+          {t('onboardingWizard.appearance.followSystem')}
+        </button>
+      </header>
+
+      <div className="mt-4 grid gap-3 sm:grid-cols-2">
+        {THEME_PRESETS.map((preset) => (
+          <ThemeOption
+            key={preset.id}
+            preset={preset}
+            isActive={!followSystem && preset.id === themeId}
+            disabled={followSystem}
+            onSelect={() => onSelect(preset.id)}
+            onPreview={() => onPreview(preset.id)}
+            onCancelPreview={onCancelPreview}
+          />
+        ))}
+      </div>
+    </section>
+  )
+}
+
+function ThemeOption({
+  preset,
+  isActive,
+  disabled,
+  onSelect,
+  onPreview,
+  onCancelPreview
+}: {
+  preset: ThemePreset
+  isActive: boolean
+  disabled: boolean
+  onSelect: () => void
+  onPreview: () => void
+  onCancelPreview: () => void
+}): React.JSX.Element {
+  const { t } = useI18n()
+  const typeLabel =
+    preset.type === 'dark'
+      ? t('onboardingWizard.appearance.dark')
+      : t('onboardingWizard.appearance.light')
+
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      onMouseEnter={onPreview}
+      onMouseLeave={onCancelPreview}
+      onFocus={onPreview}
+      onBlur={onCancelPreview}
+      disabled={disabled}
+      className={cn(
+        'group relative flex items-center gap-3 rounded-2xl border p-3 text-left transition-colors',
+        isActive
+          ? 'border-primary/45 bg-primary/8'
+          : 'border-border/70 bg-background hover:border-border hover:bg-accent/15',
+        disabled && 'cursor-default opacity-60'
+      )}
+    >
+      <div
+        className="size-12 shrink-0 rounded-xl border border-border/40"
+        style={{
+          background: `linear-gradient(135deg, ${preset.colors.background} 0%, ${preset.colors.background} 50%, ${preset.colors.card} 50%, ${preset.colors.card} 100%)`
+        }}
+      >
+        <div
+          className="m-2 h-2 rounded-full"
+          style={{ background: preset.colors.primary }}
+          aria-hidden="true"
+        />
+        <div
+          className="mx-2 h-1 rounded-full"
+          style={{ background: preset.colors.foreground, opacity: 0.5 }}
+          aria-hidden="true"
+        />
+      </div>
+
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2">
+          <span className="text-sm font-medium text-foreground">{preset.name}</span>
+          <span className="rounded-full border border-border/65 bg-background px-2 py-0.5 text-[10px] font-medium text-muted-foreground">
+            {typeLabel}
+          </span>
+        </div>
+      </div>
+
+      {isActive && <Check className="size-4 shrink-0 text-primary" />}
+    </button>
+  )
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
 function StatusPill({
   children,
   className
@@ -724,96 +1270,12 @@ function StatusPill({
   return (
     <span
       className={cn(
-        'inline-flex items-center rounded-full border px-2.5 py-1 text-[11px] font-medium whitespace-nowrap',
+        'inline-flex items-center rounded-full border px-2.5 py-0.5 text-[11px] font-medium whitespace-nowrap',
         className
       )}
     >
       {children}
     </span>
-  )
-}
-
-function renderCommandBlock(
-  t: ReturnType<typeof useI18n>['t'],
-  agentId: Exclude<WizardAgentId, 'terminal'>,
-  agent: OnboardingAgentStatus | null,
-  busyAction: string | null,
-  copyCommand: (command: string) => Promise<void>,
-  runCommand: (command: string) => Promise<void>,
-  openDocs: (url: string) => Promise<void>
-): React.JSX.Element {
-  const meta = AGENT_META[agentId]
-  const installCommand = meta.installCommand
-  const launchCommand = meta.launchCommand
-
-  const primaryCommand =
-    !agent || agent.status === 'missing' ? installCommand : agent.reason === 'login_required' ? launchCommand : null
-
-  const commandHint =
-    !agent || agent.status === 'missing'
-      ? t('onboardingWizard.helper.installDescription', {
-          agent: t(getAgentTitleKey(agentId))
-        })
-      : agent.reason === 'login_required'
-        ? resolveLoginHint(t, agentId)
-        : resolveHelperDescription(t, agentId, agent)
-
-  return (
-    <div className="mt-4 rounded-2xl border border-border/70 bg-background p-4">
-      <div className="text-sm leading-6 text-muted-foreground">{commandHint}</div>
-
-      {primaryCommand ? (
-        <>
-          <div className="mt-4 text-xs font-medium uppercase tracking-[0.16em] text-muted-foreground/80">
-            {t('onboardingWizard.helper.commandLabel')}
-          </div>
-          <code className="mt-2 block overflow-x-auto rounded-xl border border-border/70 bg-card px-3 py-2 text-xs text-foreground">
-            {primaryCommand}
-          </code>
-
-          <div className="mt-4 flex flex-wrap items-center gap-2">
-            <Button size="sm" className="rounded-xl" onClick={() => runCommand(primaryCommand)}>
-              {busyAction === primaryCommand ? (
-                <Loader2 className="size-4 animate-spin" />
-              ) : (
-                <Play className="size-4" />
-              )}
-              {t('onboardingWizard.actions.runInTerminal')}
-            </Button>
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => copyCommand(primaryCommand)}
-              className="rounded-xl border-border/70 bg-background"
-            >
-              <Copy className="size-4" />
-              {t('onboardingWizard.actions.copyCommand')}
-            </Button>
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => openDocs(meta.docsUrl)}
-              className="rounded-xl border-border/70 bg-background"
-            >
-              <ExternalLink className="size-4" />
-              {t('onboardingWizard.actions.openDocs')}
-            </Button>
-          </div>
-        </>
-      ) : (
-        <div className="mt-4">
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => openDocs(meta.docsUrl)}
-            className="rounded-xl border-border/70 bg-background"
-          >
-            <ExternalLink className="size-4" />
-            {t('onboardingWizard.actions.openDocs')}
-          </Button>
-        </div>
-      )}
-    </div>
   )
 }
 
@@ -883,76 +1345,6 @@ function getAgentTitleKey(agentId: WizardAgentId): string {
   }
 }
 
-function resolveAgentStatusText(
-  t: ReturnType<typeof useI18n>['t'],
-  agentId: WizardAgentId,
-  agent: OnboardingAgentStatus | null | undefined
-): string {
-  if (agentId === 'terminal') {
-    return t('onboardingWizard.agents.terminal.description')
-  }
-
-  if (!agent || agent.status === 'missing') {
-    return t(`${getAgentBaseKey(agentId)}.missing`)
-  }
-
-  if (agent.reason === 'login_required') {
-    return t(`${getAgentBaseKey(agentId)}.loginRequired`)
-  }
-
-  if (agent.reason === 'auth_unknown') {
-    return t(`${getAgentBaseKey(agentId)}.authUnknown`)
-  }
-
-  return t(`${getAgentBaseKey(agentId)}.ready`)
-}
-
-function resolveHelperDescription(
-  t: ReturnType<typeof useI18n>['t'],
-  agentId: WizardAgentId,
-  agent: OnboardingAgentStatus | null
-): string {
-  if (agentId === 'terminal') {
-    return t('onboardingWizard.helper.terminalDescription')
-  }
-
-  if (!agent || agent.status === 'missing') {
-    return t('onboardingWizard.helper.installDescription', {
-      agent: t(getAgentTitleKey(agentId))
-    })
-  }
-
-  if (agent.reason === 'login_required') {
-    return t('onboardingWizard.helper.loginDescription', {
-      agent: t(getAgentTitleKey(agentId))
-    })
-  }
-
-  if (agent.reason === 'auth_unknown') {
-    return t('onboardingWizard.helper.authUnknownDescription', {
-      agent: t(getAgentTitleKey(agentId))
-    })
-  }
-
-  return t('onboardingWizard.helper.agentReadyDescription', {
-    agent: t(getAgentTitleKey(agentId))
-  })
-}
-
-function resolveLoginHint(
-  t: ReturnType<typeof useI18n>['t'],
-  agentId: Exclude<WizardAgentId, 'terminal'>
-): string {
-  switch (agentId) {
-    case 'claude-code':
-      return t('onboardingWizard.helper.loginHintClaude')
-    case 'codex':
-      return t('onboardingWizard.helper.loginHintCodex')
-    case 'opencode':
-      return t('onboardingWizard.helper.loginHintOpencode')
-  }
-}
-
 function getAgentBaseKey(agentId: Exclude<WizardAgentId, 'terminal'>): string {
   switch (agentId) {
     case 'claude-code':
@@ -964,7 +1356,42 @@ function getAgentBaseKey(agentId: Exclude<WizardAgentId, 'terminal'>): string {
   }
 }
 
+function resolveAgentStatusText(
+  t: ReturnType<typeof useI18n>['t'],
+  agentId: Exclude<WizardAgentId, 'terminal'>,
+  agent: OnboardingAgentStatus | null | undefined
+): string {
+  if (!agent || agent.status === 'missing') {
+    return t(`${getAgentBaseKey(agentId)}.missing`)
+  }
+  if (agent.reason === 'login_required') {
+    return t(`${getAgentBaseKey(agentId)}.loginRequired`)
+  }
+  if (agent.reason === 'auth_unknown') {
+    return t(`${getAgentBaseKey(agentId)}.authUnknown`)
+  }
+  return t(`${getAgentBaseKey(agentId)}.ready`)
+}
+
 function resolveActionError(t: ReturnType<typeof useI18n>['t'], error: unknown): string {
   const message = error instanceof Error ? error.message : String(error)
   return `${t('onboardingWizard.toasts.actionFailed')}: ${message}`
 }
+
+// Format a binding without going through the active store — used for preview
+// chips on the keymap preset cards.
+function formatBindingForPreview(binding: KeyBinding): string {
+  const isMac = typeof navigator !== 'undefined' && /Mac/i.test(navigator.platform)
+  const symbols: string[] = []
+  for (const mod of binding.modifiers) {
+    if (mod === 'meta') symbols.push(isMac ? '⌘' : 'Ctrl')
+    else if (mod === 'ctrl') symbols.push(isMac ? '⌃' : 'Ctrl')
+    else if (mod === 'alt') symbols.push(isMac ? '⌥' : 'Alt')
+    else if (mod === 'shift') symbols.push(isMac ? '⇧' : 'Shift')
+  }
+  const keyDisplay = binding.key.length === 1 ? binding.key.toUpperCase() : binding.key
+  return [...symbols, keyDisplay].join(isMac ? '' : '+')
+}
+
+// Re-exported so other modules retain the same import surface.
+export type { ShortcutCategory }

--- a/src/renderer/src/i18n/messages.ts
+++ b/src/renderer/src/i18n/messages.ts
@@ -113,6 +113,13 @@ export const messages: Record<AppLocale, MessageTree> = {
           description:
             'This will reset all settings, theme, and keyboard shortcuts to their defaults.',
           success: 'All settings reset to defaults'
+        },
+        reopenOnboarding: {
+          label: 'Re-run welcome setup',
+          description:
+            'Reopen the first-launch wizard to revisit the agent, keymap, and theme decisions.',
+          button: 'Re-run setup',
+          toast: 'Welcome setup will reopen now.'
         }
       },
       editor: {
@@ -303,6 +310,13 @@ export const messages: Record<AppLocale, MessageTree> = {
         conflictDescription: 'This binding is already used by:',
         resetTitle: 'Reset to default',
         recording: 'Press keys...',
+        preset: {
+          label: 'Keymap preset',
+          description:
+            'Switching the preset only changes shortcuts that differ from the default. Your custom bindings always win.',
+          customNotice:
+            'You have {count} custom binding(s) that override this preset on the same shortcuts.'
+        },
         categories: {
           recent: 'Recent',
           navigation: 'Navigation',
@@ -1010,7 +1024,10 @@ export const messages: Record<AppLocale, MessageTree> = {
         runInTerminal: 'Open in Terminal',
         copyCommand: 'Copy command',
         quit: 'Quit app',
-        start: 'Start with this setup'
+        start: 'Start with this setup',
+        finish: 'Finish setup',
+        finishHint: 'Wrap up and enter Xuanpu',
+        finishDisabledHint: 'Install or sign in to at least one agent, or pick Terminal mode.'
       },
       loading: {
         title: 'Checking your local setup',
@@ -1043,6 +1060,12 @@ export const messages: Record<AppLocale, MessageTree> = {
           title: 'Xcode Command Line Tools',
           ready: 'Installed',
           missing: 'Recommended for Git and common local toolchains on macOS.'
+        },
+        collapsed: {
+          allReady: '{count}/{total} environment checks ready',
+          needsAttention: '{count} item(s) need attention',
+          expand: 'Show details',
+          collapse: 'Hide details'
         }
       },
       agents: {
@@ -1111,7 +1134,97 @@ export const messages: Record<AppLocale, MessageTree> = {
         docsOpened: 'Opened the official documentation',
         terminalOpened: 'Opened the command in the system terminal',
         actionFailed: 'Action failed',
-        selectedAgentRequired: 'Select a ready agent, or continue with Terminal mode.'
+        selectedAgentRequired: 'Select a ready agent, or continue with Terminal mode.',
+        defaultAgentSet: '{agent} is now your default for new sessions.',
+        terminalFallbackSet: 'Set Terminal mode as the fallback default.'
+      },
+      providers: {
+        title: 'AI agents',
+        description:
+          'Install, sign in, and pick a default. You can change this later in Settings.',
+        actions: {
+          install: 'Install',
+          login: 'Sign in',
+          recheck: 'Re-check',
+          setDefault: 'Set as default',
+          isDefault: 'Default agent',
+          docs: 'Docs'
+        },
+        defaultRuntimeReadout: 'Default: {agent}',
+        defaultRuntimeUnset: 'No default selected — pick one below or use Terminal mode.',
+        terminal: {
+          fallbackTitle: 'Terminal mode',
+          fallbackDescription:
+            'Skip the agent for now. You still get projects, worktrees, and the integrated terminal.',
+          setFallback: 'Use as fallback',
+          isFallback: 'Current fallback'
+        },
+        loading: {
+          message: 'Detecting installed agents…'
+        },
+        errorBanner: {
+          title: 'Could not finish the agent check',
+          retry: 'Try again',
+          fallback: 'Continue with Terminal mode'
+        }
+      },
+      keymap: {
+        title: 'Base keymap',
+        description:
+          'Pick the keystrokes you already know. We only swap shortcuts that differ from Xuanpu defaults.',
+        sample: '{shortcut} {label}',
+        samples: {
+          commandPalette: 'Command palette',
+          fileSearch: 'Find file'
+        },
+        importTitle: 'Import from your editor',
+        importDescription:
+          'We can read keybindings.json from VS Code or Cursor and bring over the commands we recognize.',
+        importEmpty: 'No VS Code or Cursor settings detected on this machine.',
+        importNotFound: 'keybindings.json not found at:\n{path}',
+        importBusy: 'Importing…',
+        importApply: 'Import from {source}',
+        importSourceVscode: 'VS Code',
+        importSourceCursor: 'Cursor',
+        importToast: {
+          success: 'Imported {count} keybinding(s) from {source}.',
+          partial:
+            'Imported {applied} from {source}; {skipped} skipped due to conflicts or unsupported shortcuts.',
+          empty: 'Nothing to import from {source} — no recognised commands.',
+          notFound: 'No keybindings.json found for {source}.',
+          error: 'Could not import from {source}: {message}'
+        },
+        importMeta: {
+          unmapped: '{count} command(s) we don’t map yet were skipped.',
+          contextScoped: '{count} entry(ies) with `when` clauses were skipped.'
+        },
+        presets: {
+          'xuanpu-default': {
+            label: 'Xuanpu default',
+            description: 'The shortcuts shipped with Xuanpu, tuned for AI sessions.'
+          },
+          vscode: {
+            label: 'VS Code',
+            description: 'Cmd+Shift+P palette, Cmd+P quick open — the muscle memory you brought.'
+          },
+          jetbrains: {
+            label: 'JetBrains',
+            description: 'Cmd+Shift+A find action, Cmd+Shift+O search everywhere.'
+          }
+        },
+        toast: {
+          switched: 'Switched to {preset}',
+          conflicts:
+            'Switched to {preset}. {count} of your custom shortcuts will keep overriding the preset.',
+          viewConflicts: 'Review them'
+        }
+      },
+      appearance: {
+        title: 'Appearance',
+        description: 'Pick a theme. You can fine-tune density and fonts later in Settings.',
+        followSystem: 'Follow system',
+        light: 'Light',
+        dark: 'Dark'
       }
     },
     sessionView: {
@@ -2412,6 +2525,12 @@ export const messages: Record<AppLocale, MessageTree> = {
           label: '重置全部设置',
           description: '这会把所有设置、主题和快捷键恢复到默认值。',
           success: '所有设置已恢复默认值'
+        },
+        reopenOnboarding: {
+          label: '重新运行欢迎向导',
+          description: '再次打开首次启动的引导页，重新选择 Agent、键位预设和主题。',
+          button: '重新运行',
+          toast: '欢迎向导即将打开。'
         }
       },
       editor: {
@@ -2597,6 +2716,11 @@ export const messages: Record<AppLocale, MessageTree> = {
         conflictDescription: '该按键已被以下操作占用：',
         resetTitle: '恢复默认',
         recording: '请按下按键...',
+        preset: {
+          label: '键位预设',
+          description: '切换预设只会改动与默认不同的快捷键。你的自定义始终优先生效。',
+          customNotice: '当前有 {count} 项自定义会继续覆盖该预设上的同名快捷键。'
+        },
         categories: {
           recent: '最近',
           navigation: '导航',
@@ -3299,7 +3423,10 @@ export const messages: Record<AppLocale, MessageTree> = {
         runInTerminal: '在终端中打开',
         copyCommand: '复制命令',
         quit: '退出应用',
-        start: '使用当前配置开始'
+        start: '使用当前配置开始',
+        finish: '完成安装',
+        finishHint: '收尾并进入玄圃',
+        finishDisabledHint: '至少安装/登录一个 Agent，或者选择终端兜底再继续。'
       },
       loading: {
         title: '正在检查本地环境',
@@ -3332,6 +3459,12 @@ export const messages: Record<AppLocale, MessageTree> = {
           title: 'Xcode Command Line Tools',
           ready: '已安装',
           missing: '在 macOS 上推荐安装，便于 Git 和常见本地工具链正常工作。'
+        },
+        collapsed: {
+          allReady: '{count}/{total} 项环境就绪',
+          needsAttention: '{count} 项需关注',
+          expand: '展开详情',
+          collapse: '收起详情'
         }
       },
       agents: {
@@ -3397,7 +3530,91 @@ export const messages: Record<AppLocale, MessageTree> = {
         docsOpened: '已打开官方文档',
         terminalOpened: '已在系统终端中打开命令',
         actionFailed: '操作失败',
-        selectedAgentRequired: '先选择一个可用 Agent，或者改用终端模式继续。'
+        selectedAgentRequired: '先选择一个可用 Agent，或者改用终端模式继续。',
+        defaultAgentSet: '已把 {agent} 设为新会话默认 Agent。',
+        terminalFallbackSet: '已把终端模式设为兜底默认。'
+      },
+      providers: {
+        title: 'AI Agent',
+        description: '安装、登录、设置默认。这些之后都可以在设置里改。',
+        actions: {
+          install: '安装',
+          login: '登录',
+          recheck: '重新检测',
+          setDefault: '设为默认',
+          isDefault: '当前默认',
+          docs: '文档'
+        },
+        defaultRuntimeReadout: '默认：{agent}',
+        defaultRuntimeUnset: '尚未选默认 Agent — 在下方挑一个，或先用终端模式。',
+        terminal: {
+          fallbackTitle: '终端模式',
+          fallbackDescription: '暂时跳过 Agent，仍然可以使用项目、worktree 和集成终端。',
+          setFallback: '用作兜底',
+          isFallback: '当前兜底'
+        },
+        loading: {
+          message: '正在检测已安装的 Agent…'
+        },
+        errorBanner: {
+          title: 'Agent 检查未能完成',
+          retry: '重试',
+          fallback: '改用终端模式继续'
+        }
+      },
+      keymap: {
+        title: '键位预设',
+        description: '从你熟悉的编辑器迁移。我们只换掉与玄圃默认不同的快捷键。',
+        sample: '{shortcut}  {label}',
+        samples: {
+          commandPalette: '命令面板',
+          fileSearch: '查找文件'
+        },
+        importTitle: '从你的编辑器导入',
+        importDescription: '我们可以读取 VS Code 或 Cursor 的 keybindings.json，把能识别的命令直接搬过来。',
+        importEmpty: '本机没有检测到 VS Code 或 Cursor 的设置。',
+        importNotFound: '没找到 keybindings.json：\n{path}',
+        importBusy: '正在导入…',
+        importApply: '从 {source} 导入',
+        importSourceVscode: 'VS Code',
+        importSourceCursor: 'Cursor',
+        importToast: {
+          success: '已从 {source} 导入 {count} 条快捷键。',
+          partial: '已从 {source} 导入 {applied} 条；{skipped} 条因冲突或不支持被跳过。',
+          empty: '{source} 里没有可导入的快捷键（没识别到玄圃支持的命令）。',
+          notFound: '未找到 {source} 的 keybindings.json。',
+          error: '导入 {source} 失败：{message}'
+        },
+        importMeta: {
+          unmapped: '另有 {count} 条命令暂未支持映射，已跳过。',
+          contextScoped: '另有 {count} 条带 `when` 上下文的快捷键被跳过。'
+        },
+        presets: {
+          'xuanpu-default': {
+            label: '玄圃默认',
+            description: '玄圃自带的快捷键，针对 AI 会话做了细调。'
+          },
+          vscode: {
+            label: 'VS Code',
+            description: 'Cmd+Shift+P 命令面板、Cmd+P 文件搜索 — 你熟悉的肌肉记忆。'
+          },
+          jetbrains: {
+            label: 'JetBrains',
+            description: 'Cmd+Shift+A 找操作、Cmd+Shift+O 全局搜索。'
+          }
+        },
+        toast: {
+          switched: '已切换到 {preset}',
+          conflicts: '已切换到 {preset}。你的 {count} 个自定义会继续覆盖该预设。',
+          viewConflicts: '去查看'
+        }
+      },
+      appearance: {
+        title: '外观',
+        description: '选一个主题。字号和密度可以稍后在设置里精调。',
+        followSystem: '跟随系统',
+        light: '浅色',
+        dark: '深色'
       }
     },
     sessionView: {

--- a/src/renderer/src/lib/keyboard-shortcuts.ts
+++ b/src/renderer/src/lib/keyboard-shortcuts.ts
@@ -200,6 +200,102 @@ const shortcutMap = new Map<string, ShortcutDefinition>()
 DEFAULT_SHORTCUTS.forEach((s) => shortcutMap.set(s.id, s))
 
 // ==========================================
+// Keymap Presets
+// ==========================================
+
+export type KeymapPresetId = 'xuanpu-default' | 'vscode' | 'jetbrains'
+
+export interface KeymapPresetMeta {
+  id: KeymapPresetId
+  /** i18n key under `onboardingWizard.keymap.presets.{id}.label` */
+  labelKey: string
+  /** i18n key under `onboardingWizard.keymap.presets.{id}.description` */
+  descriptionKey: string
+  /** Sparse map: only shortcuts that differ from DEFAULT_SHORTCUTS. */
+  overrides: Partial<Record<string, KeyBinding>>
+}
+
+export const DEFAULT_KEYMAP_PRESET: KeymapPresetId = 'xuanpu-default'
+
+export const KEYMAP_PRESETS: Record<KeymapPresetId, KeymapPresetMeta> = {
+  'xuanpu-default': {
+    id: 'xuanpu-default',
+    labelKey: 'onboardingWizard.keymap.presets.xuanpu-default.label',
+    descriptionKey: 'onboardingWizard.keymap.presets.xuanpu-default.description',
+    overrides: {}
+  },
+  vscode: {
+    id: 'vscode',
+    labelKey: 'onboardingWizard.keymap.presets.vscode.label',
+    descriptionKey: 'onboardingWizard.keymap.presets.vscode.description',
+    overrides: {
+      'nav:command-palette': { key: 'p', modifiers: ['meta', 'shift'] },
+      'nav:file-search': { key: 'p', modifiers: ['meta'] },
+      'git:push': { key: 'p', modifiers: ['alt', 'meta'] },
+      'git:commit': { key: 'Enter', modifiers: ['meta'] },
+      'git:pull': { key: 'l', modifiers: ['alt', 'meta'] },
+      'nav:filter-projects': { key: 'f', modifiers: ['meta', 'shift'] },
+      'terminal:new-tab': { key: '`', modifiers: ['ctrl', 'shift'] },
+      'terminal:close-tab': { key: 'k', modifiers: ['ctrl', 'shift'] },
+      'sidebar:toggle-right': { key: 'b', modifiers: ['alt', 'meta'] }
+    }
+  },
+  jetbrains: {
+    id: 'jetbrains',
+    labelKey: 'onboardingWizard.keymap.presets.jetbrains.label',
+    descriptionKey: 'onboardingWizard.keymap.presets.jetbrains.description',
+    overrides: {
+      'nav:command-palette': { key: 'a', modifiers: ['meta', 'shift'] },
+      'nav:file-search': { key: 'o', modifiers: ['meta', 'shift'] },
+      'nav:session-history': { key: 'e', modifiers: ['meta'] },
+      'git:commit': { key: 'k', modifiers: ['meta'] },
+      'git:push': { key: 'k', modifiers: ['meta', 'shift'] },
+      'sidebar:toggle-left': { key: '1', modifiers: ['meta'] },
+      'focus:left-sidebar': { key: '1', modifiers: ['alt'] },
+      'focus:main-pane': { key: '2', modifiers: ['alt'] }
+    }
+  }
+}
+
+export const KEYMAP_PRESET_ORDER: KeymapPresetId[] = ['xuanpu-default', 'vscode', 'jetbrains']
+
+/**
+ * Resolve the effective binding for a shortcut under a preset, with optional custom override.
+ * Priority: custom > preset.overrides > DEFAULT_SHORTCUTS.
+ */
+export function resolveBindingForPreset(
+  shortcutId: string,
+  preset: KeymapPresetId,
+  custom?: KeyBinding
+): KeyBinding | null {
+  if (custom) return custom
+  const override = KEYMAP_PRESETS[preset]?.overrides[shortcutId]
+  if (override) return override
+  return shortcutMap.get(shortcutId)?.defaultBinding ?? null
+}
+
+/**
+ * Build a Map of every shortcut's effective binding for the given preset (no custom overlay).
+ * Useful for conflict detection.
+ */
+export function buildPresetBindingMap(preset: KeymapPresetId): Map<string, KeyBinding> {
+  const result = new Map<string, KeyBinding>()
+  for (const def of DEFAULT_SHORTCUTS) {
+    const binding = resolveBindingForPreset(def.id, preset)
+    if (binding) result.set(def.id, binding)
+  }
+  return result
+}
+
+/**
+ * Returns true if the preset's overrides reference only known shortcut ids.
+ * Used by tests to ensure presets don't drift from DEFAULT_SHORTCUTS.
+ */
+export function presetOverridesAreValid(preset: KeymapPresetId): boolean {
+  return Object.keys(KEYMAP_PRESETS[preset].overrides).every((id) => shortcutMap.has(id))
+}
+
+// ==========================================
 // Utility Functions
 // ==========================================
 

--- a/src/renderer/src/stores/useShortcutStore.ts
+++ b/src/renderer/src/stores/useShortcutStore.ts
@@ -2,16 +2,36 @@ import { create } from 'zustand'
 import { persist, createJSONStorage } from 'zustand/middleware'
 import {
   type KeyBinding,
+  type KeymapPresetId,
   DEFAULT_SHORTCUTS,
+  DEFAULT_KEYMAP_PRESET,
+  KEYMAP_PRESETS,
   detectConflicts,
-  formatBinding
+  formatBinding,
+  resolveBindingForPreset,
+  serializeBinding
 } from '@/lib/keyboard-shortcuts'
 
 const SHORTCUTS_SETTING_KEY = 'keyboard_shortcuts'
+const KEYMAP_PRESET_SETTING_KEY = 'keymap_preset'
+
+export interface ShortcutImportEntry {
+  shortcutId: string
+  binding: KeyBinding
+}
+
+export interface ShortcutImportApplyResult {
+  applied: number
+  /** Pairs of shortcut ids that share the same effective binding after import. */
+  conflicts: Array<[string, string]>
+}
 
 interface ShortcutState {
-  // Custom bindings - keyed by shortcut ID
+  // Custom bindings - keyed by shortcut ID. Always wins over preset overrides.
   customBindings: Record<string, KeyBinding>
+
+  // Currently selected keymap preset. Lives between DEFAULT_SHORTCUTS and customBindings.
+  activePreset: KeymapPresetId
 
   // Actions
   setCustomBinding: (
@@ -20,6 +40,14 @@ interface ShortcutState {
   ) => { success: boolean; conflicts?: string[] }
   removeCustomBinding: (shortcutId: string) => void
   resetToDefaults: () => void
+  setActivePreset: (preset: KeymapPresetId) => { customCollisions: string[] }
+  /**
+   * Bulk-apply imported keybindings (e.g. from VS Code / Cursor). Bypasses the
+   * standard conflict guard — the import is treated as user intent and wins
+   * over earlier customizations. Conflicts that result are surfaced in the
+   * return value so the UI can warn the user.
+   */
+  applyImportEntries: (entries: ShortcutImportEntry[]) => ShortcutImportApplyResult
   getEffectiveBinding: (shortcutId: string) => KeyBinding | null
   getAllEffectiveBindings: () => Map<string, KeyBinding>
   getConflicts: (shortcutId: string, binding: KeyBinding) => string[]
@@ -31,6 +59,7 @@ export const useShortcutStore = create<ShortcutState>()(
   persist(
     (set, get) => ({
       customBindings: {},
+      activePreset: DEFAULT_KEYMAP_PRESET,
 
       setCustomBinding: (shortcutId: string, binding: KeyBinding) => {
         const allBindings = get().getAllEffectiveBindings()
@@ -43,7 +72,7 @@ export const useShortcutStore = create<ShortcutState>()(
         set((state) => {
           const newBindings = { ...state.customBindings, [shortcutId]: binding }
           // Persist to database async
-          saveToDatabase(newBindings)
+          saveBindingsToDatabase(newBindings)
           return { customBindings: newBindings }
         })
 
@@ -54,30 +83,93 @@ export const useShortcutStore = create<ShortcutState>()(
         set((state) => {
           const newBindings = { ...state.customBindings }
           delete newBindings[shortcutId]
-          saveToDatabase(newBindings)
+          saveBindingsToDatabase(newBindings)
           return { customBindings: newBindings }
         })
       },
 
       resetToDefaults: () => {
-        set({ customBindings: {} })
-        saveToDatabase({})
+        set({ customBindings: {}, activePreset: DEFAULT_KEYMAP_PRESET })
+        saveBindingsToDatabase({})
+        savePresetToDatabase(DEFAULT_KEYMAP_PRESET)
+      },
+
+      setActivePreset: (preset: KeymapPresetId) => {
+        // Detect which custom bindings would now mask non-default preset overrides
+        // (i.e., user customized a shortcut that this preset also remaps).
+        const customBindings = get().customBindings
+        const overrides = KEYMAP_PRESETS[preset]?.overrides ?? {}
+        const customCollisions: string[] = []
+
+        for (const id of Object.keys(customBindings)) {
+          const presetBinding = overrides[id]
+          if (!presetBinding) continue
+          // If the customization actually differs from what the preset would set,
+          // the user's choice will override the preset and is worth flagging.
+          if (serializeBinding(customBindings[id]) !== serializeBinding(presetBinding)) {
+            customCollisions.push(id)
+          }
+        }
+
+        set({ activePreset: preset })
+        savePresetToDatabase(preset)
+
+        return { customCollisions }
+      },
+
+      applyImportEntries: (entries: ShortcutImportEntry[]) => {
+        if (entries.length === 0) {
+          return { applied: 0, conflicts: [] }
+        }
+
+        const newBindings: Record<string, KeyBinding> = { ...get().customBindings }
+        for (const entry of entries) {
+          newBindings[entry.shortcutId] = entry.binding
+        }
+
+        set({ customBindings: newBindings })
+        saveBindingsToDatabase(newBindings)
+
+        // Post-apply conflict scan: walk the new effective binding map and
+        // surface any duplicate (key, modifiers) pairs across shortcut ids.
+        const effective = new Map<string, KeyBinding>()
+        const { activePreset } = get()
+        for (const def of DEFAULT_SHORTCUTS) {
+          const binding = resolveBindingForPreset(def.id, activePreset, newBindings[def.id])
+          if (binding) effective.set(def.id, binding)
+        }
+
+        const seen = new Map<string, string>()
+        const conflicts: Array<[string, string]> = []
+        for (const [id, binding] of effective) {
+          const key = serializeBinding(binding)
+          const prior = seen.get(key)
+          if (prior) {
+            conflicts.push([prior, id])
+          } else {
+            seen.set(key, id)
+          }
+        }
+
+        return { applied: entries.length, conflicts }
       },
 
       getEffectiveBinding: (shortcutId: string) => {
-        const custom = get().customBindings[shortcutId]
-        if (custom) return custom
-
-        const defaultShortcut = DEFAULT_SHORTCUTS.find((s) => s.id === shortcutId)
-        return defaultShortcut?.defaultBinding ?? null
+        const { customBindings, activePreset } = get()
+        return resolveBindingForPreset(shortcutId, activePreset, customBindings[shortcutId])
       },
 
       getAllEffectiveBindings: () => {
         const bindings = new Map<string, KeyBinding>()
-        const custom = get().customBindings
+        const { customBindings, activePreset } = get()
 
         for (const shortcut of DEFAULT_SHORTCUTS) {
-          bindings.set(shortcut.id, custom[shortcut.id] ?? shortcut.defaultBinding)
+          const binding = resolveBindingForPreset(
+            shortcut.id,
+            activePreset,
+            customBindings[shortcut.id]
+          )
+          if (binding) bindings.set(shortcut.id, binding)
         }
 
         return bindings
@@ -96,12 +188,25 @@ export const useShortcutStore = create<ShortcutState>()(
 
       loadFromDatabase: async () => {
         try {
-          if (typeof window !== 'undefined' && window.db?.setting) {
-            const value = await window.db.setting.get(SHORTCUTS_SETTING_KEY)
-            if (value) {
-              const parsed = JSON.parse(value) as Record<string, KeyBinding>
-              set({ customBindings: parsed })
-            }
+          if (typeof window === 'undefined' || !window.db?.setting) return
+
+          const [rawBindings, rawPreset] = await Promise.all([
+            window.db.setting.get(SHORTCUTS_SETTING_KEY),
+            window.db.setting.get(KEYMAP_PRESET_SETTING_KEY)
+          ])
+
+          const update: Partial<ShortcutState> = {}
+
+          if (rawBindings) {
+            update.customBindings = JSON.parse(rawBindings) as Record<string, KeyBinding>
+          }
+
+          if (rawPreset && isKeymapPresetId(rawPreset)) {
+            update.activePreset = rawPreset
+          }
+
+          if (Object.keys(update).length > 0) {
+            set(update)
           }
         } catch (error) {
           console.error('Failed to load shortcuts from database:', error)
@@ -112,20 +217,35 @@ export const useShortcutStore = create<ShortcutState>()(
       name: 'hive-shortcuts',
       storage: createJSONStorage(() => localStorage),
       partialize: (state) => ({
-        customBindings: state.customBindings
+        customBindings: state.customBindings,
+        activePreset: state.activePreset
       })
     }
   )
 )
 
+function isKeymapPresetId(value: string): value is KeymapPresetId {
+  return value in KEYMAP_PRESETS
+}
+
 // Save to SQLite database (async, non-blocking)
-async function saveToDatabase(bindings: Record<string, KeyBinding>): Promise<void> {
+async function saveBindingsToDatabase(bindings: Record<string, KeyBinding>): Promise<void> {
   try {
     if (typeof window !== 'undefined' && window.db?.setting) {
       await window.db.setting.set(SHORTCUTS_SETTING_KEY, JSON.stringify(bindings))
     }
   } catch (error) {
     console.error('Failed to save shortcuts to database:', error)
+  }
+}
+
+async function savePresetToDatabase(preset: KeymapPresetId): Promise<void> {
+  try {
+    if (typeof window !== 'undefined' && window.db?.setting) {
+      await window.db.setting.set(KEYMAP_PRESET_SETTING_KEY, preset)
+    }
+  } catch (error) {
+    console.error('Failed to save keymap preset to database:', error)
   }
 }
 

--- a/src/shared/types/keybinding-import.ts
+++ b/src/shared/types/keybinding-import.ts
@@ -1,0 +1,54 @@
+/**
+ * Shared types for the "Import keybindings from VS Code / Cursor" flow.
+ *
+ * The main process detects + parses the source JSONC file; the renderer then
+ * walks the resulting entries and feeds them to `useShortcutStore.setCustomBinding`.
+ * Keeping the binding shape primitive (no enum imports) lets the IPC layer
+ * stay decoupled from the renderer keymap module.
+ */
+
+export type KeybindingImportSourceId = 'vscode' | 'cursor'
+
+export type KeybindingModifier = 'ctrl' | 'meta' | 'alt' | 'shift'
+
+export interface KeybindingImportBinding {
+  /** lowercase key as `event.key`, or special name like 'Enter' / 'Tab' / 'Escape' */
+  key: string
+  modifiers: KeybindingModifier[]
+}
+
+export interface KeybindingImportSourceInfo {
+  id: KeybindingImportSourceId
+  /** Best-known absolute path to the source's keybindings.json (may not exist). */
+  path: string
+  /** True when the file is present and readable. */
+  exists: boolean
+  /** Convenience flag — same as `exists` for now, kept for future heuristics. */
+  available: boolean
+}
+
+export interface KeybindingImportEntry {
+  /** Xuanpu shortcut id this binding maps onto. */
+  shortcutId: string
+  binding: KeybindingImportBinding
+  /** Original VS Code / Cursor command, e.g. "workbench.action.showCommands" */
+  sourceCommand: string
+  /** Original "key" string from the source, e.g. "cmd+shift+p" */
+  sourceKey: string
+}
+
+export interface KeybindingImportResult {
+  source: KeybindingImportSourceId
+  /** Path that was read. */
+  path: string
+  /** Total raw rows in keybindings.json (including unmapped + skipped). */
+  parsedRows: number
+  /** Bindings ready to apply. */
+  entries: KeybindingImportEntry[]
+  /** VS Code commands without a Xuanpu equivalent (deduplicated). */
+  unmapped: string[]
+  /** Rows skipped due to a `when` context clause (we can't honor those). */
+  contextScoped: number
+  /** Parse / IO errors. */
+  errors: string[]
+}

--- a/test/onboarding/keybinding-import.test.ts
+++ b/test/onboarding/keybinding-import.test.ts
@@ -1,0 +1,298 @@
+import { describe, test, expect, vi, beforeEach } from 'vitest'
+
+import {
+  stripJsonc,
+  stripTrailingCommas,
+  parseKeyString,
+  parseImportSource,
+  detectImportSources,
+  VSCODE_COMMAND_TO_SHORTCUT
+} from '../../src/main/services/keybinding-import'
+
+// fs mock — every test resets the mock state
+vi.mock('node:fs/promises', () => ({
+  default: {},
+  access: vi.fn(),
+  readFile: vi.fn()
+}))
+
+// minimal logger mock so we don't try to write to disk
+vi.mock('../../src/main/services/logger', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn()
+  })
+}))
+
+import * as fs from 'node:fs/promises'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+// ============================================================================
+// JSONC parser
+// ============================================================================
+
+describe('stripJsonc', () => {
+  test('removes line comments', () => {
+    expect(stripJsonc('// hi\n{"a":1}')).toBe('\n{"a":1}')
+  })
+
+  test('removes block comments', () => {
+    expect(stripJsonc('/* hi */{"a":1}')).toBe('{"a":1}')
+  })
+
+  test('keeps comment-like substrings inside strings', () => {
+    expect(stripJsonc('{"key":"// not a comment"}')).toBe('{"key":"// not a comment"}')
+  })
+
+  test('handles escaped quotes inside strings', () => {
+    expect(stripJsonc('{"key":"a\\"b // c"}')).toBe('{"key":"a\\"b // c"}')
+  })
+
+  test('removes both line and block comments interleaved', () => {
+    const input = `[
+      // first
+      { "key": "a" },
+      /* between */
+      { "key": "b" } // trailing
+    ]`
+    const out = stripJsonc(input)
+    expect(out).not.toContain('// first')
+    expect(out).not.toContain('/* between */')
+    expect(out).not.toContain('// trailing')
+  })
+})
+
+describe('stripTrailingCommas', () => {
+  test('removes trailing comma before closing brace', () => {
+    expect(stripTrailingCommas('{"a":1,}')).toBe('{"a":1}')
+  })
+  test('removes trailing comma before closing bracket', () => {
+    expect(stripTrailingCommas('[1,2,]')).toBe('[1,2]')
+  })
+  test('preserves valid commas', () => {
+    expect(stripTrailingCommas('[1,2,3]')).toBe('[1,2,3]')
+  })
+})
+
+// ============================================================================
+// parseKeyString
+// ============================================================================
+
+describe('parseKeyString', () => {
+  test('parses cmd+shift+p', () => {
+    expect(parseKeyString('cmd+shift+p')).toEqual({
+      key: 'p',
+      modifiers: ['meta', 'shift']
+    })
+  })
+
+  test('parses ctrl+f', () => {
+    expect(parseKeyString('ctrl+f')).toEqual({
+      key: 'f',
+      modifiers: ['ctrl']
+    })
+  })
+
+  test('parses alt+enter and normalizes the key name', () => {
+    expect(parseKeyString('alt+enter')).toEqual({
+      key: 'Enter',
+      modifiers: ['alt']
+    })
+  })
+
+  test('parses chord shortcut by taking only the first chord', () => {
+    expect(parseKeyString('ctrl+k ctrl+s')).toEqual({
+      key: 'k',
+      modifiers: ['ctrl']
+    })
+  })
+
+  test('handles uppercase mixed input', () => {
+    expect(parseKeyString('CMD+SHIFT+P')).toEqual({
+      key: 'p',
+      modifiers: ['meta', 'shift']
+    })
+  })
+
+  test('treats win/super as meta', () => {
+    expect(parseKeyString('win+a')).toEqual({ key: 'a', modifiers: ['meta'] })
+    expect(parseKeyString('super+a')).toEqual({ key: 'a', modifiers: ['meta'] })
+  })
+
+  test('treats option as alt', () => {
+    expect(parseKeyString('option+t')).toEqual({ key: 't', modifiers: ['alt'] })
+  })
+
+  test('returns null when there is no non-modifier key', () => {
+    expect(parseKeyString('cmd+shift')).toBeNull()
+  })
+
+  test('returns null on empty string', () => {
+    expect(parseKeyString('')).toBeNull()
+  })
+
+  test('normalizes arrow keys', () => {
+    expect(parseKeyString('cmd+up')).toEqual({ key: 'ArrowUp', modifiers: ['meta'] })
+  })
+
+  test('does not duplicate modifiers when listed twice', () => {
+    expect(parseKeyString('cmd+meta+a')).toEqual({ key: 'a', modifiers: ['meta'] })
+  })
+})
+
+// ============================================================================
+// VSCODE_COMMAND_TO_SHORTCUT mapping
+// ============================================================================
+
+describe('VSCODE_COMMAND_TO_SHORTCUT', () => {
+  test('maps the most-used commands to Xuanpu shortcuts', () => {
+    expect(VSCODE_COMMAND_TO_SHORTCUT['workbench.action.showCommands']).toBe('nav:command-palette')
+    expect(VSCODE_COMMAND_TO_SHORTCUT['workbench.action.quickOpen']).toBe('nav:file-search')
+    expect(VSCODE_COMMAND_TO_SHORTCUT['workbench.action.terminal.new']).toBe('terminal:new-tab')
+    expect(VSCODE_COMMAND_TO_SHORTCUT['git.push']).toBe('git:push')
+  })
+
+  test('does not contain values that point at non-existent shortcut categories', () => {
+    // crude sanity: every value uses the {category}:{action} convention
+    for (const value of Object.values(VSCODE_COMMAND_TO_SHORTCUT)) {
+      expect(value).toMatch(/^[a-z]+(?:-[a-z]+)*:[a-z-]+$/)
+    }
+  })
+})
+
+// ============================================================================
+// parseImportSource (full pipeline)
+// ============================================================================
+
+describe('parseImportSource', () => {
+  test('returns errors when the file does not exist', async () => {
+    vi.mocked(fs.readFile).mockRejectedValue(new Error('ENOENT'))
+
+    const result = await parseImportSource('vscode')
+
+    expect(result.entries).toEqual([])
+    expect(result.errors.length).toBeGreaterThan(0)
+    expect(result.errors[0]).toMatch(/Failed to read/)
+  })
+
+  test('returns errors when the file is not a JSON array', async () => {
+    vi.mocked(fs.readFile).mockResolvedValue('{"key":"value"}')
+
+    const result = await parseImportSource('vscode')
+
+    expect(result.errors).toContain('keybindings.json is not a JSON array')
+  })
+
+  test('returns errors when the file is malformed JSONC', async () => {
+    vi.mocked(fs.readFile).mockResolvedValue('this is not json at all')
+
+    const result = await parseImportSource('vscode')
+
+    expect(result.errors.length).toBeGreaterThan(0)
+    expect(result.errors[0]).toMatch(/Could not parse keybindings\.json/)
+  })
+
+  test('maps known commands and skips unmapped ones', async () => {
+    const file = `[
+      // mapped — VS Code default for the command palette
+      { "key": "cmd+shift+p", "command": "workbench.action.showCommands" },
+      // mapped — terminal new tab
+      { "key": "cmd+shift+grave", "command": "workbench.action.terminal.new" },
+      // unmapped — editor-internal
+      { "key": "cmd+d", "command": "editor.action.addSelectionToNextFindMatch" },
+    ]`
+    vi.mocked(fs.readFile).mockResolvedValue(file)
+
+    const result = await parseImportSource('vscode')
+
+    expect(result.parsedRows).toBe(3)
+    expect(result.entries.length).toBe(2)
+    expect(result.entries.map((e) => e.shortcutId).sort()).toEqual([
+      'nav:command-palette',
+      'terminal:new-tab'
+    ])
+    expect(result.unmapped).toContain('editor.action.addSelectionToNextFindMatch')
+  })
+
+  test('skips rows with a `when` clause but counts them', async () => {
+    const file = `[
+      { "key": "cmd+shift+p", "command": "workbench.action.showCommands", "when": "editorTextFocus" }
+    ]`
+    vi.mocked(fs.readFile).mockResolvedValue(file)
+
+    const result = await parseImportSource('vscode')
+
+    expect(result.entries).toEqual([])
+    expect(result.contextScoped).toBe(1)
+  })
+
+  test('skips VS Code "-command" unbinds', async () => {
+    const file = `[
+      { "key": "cmd+t", "command": "-workbench.action.tasks.runTask" }
+    ]`
+    vi.mocked(fs.readFile).mockResolvedValue(file)
+
+    const result = await parseImportSource('vscode')
+
+    expect(result.entries).toEqual([])
+    expect(result.unmapped).toEqual([])
+  })
+
+  test('deduplicates by shortcutId — last entry wins', async () => {
+    const file = `[
+      { "key": "cmd+1", "command": "workbench.action.quickOpen" },
+      { "key": "cmd+e", "command": "workbench.action.quickOpen" }
+    ]`
+    vi.mocked(fs.readFile).mockResolvedValue(file)
+
+    const result = await parseImportSource('vscode')
+
+    expect(result.entries.length).toBe(1)
+    expect(result.entries[0].sourceKey).toBe('cmd+e')
+  })
+
+  test('sorts unmapped commands and dedupes them', async () => {
+    const file = `[
+      { "key": "cmd+a", "command": "z.command" },
+      { "key": "cmd+b", "command": "a.command" },
+      { "key": "cmd+c", "command": "z.command" }
+    ]`
+    vi.mocked(fs.readFile).mockResolvedValue(file)
+
+    const result = await parseImportSource('vscode')
+
+    expect(result.unmapped).toEqual(['a.command', 'z.command'])
+  })
+})
+
+// ============================================================================
+// detectImportSources
+// ============================================================================
+
+describe('detectImportSources', () => {
+  test('reports both vscode and cursor entries with platform-aware paths', async () => {
+    vi.mocked(fs.access).mockResolvedValue(undefined as unknown as void)
+
+    const sources = await detectImportSources()
+
+    expect(sources).toHaveLength(2)
+    expect(sources.map((s) => s.id).sort()).toEqual(['cursor', 'vscode'])
+    for (const s of sources) {
+      expect(s.exists).toBe(true)
+      expect(s.path.length).toBeGreaterThan(0)
+    }
+  })
+
+  test('marks `exists: false` when the file is unreadable', async () => {
+    vi.mocked(fs.access).mockRejectedValue(new Error('ENOENT'))
+
+    const sources = await detectImportSources()
+
+    expect(sources.every((s) => !s.exists)).toBe(true)
+  })
+})

--- a/test/onboarding/keymap-presets.test.ts
+++ b/test/onboarding/keymap-presets.test.ts
@@ -1,0 +1,132 @@
+import { describe, test, expect } from 'vitest'
+import {
+  DEFAULT_SHORTCUTS,
+  KEYMAP_PRESETS,
+  KEYMAP_PRESET_ORDER,
+  buildPresetBindingMap,
+  detectConflicts,
+  presetOverridesAreValid,
+  resolveBindingForPreset,
+  serializeBinding,
+  type KeymapPresetId
+} from '../../src/renderer/src/lib/keyboard-shortcuts'
+
+describe('Keymap Presets — structural integrity', () => {
+  test('every preset id matches its key in KEYMAP_PRESETS', () => {
+    for (const [id, meta] of Object.entries(KEYMAP_PRESETS)) {
+      expect(meta.id).toBe(id)
+    }
+  })
+
+  test('KEYMAP_PRESET_ORDER lists every preset exactly once', () => {
+    const sortedKeys = [...Object.keys(KEYMAP_PRESETS)].sort()
+    const sortedOrder = [...KEYMAP_PRESET_ORDER].sort()
+    expect(sortedOrder).toEqual(sortedKeys)
+  })
+
+  test('preset overrides reference only known shortcut ids', () => {
+    for (const presetId of KEYMAP_PRESET_ORDER) {
+      expect(presetOverridesAreValid(presetId)).toBe(true)
+    }
+  })
+
+  test('xuanpu-default preset has no overrides', () => {
+    expect(KEYMAP_PRESETS['xuanpu-default'].overrides).toEqual({})
+  })
+})
+
+describe('Keymap Presets — internal binding consistency', () => {
+  // CRITICAL: Switching to any preset must not produce a self-conflict.
+  // Otherwise Cmd+Shift+P would fire two shortcuts at once.
+  for (const presetId of ['xuanpu-default', 'vscode', 'jetbrains'] as KeymapPresetId[]) {
+    test(`preset "${presetId}" has zero internal conflicts`, () => {
+      const bindings = buildPresetBindingMap(presetId)
+      const seen = new Map<string, string>() // serialized binding -> shortcut id
+
+      for (const [id, binding] of bindings) {
+        const ser = serializeBinding(binding)
+        if (seen.has(ser)) {
+          throw new Error(
+            `Preset "${presetId}" conflict: "${seen.get(ser)}" and "${id}" both bind to "${ser}"`
+          )
+        }
+        seen.set(ser, id)
+      }
+    })
+  }
+})
+
+describe('resolveBindingForPreset — priority', () => {
+  test('returns custom binding when provided', () => {
+    const custom = { key: 'q', modifiers: ['meta'] as const }
+    const result = resolveBindingForPreset('nav:command-palette', 'vscode', {
+      key: 'q',
+      modifiers: ['meta']
+    })
+    expect(result).toEqual(custom)
+  })
+
+  test('returns preset override when no custom', () => {
+    const result = resolveBindingForPreset('nav:command-palette', 'vscode')
+    expect(result).toEqual({ key: 'p', modifiers: ['meta', 'shift'] })
+  })
+
+  test('returns DEFAULT_SHORTCUTS binding when preset has no override', () => {
+    const result = resolveBindingForPreset('session:new', 'vscode')
+    expect(result).toEqual({ key: 't', modifiers: ['meta'] })
+  })
+
+  test('returns null for unknown shortcut id', () => {
+    expect(resolveBindingForPreset('does-not-exist', 'vscode')).toBeNull()
+  })
+})
+
+describe('Preset content sanity (catches accidental drift)', () => {
+  test('vscode preset overrides nav:command-palette to Cmd+Shift+P', () => {
+    expect(KEYMAP_PRESETS.vscode.overrides['nav:command-palette']).toEqual({
+      key: 'p',
+      modifiers: ['meta', 'shift']
+    })
+  })
+
+  test('jetbrains preset overrides nav:command-palette to Cmd+Shift+A (Find Action)', () => {
+    expect(KEYMAP_PRESETS.jetbrains.overrides['nav:command-palette']).toEqual({
+      key: 'a',
+      modifiers: ['meta', 'shift']
+    })
+  })
+
+  test('vscode preset frees Cmd+Shift+P from git:push (now alt+meta+p)', () => {
+    expect(KEYMAP_PRESETS.vscode.overrides['git:push']).toEqual({
+      key: 'p',
+      modifiers: ['alt', 'meta']
+    })
+  })
+
+  test('detectConflicts treats meta and ctrl as separate when serialized', () => {
+    // Sanity: the conflict detector must distinguish ctrl-only vs meta-only,
+    // even though eventMatchesBinding treats them as the same key at runtime.
+    const map = new Map([
+      ['a:1', { key: 't', modifiers: ['meta'] }],
+      ['a:2', { key: 't', modifiers: ['ctrl'] }]
+    ])
+    const conflicts = detectConflicts({ key: 't', modifiers: ['meta'] }, map, 'a:1')
+    expect(conflicts).toEqual([])
+  })
+})
+
+describe('DEFAULT_SHORTCUTS still in sync with presets', () => {
+  test('every shortcut id in DEFAULT_SHORTCUTS is unique', () => {
+    const ids = DEFAULT_SHORTCUTS.map((s) => s.id)
+    const unique = new Set(ids)
+    expect(unique.size).toBe(ids.length)
+  })
+
+  test('xuanpu-default applied = exactly DEFAULT_SHORTCUTS bindings', () => {
+    const bindings = buildPresetBindingMap('xuanpu-default')
+    expect(bindings.size).toBe(DEFAULT_SHORTCUTS.length)
+    for (const def of DEFAULT_SHORTCUTS) {
+      expect(bindings.get(def.id)).toEqual(def.defaultBinding)
+    }
+  })
+})

--- a/test/onboarding/useShortcutStore.test.ts
+++ b/test/onboarding/useShortcutStore.test.ts
@@ -1,0 +1,148 @@
+import { describe, test, expect, beforeEach, vi } from 'vitest'
+import { useShortcutStore } from '../../src/renderer/src/stores/useShortcutStore'
+import { DEFAULT_KEYMAP_PRESET } from '../../src/renderer/src/lib/keyboard-shortcuts'
+
+// Avoid the SQLite IPC layer leaking into tests
+beforeEach(() => {
+  vi.stubGlobal('window', {
+    ...((globalThis as { window?: object }).window ?? {}),
+    db: {
+      setting: {
+        get: vi.fn().mockResolvedValue(null),
+        set: vi.fn().mockResolvedValue(undefined)
+      }
+    }
+  })
+
+  // Clear localStorage so persist middleware starts clean each test
+  localStorage.clear()
+
+  // Reset store to a clean baseline
+  useShortcutStore.setState({
+    customBindings: {},
+    activePreset: DEFAULT_KEYMAP_PRESET
+  })
+})
+
+describe('useShortcutStore — preset switching', () => {
+  test('default activePreset is xuanpu-default', () => {
+    expect(useShortcutStore.getState().activePreset).toBe('xuanpu-default')
+  })
+
+  test('setActivePreset updates state and reports zero collisions when no customBindings', () => {
+    const result = useShortcutStore.getState().setActivePreset('vscode')
+    expect(result.customCollisions).toEqual([])
+    expect(useShortcutStore.getState().activePreset).toBe('vscode')
+  })
+
+  test('after switching to vscode, getEffectiveBinding returns Cmd+Shift+P for command palette', () => {
+    useShortcutStore.getState().setActivePreset('vscode')
+    const binding = useShortcutStore.getState().getEffectiveBinding('nav:command-palette')
+    expect(binding).toEqual({ key: 'p', modifiers: ['meta', 'shift'] })
+  })
+
+  test('after switching to jetbrains, file search is Cmd+Shift+O (Search Everywhere)', () => {
+    useShortcutStore.getState().setActivePreset('jetbrains')
+    const binding = useShortcutStore.getState().getEffectiveBinding('nav:file-search')
+    expect(binding).toEqual({ key: 'o', modifiers: ['meta', 'shift'] })
+  })
+
+  test('shortcut not in preset overrides falls back to DEFAULT_SHORTCUTS', () => {
+    useShortcutStore.getState().setActivePreset('vscode')
+    // session:new is not in any preset override
+    const binding = useShortcutStore.getState().getEffectiveBinding('session:new')
+    expect(binding).toEqual({ key: 't', modifiers: ['meta'] })
+  })
+})
+
+describe('useShortcutStore — custom bindings keep priority over preset', () => {
+  test('customBindings remain active after switching preset', () => {
+    // User customizes command-palette to something completely different
+    const customBinding = { key: 'q', modifiers: ['meta', 'alt'] as const }
+    useShortcutStore.setState({
+      customBindings: { 'nav:command-palette': customBinding }
+    })
+
+    // Switch to vscode preset
+    useShortcutStore.getState().setActivePreset('vscode')
+
+    // The custom binding should still win
+    const binding = useShortcutStore.getState().getEffectiveBinding('nav:command-palette')
+    expect(binding).toEqual(customBinding)
+  })
+
+  test('setActivePreset reports collisions when customBindings differ from preset overrides', () => {
+    // User customized command-palette; vscode preset also remaps it (but to a different value)
+    useShortcutStore.setState({
+      customBindings: {
+        'nav:command-palette': { key: 'q', modifiers: ['meta', 'alt'] }
+      }
+    })
+
+    const result = useShortcutStore.getState().setActivePreset('vscode')
+    expect(result.customCollisions).toContain('nav:command-palette')
+  })
+
+  test('setActivePreset reports no collision when custom equals preset override', () => {
+    // User happens to have customized to the same value vscode would set
+    useShortcutStore.setState({
+      customBindings: {
+        'nav:command-palette': { key: 'p', modifiers: ['meta', 'shift'] }
+      }
+    })
+
+    const result = useShortcutStore.getState().setActivePreset('vscode')
+    expect(result.customCollisions).toEqual([])
+  })
+
+  test('setActivePreset ignores customBindings on shortcuts the preset does not remap', () => {
+    // User customizes session:new (not in any preset) — switching preset should not flag it
+    useShortcutStore.setState({
+      customBindings: {
+        'session:new': { key: 'q', modifiers: ['meta'] }
+      }
+    })
+
+    const result = useShortcutStore.getState().setActivePreset('vscode')
+    expect(result.customCollisions).toEqual([])
+  })
+})
+
+describe('useShortcutStore — getAllEffectiveBindings includes preset overrides', () => {
+  test('vscode preset shifts command-palette and file-search into resolved map', () => {
+    useShortcutStore.getState().setActivePreset('vscode')
+    const all = useShortcutStore.getState().getAllEffectiveBindings()
+    expect(all.get('nav:command-palette')).toEqual({ key: 'p', modifiers: ['meta', 'shift'] })
+    expect(all.get('nav:file-search')).toEqual({ key: 'p', modifiers: ['meta'] })
+  })
+})
+
+describe('useShortcutStore — resetToDefaults', () => {
+  test('clears customBindings and resets preset to xuanpu-default', () => {
+    useShortcutStore.setState({
+      customBindings: { 'session:new': { key: 'q', modifiers: ['meta'] } },
+      activePreset: 'vscode'
+    })
+
+    useShortcutStore.getState().resetToDefaults()
+
+    const state = useShortcutStore.getState()
+    expect(state.customBindings).toEqual({})
+    expect(state.activePreset).toBe('xuanpu-default')
+  })
+})
+
+describe('useShortcutStore — conflict detection respects active preset', () => {
+  test('cannot set custom binding that collides with preset override on a sibling', () => {
+    // Under vscode preset, nav:command-palette = Cmd+Shift+P. Trying to assign the
+    // same combo to git:push must be rejected.
+    useShortcutStore.getState().setActivePreset('vscode')
+
+    const result = useShortcutStore
+      .getState()
+      .setCustomBinding('git:push', { key: 'p', modifiers: ['meta', 'shift'] })
+
+    expect(result.success).toBe(false)
+    expect(result.conflicts).toContain('nav:command-palette')
+  })
+})


### PR DESCRIPTION
## Summary

把首启 onboarding 从"两步 stepper + 单选 agent"改造成单页 4 区块；引入 keymap 预设系统；支持从 VS Code / Cursor 直接导入 keybindings.json。直击的产品反馈：**老 VS Code/JetBrains 用户键位不熟就不愿意换玄圃**。

参考 Zed onboarding 的形态但做"玄圃式克制" —— 不抄 5 provider 凑数、第一方账号 Sign In、Trust All Projects、独立 Vim toggle。

## Highlights

### 1. 单页 4 区块 wizard（替代旧两步 stepper）

```
┌── 欢迎来到玄圃                              完成 ⌘↵ ┐
├── 环境检查（折叠条；issues>0 默认展开）              ┤
├── AI Provider（4 卡片平行：claude / codex / opencode / terminal）
│     每卡独立按钮：Install / Login / 设为默认            
│     install / login 跑完 5s 自动 onRefresh
├── Base Keymap（3 预设网格：默认 / VS Code / JetBrains） 
├── 外观（主题缩略图 + 跟随系统）                        
└── 退出 · 用作兜底 · 完成 ⌘↵                          ┘
```

### 2. Keymap 预设系统

3 套：\`xuanpu-default\` / \`vscode\` / \`jetbrains\`，sparse map（仅覆盖与默认不同的 shortcut）。
- VS Code preset 覆盖 9 项（Cmd+Shift+P 命令面板、Cmd+P 文件搜索 等）
- JetBrains preset 覆盖 8 项（Cmd+Shift+A Find Action、Cmd+Shift+O Search Everywhere 等）
- 优先级：custom > preset > default
- SettingsShortcuts 顶部加 chip 切换器，事后改也方便
- vitest 校验：每套 preset 内部无冲突

### 3. VS Code / Cursor keybindings.json 导入

- 跨平台路径解析（macOS / Linux / Windows）
- 自写 JSONC parser（避免新增依赖）
- 14 条 command 映射（command-palette / quick-open / terminal × 4 / sidebar × 2 / git × 4 / settings × 2 / focus × 2）
- 边界处理：chord shortcut 取首段 / when 上下文跳过 / unbind 跳过 / 未识别命令进 unmapped
- 双触点：onboarding wizard + Settings → Shortcuts
- toast 分级：成功 / 部分冲突 / 未找到 / 空 / 错误

### 4. 杂项

- AgentSetupGuard.completeSetup() 退化为无参，每个选择即时落库（quit 中途选择不丢）
- analytics event_version: 2，新增 default_runtime / keymap_preset / theme_id / theme_follow_system
- SettingsGeneral 加"重新运行欢迎向导"按钮
- 60 个 vitest 单元测试，0 lint error

## 文件改动（15 个）

\`\`\`
src/main/index.ts                                       +15
src/main/services/keybinding-import.ts                 NEW 346
src/preload/index.{ts,d.ts}                             +52
src/renderer/src/components/settings/SettingsGeneral.tsx       +30
src/renderer/src/components/settings/SettingsShortcuts.tsx     +247
src/renderer/src/components/setup/AgentSetupGuard.tsx          +24
src/renderer/src/components/setup/AgentSetupWizard.tsx        +1701/-583
src/renderer/src/i18n/messages.ts                              +225
src/renderer/src/lib/keyboard-shortcuts.ts                     +96
src/renderer/src/stores/useShortcutStore.ts                    +162
src/shared/types/keybinding-import.ts                  NEW 54
test/onboarding/{keybinding-import,keymap-presets,useShortcutStore}.test.ts NEW 578
\`\`\`

## Test plan

- [ ] 全新数据库（删 \`~/.xuanpu/xuanpu.db\`）启动 → 单页 wizard 4 区块全部可见
- [ ] 已用过的库 → Settings → General → "重新运行欢迎向导" → 立即重弹
- [ ] Provider 卡片：点 Install 触发终端命令；5s 后自动 onRefresh；点"设为默认"写库
- [ ] 切 VS Code preset → toast 提示；进 SettingsShortcuts 顶部 chip 同步显示；按 Cmd+Shift+P 真的触发命令面板
- [ ] onboarding 内点主题缩略图 → 整窗口实时变色
- [ ] 中途按 quit → 重启后 wizard 仍弹（initialSetupComplete=false），但 keymap / theme 选择已保留
- [ ] Cmd+Enter 触发"完成"
- [ ] VS Code 导入：点击导入 → keybindings.json 里映射的命令导入成功；toast 显示数量；Settings 顶部立即看到自定义记号
- [ ] Cursor 导入：同上
- [ ] 导入 source 不存在时按钮灰显，hover 显示路径
- [ ] \`pnpm vitest run test/onboarding\` —— 60 / 60 通过
- [ ] \`pnpm lint\` —— 0 errors（44 warnings 与 main 一致，全是预存）

## 不在本 PR 范围

- 隐私 / Telemetry / Vim toggle 区块（用户决策不放 onboarding）
- VS Code chord shortcut（取首段已是体验最优解）
- VS Code \`when\` 上下文 binding（玄圃 shortcut 是全局的，无对应语义）
- settings.json 导入（theme / font 语义重叠少）
- Playwright e2e（vitest 单元覆盖即可）
- 清理 6 处遗留的 \`defaultAgentSdk\` → \`defaultRuntimeId\` 半完成迁移（独立重构话题）

🤖 Generated with [Claude Code](https://claude.com/claude-code)