### PR TITLE
feat: v1.4.6 字段内存 + v1.5.0 Token Saver + SDK resume 修复

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -154,11 +154,11 @@ A `headless` service entry is also kept, so the desktop app and automation / rem
 
 v1.4.0 cracked the first mile of "field." The 1.4.x line is about **making memory visible and editable**:
 
-- **1.4.3 release / onboarding hardening** — CI post-package verify, first-run onboarding card, README.en.md sync, Edit/Write diff preview, Composer image large preview
+- **1.4.1 Pinned Facts** ✅ — pin permanent worktree facts like "this project uses pnpm" from the GUI; automatically prefixed into every prompt
+- **1.4.2 Memory panel** ✅ — promote the 4-tab Field Context Debug into a real Memory panel: see + edit + reset + regenerate; `/remember` / `/forget` slash commands manage Pinned Facts directly from the composer
+- **1.4.3 release / onboarding hardening** — CI post-package verify, Edit/Write diff fold, Composer image lightbox (shipped); first-run onboarding checklist + empty-state copy still in flight
 - **1.4.4 Codex experience overhaul** — make Codex inside Xuanpu actually feel native
-- **1.4.5 Memory panel** — promote the 4-tab Field Context Debug into a real Memory panel: see + edit + reset + regenerate
-- **1.4.6 Cost visibility** — token / ¥ spend on compaction, surfaced clearly per month
-- **1.4.x cross-agent injection quality** — empirically verify Codex / OpenCode / Amp are _using_ the Field Context prefix, not silently dropping it
+- **1.4.x cost visibility + cross-agent injection quality** — surface monthly token / ¥ spend on compaction; empirically verify Codex / OpenCode / Amp are _using_ the Field Context prefix, not silently dropping it
 
 The next ring (VISION §3.2) is **XFP (Xuanpu Field Protocol)** — let any agent vendor obtain the field through a shared protocol, so "agents are stronger inside Xuanpu" becomes a standard, not a moat.
 

--- a/README.md
+++ b/README.md
@@ -156,10 +156,11 @@ pnpm dev
 
 v1.4.0 把"现场"打通了第一公里。1.4.x 的核心是**让记忆变得可见可编辑**：
 
-- **1.4.1 Pinned Facts**：用户能在 GUI 里直接钉住"这个项目用 pnpm"这种永久事实
-- **1.4.2 Memory 面板**：把 4-tab Field Context Debug 升级为完整的 Memory 面板，能看见 + 编辑 + 重置 + 重新生成
-- **1.4.3 成本可见**：本月压缩消耗了多少 token / ¥X，明明白白告诉用户
-- **1.4.4 跨 agent 注入质量验证**：实测 Codex / OpenCode / Amp 收到 Field Context prefix 是真用还是当垃圾忽略
+- **1.4.1 Pinned Facts** ✅ — 用户能在 GUI 里直接钉住"这个项目用 pnpm"这种永久事实，每条 prompt 自动注入
+- **1.4.2 Memory 面板** ✅ — 把 4-tab Field Context Debug 升级为完整的 Memory 面板，能看见 + 编辑 + 重置 + 重新生成；`/remember` `/forget` slash 命令直接管 Pinned Facts
+- **1.4.3 发版 / onboarding 加固** — CI post-package verify、Edit/Write diff 折叠、Composer 图片大图预览（已落）；首次 onboarding checklist + 空状态文案仍在路上
+- **1.4.4 Codex 体验对齐** — 让 Codex 在玄圃里跑得真正像 native
+- **1.4.x 成本可见 + 跨 agent 注入质量验证** — 本月压缩消耗了多少 token / ¥X 明白告诉用户；实测 Codex / OpenCode / Amp 收到 Field Context prefix 是真用还是当垃圾忽略
 
 更远的第二圈（VISION §3.2）是 **XFP（Xuanpu Field Protocol）** —— 让任何 agent 厂商能用同一套协议获取现场，把"在玄圃里 agent 比在原生环境里更强"做成标准。
 

--- a/docs/plans/2026-05-03-field-memory-implementation.md
+++ b/docs/plans/2026-05-03-field-memory-implementation.md
@@ -1,0 +1,279 @@
+# Field Memory v1.4.1 + 1.4.2 + 1.4.3 — 实施 PRD
+
+- 日期：2026-05-03
+- 版本范围：v1.4.1 / v1.4.2 / v1.4.3
+- 状态：DRAFT（待评审）
+- Supersedes（合并以下三份散文档为单一执行口径，原文保留为历史背景）：
+  - `docs/essays/2026-04-25-from-1-3-to-1-4-ai-native-workbench.md`
+  - `docs/plans/2026-04-25-memory-product-direction.md`
+  - `docs/plans/2026-04-25-v1.4.3-plan.md`
+
+---
+
+## 0. 现状基线（v1.4.5 已实现，无需重做）
+
+| Phase | 内容 | 落地位置 |
+|---|---|---|
+| 21 | Field Event Stream | `field_events` 表（schema v18）、`src/main/ipc/field-handlers.ts`、`src/main/field/{emit,repository,privacy}.ts` |
+| 22A | Working Memory / Field Context 注入 | `src/main/field/context-builder.ts`、`context-formatter.ts`、`src/shared/types/field-context.ts` |
+| 22B.1 | Episodic Memory（6h 滚动 + Haiku/rule compactor） | `field_episodic_memory` 表（schema v19）、`src/main/field/episodic-{compactor,updater}.ts`、`claude-haiku-compactor.ts` |
+| 22C | Semantic Memory（只读 `memory.md`） | `src/main/field/semantic-memory-loader.ts` |
+| 24C | Session Checkpoint（abort 现场） | `field_session_checkpoints` 表（schema v20）、`src/main/field/checkpoint-{generator,verifier,repository}.ts` |
+| Debug UI | FieldContextDebug 面板（4 tabs） | `src/renderer/src/components/sessions/FieldContextDebug.tsx` |
+| IPC | `window.fieldOps` namespace | `src/preload/index.ts`（约 L1911–1977）、`src/preload/index.d.ts` |
+
+**当前 schema 版本**：`CURRENT_SCHEMA_VERSION = 20`（`src/main/db/schema.ts` L1）。下一次 migration 编号 = **v21**。
+
+---
+
+## 1. 目标与非目标
+
+### 目标
+- **1.4.1**：让用户能写"永恒事实"（Pinned Facts），并被自动注入到每条 prompt 的 Field Context 前缀。
+- **1.4.2**：让用户**看见**记忆（Pinned + Observed + Semantic），并能编辑 Pinned、重压 / 清空 Observed；slash command（`/remember`、`/forget`）作为快速入口。
+- **1.4.3**：把"能稳定发版 + 第一次打开就看得懂"两件事补齐——release 守卫 + onboarding + 空状态 + diff/image polish + README.en 同步。
+
+### 非目标（明确划走，不在本 PRD 内）
+- Guardian / Autopilot 托管档（推 1.5+）
+- 跨 agent（Codex / OpenCode / Amp）注入质量验证（1.4.4 单独立项）
+- 多 provider 配置 / Haiku 替代模型（1.4.5+）
+- Semantic Memory 改造为 LLM 主动提议（1.4.x 不做，仍只读 `memory.md`）
+- Pinned Facts 跨 worktree 共享（1.4.x 不做，按 worktree 隔离）
+
+---
+
+## 2. v1.4.1 — Pinned Facts（P0，~1 天）
+
+### 2.1 DB Schema（schema v21）
+
+```sql
+CREATE TABLE field_pinned_facts (
+  worktree_id TEXT PRIMARY KEY REFERENCES worktrees(id) ON DELETE CASCADE,
+  content_md  TEXT NOT NULL DEFAULT '',
+  updated_at  INTEGER NOT NULL,
+  created_at  INTEGER NOT NULL
+);
+```
+
+- 落点：`src/main/db/schema.ts` 的 `MIGRATIONS` 数组末尾追加 v21；bump `CURRENT_SCHEMA_VERSION = 21`。
+- 约束：单行 per worktree（PK = worktree_id）；2000 字上限在应用层校验，不进 DB CHECK（保留迁移弹性）。
+- ON DELETE CASCADE：删除 worktree 自动清理。
+
+### 2.2 IPC（扩 `window.fieldOps`，不新开 namespace）
+
+| Channel | 入参 | 出参 |
+|---|---|---|
+| `field:getPinnedFacts` | `worktreeId: string` | `{ contentMd: string; updatedAt: number } \| null` |
+| `field:updatePinnedFacts` | `worktreeId: string, contentMd: string` | `void` |
+
+- 实现：`src/main/ipc/field-handlers.ts` 追加两个 handler；新增 `src/main/field/pinned-facts-repository.ts`，模仿 `repository.ts` 的 prepared statement 模式。
+- Preload：`src/preload/index.ts` 在 `fieldOps` 对象内追加两个方法；同步类型到 `src/preload/index.d.ts`。
+
+### 2.3 注入逻辑
+
+- 改 `src/main/field/context-formatter.ts`：在 **Worktree 区块之后、Recent Activity 之前**插入：
+  ```markdown
+  ## Pinned Facts
+  <content_md>
+  ```
+- 单独 token budget：建议 **400 tokens 上限**；超出只截断 Pinned 段（不影响其它段）。
+- `content_md` 为空 / 仅空白 → 整段不渲染（连标题也不写）。
+
+### 2.4 UI 草图（最小化）
+
+```
+┌─ Worktree Detail Page ──────────────────────────────┐
+│ ...existing header...                              │
+│ ...existing sections...                            │
+│                                                    │
+│ ┌─ Pinned Facts ─────────────────────────[saved]─┐ │
+│ │ ┌──────────────────────────────────────────┐   │ │
+│ │ │ - 用 pnpm，不要用 npm                       │   │ │
+│ │ │ - DB at ~/.xuanpu/xuanpu.db              │   │ │
+│ │ │ - 我们不写注释                              │   │ │
+│ │ └──────────────────────────────────────────┘   │ │
+│ │                              123 / 2000   [Save]│ │
+│ └────────────────────────────────────────────────┘ │
+└────────────────────────────────────────────────────┘
+```
+
+- 文件：`src/renderer/src/components/worktrees/PinnedFactsCard.tsx`
+- 控件：shadcn `<Textarea>` + 字数计数 + 「保存」按钮
+- 自动保存：debounce 800ms；显式按钮兜底 + 显示 `saved` / `saving...` 状态
+- 状态：复用 `useWorktreeStore`，**不新开 store**
+
+### 2.5 验收信号
+
+- [ ] DB 升级到 v21，`field_pinned_facts` 表在 `~/.xuanpu/xuanpu.db` 中存在
+- [ ] 写一条 fact → reload app → fact 仍在
+- [ ] 发一条 prompt → `FieldContextDebug` 的 Last Injection 里能看到 `## Pinned Facts` 段
+- [ ] 清空 textarea → 下一次 injection 中 Pinned Facts 段消失
+- [ ] 字数 > 2000 → 应用层提示 + 保存被拒
+
+---
+
+## 3. v1.4.2 — Memory 面板 + slash commands（P0，~1 天）
+
+### 3.1 DB
+
+无新增。复用 1.4.1 的 `field_pinned_facts` + 1.4.0 的 `field_episodic_memory`。
+
+### 3.2 IPC（扩 `fieldOps`）
+
+| Channel | 入参 | 出参 |
+|---|---|---|
+| `field:regenerateEpisodic` | `worktreeId` | `{ summaryMd; compactorId; version; compactedAt }` |
+| `field:clearEpisodic` | `worktreeId` | `void` |
+| 复用 1.4.1 | `getPinnedFacts` / `updatePinnedFacts` | — |
+
+- `regenerateEpisodic`：触发 `episodic-updater.ts` 强制重跑（绕过滚动窗口判断）。
+- `clearEpisodic`：删除该 worktree 的 episodic 行（下次自动重建）。
+
+### 3.3 Slash commands
+
+- `/remember <fact>`：追加一行 `- <fact>` 到 `field_pinned_facts.content_md` 末尾；超 2000 字 → toast 提示 + 不保存。
+- `/forget <fact>`：在 content_md 中按子串 case-insensitive 匹配并删除该行；
+  - 0 命中 → toast「未找到」
+  - 1 命中 → 直接删 + toast 确认
+  - >1 命中 → toast「请到 Memory 面板手动选择」并打开面板
+- 实现：`src/renderer/src/hooks/useCommands.ts` 注册命令；dispatch 到 `window.fieldOps.updatePinnedFacts`。
+
+### 3.4 UI 草图
+
+```
+┌─ Session HQ Right Panel ────────────────────────────┐
+│ [Files] [Git] [Memory] [Field Debug*]              │
+│         (* dev-only)                               │
+│                                                    │
+│ ┌─ Pinned Facts ──────────────────────────────────┐│
+│ │ <PinnedFactsCard 复用>                           ││
+│ └────────────────────────────────────────────────┘│
+│                                                    │
+│ ┌─ Observed (Episodic) ────────[Regenerate][Clear]┐│
+│ │ compactor: claude-haiku v3 · 12m ago             ││
+│ │ ─────────────────────────────────────────       ││
+│ │ <markdown summary>                              ││
+│ └────────────────────────────────────────────────┘│
+│                                                    │
+│ ┌─ Semantic ──────────────────────────────────────┐│
+│ │ .xuanpu/memory.md (3 days ago)    [Open]        ││
+│ │ ~/.xuanpu/memory.md (never)       [Create]      ││
+│ └────────────────────────────────────────────────┘│
+└────────────────────────────────────────────────────┘
+```
+
+- 新文件：`src/renderer/src/components/sessions/MemoryPanel.tsx`
+- 入口：Session HQ 右侧 panel tab 列表加 "Memory"（在 Files / Git 之后）
+- `FieldContextDebug.tsx` 退化为 dev-only：用 `import.meta.env.DEV` 控制 tab 是否注册；非 DEV 模式不出现。
+
+### 3.5 验收信号
+
+- [ ] `/remember 项目用 pnpm 不要用 npm` → Memory 面板 Pinned Facts 多一行
+- [ ] `/forget pnpm` → 该行消失
+- [ ] 点 [Regenerate] → Episodic 摘要在 ≤10s 内更新，`compactedAt` 刷新
+- [ ] 点 [Clear] → Episodic 区域显示空状态文案
+- [ ] 普通 build 启动后**默认看不到** "Field Debug" tab
+- [ ] Semantic 区显示两个 memory.md 路径 + mtime；存在 → [Open]，不存在 → [Create]
+
+---
+
+## 4. v1.4.3 — 基础设施 + UX polish（P1，~1–2 天）
+
+拆三个独立 PR，可并行：
+
+### 4.1 PR A · Release / Onboarding 守卫
+
+**Release verify step**（`.github/workflows/release.yml`）：
+- 检查 `out/<platform>/cloudflared/<expected>/cloudflared` 存在且 `chmod +x` 可执行
+- 检查 `out/<platform>/resources/mobile-ui/index.html` 存在
+- 检查 `app.asar` + `better-sqlite3.node` / `node-pty.node` 三平台 native bindings
+- 任一失败 → workflow fail，release 不发布
+
+**首次 onboarding（4 step checklist）**：
+- 新组件：`src/renderer/src/components/onboarding/FirstRunChecklist.tsx`
+- 状态存 `useUiStateStore`（**不再 bump schema**）
+- 步骤：
+  1. 选 / 创建一个 worktree
+  2. 发出第一条 prompt
+  3. 展开 Field Context Debug（或 Memory 面板）
+  4. 启用 Hub 扫码
+
+### 4.2 PR B · 空状态 + 文案 + README.en
+
+**空状态文案**（`FieldContextDebug.tsx` & `MemoryPanel.tsx`）：
+
+| 区块 | 空状态文案 | CTA |
+|---|---|---|
+| Last Injection | 还没有现场。发一条消息试试。 | — |
+| Episodic | 约 20 个事件后会自动压缩成摘要。 | — |
+| Semantic | 还没有 memory.md。这是你写项目永恒事实的地方。 | [创建 memory.md] |
+| Checkpoint | abort 当前 session 时会自动记录现场，方便下次接着干。 | — |
+
+- Semantic 的 [创建 memory.md] 调 `window.fileOps.create`（路径用 `.xuanpu/memory.md`），创建后调用 `systemOps.openInEditor`。
+
+**README.en.md 同步**：
+- 把中文版 1.4.0 的"现场提供者 + 分层记忆"章节翻译到 README.en.md
+- 中英目录结构 1:1 对齐
+
+### 4.3 PR C · 卡片可视化增强
+
+**Diff 折叠**（`FileWriteCard` / `FileEditCard`）：
+- 落点目录：`src/renderer/src/components/sessions/cards/`（实施时 grep 确认）
+- 默认展示前 **10 行**（多行 padding 提示「+N more lines」）
+- 「展开 / 收起」按钮（`<ChevronDown>` / `<ChevronUp>`）
+- 实现优先用现成 `react-diff-viewer`，不行再手卷
+
+**Composer 缩略图 lightbox**：
+- 新组件：`src/renderer/src/components/ui/image-lightbox.tsx`
+- 触发：composer 中点击图片缩略图
+- 行为：modal 居中、保持比例、最大 90vw × 90vh、ESC 关闭、点背景关闭、双击恢复 1:1
+
+### 4.4 验收信号（合并表）
+
+| 项 | 信号 |
+|---|---|
+| Release verify | 故意删一个 cloudflared 二进制 → workflow 红灯 |
+| Onboarding | 全新数据库启动 → 看到 4 step checklist；完成后不再出现 |
+| 空状态 | 全新 worktree 打开 Memory 面板 → 四个区块都有人话 + 必要 CTA |
+| Semantic CTA | 点「创建 memory.md」→ 文件创建 + 自动在编辑器打开 |
+| Diff 折叠 | 触发一次 100 行的 Edit → 卡片默认 ≤12 行 + 展开按钮可用 |
+| Image lightbox | composer 贴图 → 点击放大 → ESC 收回 |
+| README.en | 中英文 1.4.0 章节内容点对点对齐 |
+
+---
+
+## 5. 复用的现有代码（不要重写）
+
+| 用途 | 文件 |
+|---|---|
+| DB migration | `src/main/db/schema.ts`（追加 v21） |
+| Repository 模式参考 | `src/main/field/repository.ts` |
+| Field Context 注入位置 | `src/main/field/context-formatter.ts` |
+| IPC handler 落点 | `src/main/ipc/field-handlers.ts` |
+| Preload 暴露 | `src/preload/index.ts`（`fieldOps` 对象，约 L1911–1977）|
+| Preload 类型 | `src/preload/index.d.ts` |
+| UI 模式参考 | `src/renderer/src/components/sessions/FieldContextDebug.tsx` |
+| Slash command 接入 | `src/renderer/src/hooks/useCommands.ts` |
+| Worktree 状态 | `src/renderer/src/stores/useWorktreeStore.ts` |
+
+---
+
+## 6. 实施顺序与 PR 拆分
+
+```
+1.4.1  → 1 个 PR：DB migration + fieldOps 扩展 + PinnedFactsCard + injection
+1.4.2  → 1 个 PR：MemoryPanel + slash commands + FieldContextDebug 收纳
+1.4.3  → 3 个 PR（A / B / C），可并行
+```
+
+总估时：3–4 个工作日。
+
+---
+
+## 7. Open Questions
+
+- Pinned Facts 与未来"衰减/合并"机制的关系（1.5+ 才决）
+- Semantic Memory 是否最终走 LLM 主动提议（暂不在 1.4.x）
+- Guardian 何时启动（看 1.4.0 稳定信号）
+- 跨 agent 注入质量验证（1.4.4 单独立项）
+- `/forget` 的模糊匹配策略——子串够不够？是否需要 fuzzy（FuseJS）？暂定子串，PR 中再回看。

--- a/docs/plans/2026-05-04-token-saver-pipeline.md
+++ b/docs/plans/2026-05-04-token-saver-pipeline.md
@@ -1,0 +1,239 @@
+# 玄圃 Token Saver — 通用上下文卸载管线
+
+**版本目标**：v1.5.0（暂定）
+**承接**：v1.4.6（字段内存）已交付，本计划是其后续。
+**分支策略**：在当前分支 `feat_20260503_field_memory` 上连续推进，不再拆 PR、不再新开分支。
+
+---
+
+## 一、定位（修正自此前的视角）
+
+### 1.1 之前的视角偏窄
+v1.4.6 的后续讨论里把"压缩 / 上下文卸载"放在「现场感知增强」章节下，等于把它当现场感知的子能力。这是错的。
+
+### 1.2 正确定位
+**Token Saver 是玄圃的横切基础能力**，现场感知只是第一个受益场景：
+
+```
+玄圃 Token Saver / Context Offloading（横切能力）
+  ├─ 服务于现场感知（让有限 context 装更多 signal）
+  ├─ 服务于普通对话（每条 bash/工具输出都更省）
+  ├─ 服务于多 agent 并发（5 个会话同时省 = 5 倍效益）
+  └─ 是对外可见的差异化卖点（其他 IDE/agent 没有）
+```
+
+### 1.3 卖点定义
+> "玄圃替你管 context，把昂贵的工具输出压缩或卸载到本地，agent 看到的是精简版 + 引用路径，token 实打实节省。"
+
+这是其他 agent IDE（Cursor、Cline、Continue、Aider）都没有的能力。必须做出"用户可感知"的反馈层，不然省了也白省。
+
+---
+
+## 二、关键架构事实（决定方案选择）
+
+### 2.1 SDK 数据流上的可控点
+
+```
+user 输入
+   │
+   ▼
+① Field Context 注入 ←──── 玄圃 100% 控制
+   │
+   ▼
+② SDK query()
+   │
+   ▼
+③ Anthropic API ←──── 玄圃看不见、动不了
+   │
+   ▼ (model 返回 tool_use)
+④ canUseTool hook ←──── 玄圃可拦截、可改输入、可拒绝
+   │
+   ▼
+⑤ 工具执行
+   │
+   ▼
+⑥ tool_result 拼回 API ←──── 玄圃看不见、动不了
+   │
+   ▼
+⑦ SDK emit message → 玄圃 UI/DB ←──── 玄圃可读可改（仅展示）
+```
+
+**核心约束**：第 ③⑥ 段是 SDK 与 Anthropic 的封闭通道，玄圃既看不见也动不了。要真正"卸载 token"，必须**在第 ⑤ 段把输出在落到 ⑥ 之前压缩好**。
+
+### 2.2 为什么 canUseTool + shim 不够
+
+`canUseTool` 只能改写工具**输入**，不能改写**输出**。和 RTK `git diff → rtk git diff` 是同构的——所有压缩逻辑必须塞进 shim 脚本本身。这意味着：
+
+- 12 类压缩规则要在 bash 里实现（不现实）
+- 或每次 Bash 调用都冷启动 `node compress.js`（性能不可接受）
+- 或起一个常驻 daemon 走 unix socket（**这就是 MCP**）
+
+绕一圈又回到 MCP。
+
+### 2.3 选定方案：进程内 MCP 接管 Bash
+
+`@anthropic-ai/claude-agent-sdk` 支持 `sdkMcpServers`（in-process MCP），不需要 spawn 子进程，本质是 SDK 与玄圃 main process 内的一次函数调用。开销可忽略。
+
+工作机制：
+
+1. 玄圃 main 进程注册 in-process MCP server `xuanpu-tools`
+2. 暴露工具 `Bash`（同名 shadow 内建）
+3. SDK 配置 `disallowedTools: ['Bash']` 禁内建
+4. agent 看到的"Bash"工具描述、参数都不变
+5. 工具实现内部完成：执行 → tee 到 archive（cold） → 压缩规则（hot） → 返回压缩文本 + metadata
+6. metadata 给 UI 渲染节省指示器
+
+---
+
+## 三、Agent 适配能力分布
+
+| Agent | 拦截能力 | MVP 是否覆盖 |
+|---|---|---|
+| **Claude Code** | `canUseTool` + 进程内 MCP，能完整卸载 | ✅ MVP 唯一目标 |
+| **OpenCode** | 自己的 server-tool 协议（玄圃已在跑 server），理论可改造 | ❌ 二期 |
+| **Codex** | 拦截最弱，目前只能在 ⑦ 段做展示压缩，不真省 token | ❌ 二期，可能永远只展示压缩 |
+
+---
+
+## 四、MVP 范围（决定版）
+
+### 4.1 工具覆盖
+**只做 `Bash`**。
+
+| 工具 | MVP | 二期 | 永不做 |
+|---|---|---|---|
+| Bash | ✅ | | |
+| Grep | | ✅ | |
+| Read | | ✅ | |
+| WebFetch / WebSearch | | ✅ | |
+| Glob | | | ❌（输出本就小） |
+| Write | | | ❌（无输出） |
+| Edit / NotebookEdit | | | ❌（无输出） |
+
+### 4.2 输出包含
+- 进程内 MCP server `xuanpu-tools`
+- 接管 `Bash` 的工具实现（含 timeout / env / cwd / 信号 / background 语义对齐）
+- `OutputCompressionPipeline` 接口 + 5 个最高 ROI 压缩策略（Stats Extraction / Failure Focus / NDJSON / Code Filter / Dedup —— 借鉴 RTK，TS 实现）
+- `~/.xuanpu/archive/<session>/<seq>.txt` 落盘
+- UI Bubble 节省指示器（`📦 8,432 → 412 tokens · 95% 省 · 展开原文`）
+- 会话级累计 banner（`本会话已节省 142,318 tokens`）
+- 设置开关 `Settings → 上下文卸载` 默认开
+- 设置里的 archive 目录大小展示 + 一键清理
+
+### 4.3 不做
+- ❌ 替换 Read / Grep / Write / Edit
+- ❌ OpenCode / Codex 适配
+- ❌ 全局看板（"本周节省 X tokens"）→ v1.6
+- ❌ archive 检索（"上次那个错误日志在哪"）→ v1.6
+- ❌ 自动学习压缩规则 → 永远不做（玄学）
+
+---
+
+## 五、实施阶段（同分支连续提交）
+
+> 都在 `feat_20260503_field_memory` 分支上推进，每个阶段一个 commit，不开 PR、不切分支。最后由用户决定何时合并。
+
+### 阶段 0 · 安全边界（半天）
+**目标**：为后续压缩管线打底。
+- 翻 privacy 默认（采集开关默认开）
+- 抽出 redact 模块为独立单元
+- 补单测覆盖关键脱敏场景
+
+### 阶段 1 · OutputCompressionPipeline 接口（1 天）
+**目标**：抽接口，不绑定 Bash。
+- `OutputStrategy` 接口：`compress(stdout, stderr, ctx) → { text, archive, before, after, ruleHits }`
+- 5 个内置策略实现（Stats / Failure / NDJSON / Code / Dedup）
+- 单测覆盖每个策略 happy path + 极端输入
+
+### 阶段 2 · 进程内 MCP server + Bash 接管（2 天）
+**目标**：MVP 核心。
+- 在 `src/main/services/` 下新建 `xuanpu-tools-mcp.ts`
+- 实现 `sdkMcpServers` 注册逻辑
+- 实现 `Bash` 工具完整语义对齐（参考内建 Bash 文档/行为）
+- 接入 OutputCompressionPipeline
+- archive 落盘（`ContextOffloadStore`）
+- `claude-code-implementer.ts` 配置 `disallowedTools: ['Bash']` + 注入 MCP
+
+**关键测试**：
+- 同一条 `npm test` 命令，开关开 vs 关，对比 token 计数
+- archive 文件可读、原文完整
+- 长输出（>10MB）不内存爆掉（流式 tee）
+- 中断信号正确传递
+
+### 阶段 3 · UI 感知层（1.5 天）
+**目标**：用户能直观感受到玄圃在帮他省 token。
+- Bubble metadata 渲染（节省指示器 + "展开原文"按钮）
+- 展开走 `fileOps.read(archive)`
+- 会话级累计 banner（在 SessionView 顶部）
+- 设置页 toggle + archive 用量展示
+
+### 阶段 4 · 验收 + 文档 + 落地（半天）
+- README 中英双语补一节"Token Saver"
+- 跑一遍真实场景 demo（pnpm dev / pnpm test 几次）
+- 截图归档至 `docs/screenshots/token-saver/`
+- commit `feat(v1.5.0): Token Saver MVP`
+
+**总计**：约 5 天。
+
+---
+
+## 六、验收信号
+
+### 6.1 功能验收
+- ✅ 开 toggle 后，Claude Code 会话里执行 `pnpm test` 一次，agent 收到的 `tool_result` token 数 ≤ 原始的 30%
+- ✅ Bubble 上能看到 `before / after / saved` 数字
+- ✅ "展开原文"能完整还原（diff 原文 vs archive 文件，hash 一致）
+- ✅ 关闭 toggle，回退到原生 Bash 行为，无副作用
+
+### 6.2 性能验收
+- ✅ 单次 Bash 包装开销 < 5ms（不含 user command 执行时间）
+- ✅ archive 写入异步，不阻塞 tool_result 返回
+- ✅ 10MB 输出压缩耗时 < 200ms
+
+### 6.3 卖点验收
+- ✅ 用户首次开会话能看到 banner "本会话已节省 X tokens"
+- ✅ 截图能直观传达"省了多少"
+
+---
+
+## 七、风险与对冲
+
+| 风险 | 影响 | 对冲 |
+|---|---|---|
+| Bash 语义遗漏（agent 期望某个特性丢失） | 任务执行失败 | 大量集成测试 + 一键关闭 toggle |
+| 压缩规则误删关键信息 | agent 误判 | 默认保守压缩 + 用户可关 |
+| archive 占盘 | 磁盘膨胀 | 设置里展示用量 + 自动 7 天清理 |
+| SDK 升级后 `sdkMcpServers` API 变 | 阶段 2 失效 | 锁 SDK 版本 + CI 测试 |
+| 内建 Bash 后续有玄圃缺失的特性 | 体验倒退 | 监控 SDK changelog，必要时合并 |
+
+---
+
+## 八、未来路线（不在 MVP 内）
+
+- v1.6：扩到 Read / Grep / WebFetch
+- v1.6：archive 检索（"上次那个 OOM 日志在哪"）
+- v1.7：OpenCode 适配
+- v1.7：全局节省看板
+- v1.8：Codex 展示层压缩（无法真省 token，仅 UI 体验）
+- v2.0：把 archive 接入字段内存的 episodic 层（"压缩+召回"闭环）
+
+---
+
+## 九、与 RTK 的关系（最终澄清）
+
+**RTK 是参考实现，不是依赖**。
+
+- RTK 的 12 类规则 → 玄圃 TS 实现，进 `OutputCompressionPipeline`
+- RTK 的 tee 模式 → 玄圃 `ContextOffloadStore` 同思路
+- 不 shell-out 调 RTK 二进制，不增加外部依赖
+- 内部技术文档可以提一句"灵感来源于 RTK"，对外文档不出现 RTK 字样
+
+---
+
+## 十、对外命名
+
+内部代码层：`OutputCompressionPipeline` / `ContextOffloadStore` / `xuanpu-tools-mcp`
+
+对外用户层：**Token Saver**（中文："上下文卸载" / "智能压缩"）
+
+设置项命名：`Settings → 性能 → 上下文卸载`（默认开）

--- a/src/main/db/schema.ts
+++ b/src/main/db/schema.ts
@@ -1,4 +1,4 @@
-export const CURRENT_SCHEMA_VERSION = 20
+export const CURRENT_SCHEMA_VERSION = 21
 
 export const SCHEMA_SQL = `
 -- Projects table
@@ -234,6 +234,18 @@ CREATE INDEX IF NOT EXISTS idx_field_session_checkpoints_worktree_created
   ON field_session_checkpoints(worktree_id, created_at DESC);
 CREATE UNIQUE INDEX IF NOT EXISTS idx_field_session_checkpoints_worktree_hash
   ON field_session_checkpoints(worktree_id, packet_hash);
+
+-- Phase 22D / v1.4.1: Pinned Facts (per-worktree user-authored permanent facts)
+-- See docs/plans/2026-05-03-field-memory-implementation.md
+-- Single row per worktree; content is freeform markdown injected verbatim
+-- into Field Context as a "## Pinned Facts" section. Application enforces
+-- a 2000-char cap; no DB CHECK so future cap changes need no migration.
+CREATE TABLE IF NOT EXISTS field_pinned_facts (
+  worktree_id TEXT PRIMARY KEY REFERENCES worktrees(id) ON DELETE CASCADE,
+  content_md TEXT NOT NULL DEFAULT '',
+  updated_at INTEGER NOT NULL,
+  created_at INTEGER NOT NULL
+);
 `
 
 export interface Migration {
@@ -716,6 +728,29 @@ export const MIGRATIONS: Migration[] = [
       DROP INDEX IF EXISTS idx_field_session_checkpoints_worktree_hash;
       DROP INDEX IF EXISTS idx_field_session_checkpoints_worktree_created;
       DROP TABLE IF EXISTS field_session_checkpoints;
+    `
+  },
+  {
+    version: 21,
+    name: 'add_field_pinned_facts',
+    up: `
+      -- v1.4.1: Pinned Facts (per-worktree user-authored permanent facts)
+      -- See docs/plans/2026-05-03-field-memory-implementation.md
+      --
+      -- Single row per worktree (PK = worktree_id). content_md is freeform
+      -- markdown injected verbatim into Field Context. 2000-char cap is
+      -- enforced in the application layer to keep future cap changes
+      -- migration-free. ON DELETE CASCADE: removing a worktree clears its
+      -- pinned facts automatically.
+      CREATE TABLE IF NOT EXISTS field_pinned_facts (
+        worktree_id TEXT PRIMARY KEY REFERENCES worktrees(id) ON DELETE CASCADE,
+        content_md TEXT NOT NULL DEFAULT '',
+        updated_at INTEGER NOT NULL,
+        created_at INTEGER NOT NULL
+      );
+    `,
+    down: `
+      DROP TABLE IF EXISTS field_pinned_facts;
     `
   }
 ]

--- a/src/main/field/claude-haiku-compactor.ts
+++ b/src/main/field/claude-haiku-compactor.ts
@@ -31,6 +31,7 @@ import {
   type EpisodicCompactor
 } from './episodic-compactor'
 import type { StoredFieldEvent } from './repository'
+import { redactSecrets as sharedRedactSecrets } from './redact'
 
 const log = createLogger({ component: 'ClaudeHaikuCompactor' })
 
@@ -309,8 +310,11 @@ function truncate(s: string, max: number): string {
 const SECRET_INLINE_REGEX =
   /(api[_-]?key|password|token|secret|authorization|bearer)\s*[:=]?\s*\S+/gi
 
+// NOTE: This local regex is no longer used at runtime — sharedRedactSecrets
+// from `./redact` is the real implementation. The wrapper preserves the old
+// exported test surface (`__HAIKU_COMPACTOR_TUNABLES_FOR_TEST.redactSecrets`).
 function redactSecrets(s: string): string {
-  return s.replace(SECRET_INLINE_REGEX, (_m, kw: string) => `${kw}=[REDACTED]`)
+  return sharedRedactSecrets(s, { mode: 'inline' })
 }
 
 function sleep(ms: number): Promise<void> {

--- a/src/main/field/context-builder.ts
+++ b/src/main/field/context-builder.ts
@@ -21,6 +21,7 @@ import { getFieldEventSink } from './sink'
 import { getRecentFieldEvents, type StoredFieldEvent } from './repository'
 import { getSemanticMemory } from './semantic-memory-loader'
 import { verifyCheckpoint } from './checkpoint-verifier'
+import { getPinnedFacts } from './pinned-facts-repository'
 import { createLogger } from '../services/logger'
 import type {
   FieldContextSnapshot,
@@ -130,6 +131,7 @@ export async function buildFieldContextSnapshot(
         }
       : null,
     worktreeNotes: worktreeRow?.context ?? null,
+    pinnedFacts: readPinnedFacts(opts.worktreeId),
     checkpoint,
     episodicSummary: readEpisodicSummary(opts.worktreeId),
     semanticMemory: semanticMemory
@@ -147,6 +149,16 @@ export async function buildFieldContextSnapshot(
     focus: { file: focusFile, selection: focusSelection },
     lastTerminal,
     recentActivity
+  }
+}
+
+function readPinnedFacts(worktreeId: string): FieldContextSnapshot['pinnedFacts'] {
+  const entry = getPinnedFacts(worktreeId)
+  if (!entry) return null
+  if (entry.contentMd.trim().length === 0) return null
+  return {
+    contentMd: entry.contentMd,
+    updatedAt: entry.updatedAt
   }
 }
 

--- a/src/main/field/context-formatter.ts
+++ b/src/main/field/context-formatter.ts
@@ -28,6 +28,11 @@ const MAX_SUMMARY_CHARS = 2000
 const MAX_SUMMARY_CHARS_SHRUNK = 800
 const MAX_SEMANTIC_CHARS = 4000
 const MAX_SEMANTIC_CHARS_SHRUNK = 1000
+// v1.4.1: Pinned Facts have a dedicated cap so they don't get squeezed by
+// long episodic/semantic blocks. Full ~400 tokens; minimum keeps the first
+// 300 chars so the user's most-important facts are always present.
+const MAX_PINNED_FACTS_CHARS = 1200
+const MAX_PINNED_FACTS_CHARS_SHRUNK = 300
 const OUTPUT_HEAD_LINES_BASE = 20
 const OUTPUT_HEAD_LINES_SHRUNK = 3
 const OUTPUT_TAIL_LINES_BASE = 50
@@ -78,6 +83,7 @@ export function formatFieldContext(
       notesMaxChars: Infinity,
       summaryMaxChars: MAX_SUMMARY_CHARS,
       semanticMaxChars: MAX_SEMANTIC_CHARS,
+      pinnedFactsMaxChars: MAX_PINNED_FACTS_CHARS,
       outputHeadLines: OUTPUT_HEAD_LINES_BASE,
       outputTailLines: OUTPUT_TAIL_LINES_BASE,
       resumedLevel: RESUMED_FULL
@@ -88,6 +94,7 @@ export function formatFieldContext(
       notesMaxChars: Infinity,
       summaryMaxChars: MAX_SUMMARY_CHARS,
       semanticMaxChars: MAX_SEMANTIC_CHARS,
+      pinnedFactsMaxChars: MAX_PINNED_FACTS_CHARS,
       outputHeadLines: OUTPUT_HEAD_LINES_BASE,
       outputTailLines: OUTPUT_TAIL_LINES_BASE,
       resumedLevel: RESUMED_FULL
@@ -98,6 +105,7 @@ export function formatFieldContext(
       notesMaxChars: Infinity,
       summaryMaxChars: MAX_SUMMARY_CHARS_SHRUNK,
       semanticMaxChars: MAX_SEMANTIC_CHARS,
+      pinnedFactsMaxChars: MAX_PINNED_FACTS_CHARS,
       outputHeadLines: OUTPUT_HEAD_LINES_BASE,
       outputTailLines: OUTPUT_TAIL_LINES_BASE,
       resumedLevel: RESUMED_FULL
@@ -108,6 +116,7 @@ export function formatFieldContext(
       notesMaxChars: MAX_NOTES_CHARS,
       summaryMaxChars: MAX_SUMMARY_CHARS_SHRUNK,
       semanticMaxChars: MAX_SEMANTIC_CHARS,
+      pinnedFactsMaxChars: MAX_PINNED_FACTS_CHARS,
       outputHeadLines: OUTPUT_HEAD_LINES_BASE,
       outputTailLines: OUTPUT_TAIL_LINES_BASE,
       resumedLevel: RESUMED_FULL
@@ -118,6 +127,7 @@ export function formatFieldContext(
       notesMaxChars: MAX_NOTES_CHARS,
       summaryMaxChars: MAX_SUMMARY_CHARS_SHRUNK,
       semanticMaxChars: MAX_SEMANTIC_CHARS_SHRUNK,
+      pinnedFactsMaxChars: MAX_PINNED_FACTS_CHARS,
       outputHeadLines: OUTPUT_HEAD_LINES_BASE,
       outputTailLines: OUTPUT_TAIL_LINES_SHRUNK,
       resumedLevel: RESUMED_SHRUNK
@@ -128,6 +138,7 @@ export function formatFieldContext(
       notesMaxChars: MAX_NOTES_CHARS,
       summaryMaxChars: MAX_SUMMARY_CHARS_SHRUNK,
       semanticMaxChars: MAX_SEMANTIC_CHARS_SHRUNK,
+      pinnedFactsMaxChars: MAX_PINNED_FACTS_CHARS_SHRUNK,
       outputHeadLines: OUTPUT_HEAD_LINES_SHRUNK,
       outputTailLines: OUTPUT_TAIL_LINES_SHRUNK,
       resumedLevel: RESUMED_SHRUNK
@@ -138,6 +149,7 @@ export function formatFieldContext(
       notesMaxChars: MAX_NOTES_CHARS,
       summaryMaxChars: MAX_SUMMARY_CHARS_SHRUNK,
       semanticMaxChars: MAX_SEMANTIC_CHARS_SHRUNK,
+      pinnedFactsMaxChars: MAX_PINNED_FACTS_CHARS_SHRUNK,
       outputHeadLines: OUTPUT_HEAD_LINES_SHRUNK,
       outputTailLines: OUTPUT_TAIL_LINES_SHRUNK,
       resumedLevel: RESUMED_MINIMAL
@@ -148,18 +160,22 @@ export function formatFieldContext(
       notesMaxChars: MAX_NOTES_CHARS,
       summaryMaxChars: 0,
       semanticMaxChars: MAX_SEMANTIC_CHARS_SHRUNK,
+      pinnedFactsMaxChars: MAX_PINNED_FACTS_CHARS_SHRUNK,
       outputHeadLines: OUTPUT_HEAD_LINES_SHRUNK,
       outputTailLines: OUTPUT_TAIL_LINES_SHRUNK,
       resumedLevel: RESUMED_MINIMAL
     },
     // Tier 8: drop semantic memory entirely (extreme budget). Resumed kept
     // minimal (summary+warnings only) — it's a 1-line fact about prior session
-    // that's almost always cheaper than dropping entirely.
+    // that's almost always cheaper than dropping entirely. Pinned Facts are
+    // kept (shrunk) — they are user-authored permanent intent and dropping
+    // them silently is worse than dropping low-signal episodic data.
     {
       activityCount: 0,
       notesMaxChars: MAX_NOTES_CHARS,
       summaryMaxChars: 0,
       semanticMaxChars: 0,
+      pinnedFactsMaxChars: MAX_PINNED_FACTS_CHARS_SHRUNK,
       outputHeadLines: OUTPUT_HEAD_LINES_SHRUNK,
       outputTailLines: OUTPUT_TAIL_LINES_SHRUNK,
       resumedLevel: RESUMED_MINIMAL
@@ -192,6 +208,8 @@ interface FormatTier {
   summaryMaxChars: number
   /** Char budget per semantic-memory layer (project, user). 0 = drop entirely. */
   semanticMaxChars: number
+  /** v1.4.1: char budget for the Pinned Facts section. 0 = drop entirely. */
+  pinnedFactsMaxChars: number
   outputHeadLines: number
   outputTailLines: number
   /** Phase 24C: Resumed block shrink level. 0=full, 1=shrunk, 2=minimal, 3=dropped. */
@@ -238,6 +256,22 @@ function render(snapshot: FieldContextSnapshot, tier: FormatTier): string {
   // (so the live scene wins) and before Semantic Memory (because resume
   // hints are more time-sensitive than long-lived rules).
   renderResumedBlock(lines, snapshot, tier.resumedLevel)
+
+  // v1.4.1: Pinned Facts (user-authored permanent facts for this worktree).
+  // Placed before Semantic Memory because pinned facts are user intent
+  // scoped to *this* worktree and trump generic project/user rules.
+  if (snapshot.pinnedFacts && tier.pinnedFactsMaxChars > 0) {
+    const trimmed = snapshot.pinnedFacts.contentMd.trim()
+    if (trimmed.length > 0) {
+      lines.push('## Pinned Facts')
+      lines.push(
+        `*(User-authored permanent facts for this worktree. Treat as binding rules unless the current task explicitly overrides.)*`
+      )
+      lines.push('')
+      lines.push(truncate(trimmed, tier.pinnedFactsMaxChars))
+      lines.push('')
+    }
+  }
 
   // Semantic Memory: project-level (Phase 22C.1).
   if (snapshot.semanticMemory && tier.semanticMaxChars > 0) {

--- a/src/main/field/episodic-updater.ts
+++ b/src/main/field/episodic-updater.ts
@@ -20,6 +20,7 @@ import { getDatabase } from '../db'
 import { getEventBus } from '../../server/event-bus'
 import { createLogger } from '../services/logger'
 import { isFieldCollectionEnabled } from './privacy'
+import { redactSecrets } from './redact'
 import { getFieldEventSink } from './sink'
 import { getRecentFieldEvents } from './repository'
 import {
@@ -401,7 +402,7 @@ class EpisodicMemoryUpdater {
       })
 
       if (process.env.XUANPU_FIELD_DEBUG_BODIES === 'true') {
-        log.debug('Episodic compaction body', { body: redactSecrets(output.markdown) })
+        log.debug('Episodic compaction body', { body: redactForLog(output.markdown) })
       }
 
       return output
@@ -430,16 +431,13 @@ class EpisodicMemoryUpdater {
 }
 
 // ---------------------------------------------------------------------------
-// Secret redaction (conservative line-level replacement)
+// Secret redaction — delegates to shared module (src/main/field/redact.ts).
+// This consumer uses 'line' mode for max safety (debug logs of compacted
+// bodies should NEVER leak credentials, even at the cost of context).
 // ---------------------------------------------------------------------------
 
-const SECRET_LINE_REGEX = /(api[_-]?key|password|token|secret|authorization|bearer)/i
-
-function redactSecrets(s: string): string {
-  return s
-    .split('\n')
-    .map((line) => (SECRET_LINE_REGEX.test(line) ? '[REDACTED LINE]' : line))
-    .join('\n')
+function redactForLog(s: string): string {
+  return redactSecrets(s, { mode: 'line' })
 }
 
 // ---------------------------------------------------------------------------
@@ -511,7 +509,7 @@ export const __UPDATER_TUNABLES_FOR_TEST = {
   MIN_EVENTS_BEFORE_TRIGGER,
   MIN_AGE_BEFORE_TRIGGER_MS,
   COMPACTOR_PRIORITY,
-  redactSecrets
+  redactForLog
 }
 
 export { EpisodicMemoryUpdater }

--- a/src/main/field/pinned-facts-repository.ts
+++ b/src/main/field/pinned-facts-repository.ts
@@ -1,0 +1,86 @@
+/**
+ * Pinned Facts repository — v1.4.1.
+ *
+ * One row per worktree (PK = worktree_id) holding user-authored permanent
+ * facts as freeform markdown. The application enforces a 2000-char cap;
+ * the DB itself is uncapped to keep future cap changes migration-free.
+ *
+ * See docs/plans/2026-05-03-field-memory-implementation.md
+ */
+import { getDatabase } from '../db'
+
+export const PINNED_FACTS_MAX_CHARS = 2000
+
+export interface PinnedFactsRecord {
+  worktreeId: string
+  contentMd: string
+  updatedAt: number
+  createdAt: number
+}
+
+interface Row {
+  worktree_id: string
+  content_md: string
+  updated_at: number
+  created_at: number
+}
+
+function rowToRecord(row: Row): PinnedFactsRecord {
+  return {
+    worktreeId: row.worktree_id,
+    contentMd: row.content_md,
+    updatedAt: row.updated_at,
+    createdAt: row.created_at
+  }
+}
+
+/** Returns the pinned facts row for a worktree, or null if none. */
+export function getPinnedFacts(worktreeId: string): PinnedFactsRecord | null {
+  const sql = `
+    SELECT worktree_id, content_md, updated_at, created_at
+      FROM field_pinned_facts
+     WHERE worktree_id = ?
+     LIMIT 1
+  `
+  const row = getDatabase().getDbHandle().prepare(sql).get(worktreeId) as Row | undefined
+  return row ? rowToRecord(row) : null
+}
+
+/**
+ * Upsert pinned facts for a worktree. Empty / whitespace-only content is
+ * stored as an empty string (not deleted) so we keep the row's createdAt
+ * stable across edits.
+ *
+ * Throws if `contentMd` exceeds {@link PINNED_FACTS_MAX_CHARS}.
+ */
+export function upsertPinnedFacts(worktreeId: string, contentMd: string): PinnedFactsRecord {
+  if (contentMd.length > PINNED_FACTS_MAX_CHARS) {
+    throw new Error(
+      `Pinned Facts content exceeds ${PINNED_FACTS_MAX_CHARS} chars (got ${contentMd.length})`
+    )
+  }
+  const now = Date.now()
+  const sql = `
+    INSERT INTO field_pinned_facts (worktree_id, content_md, updated_at, created_at)
+    VALUES (?, ?, ?, ?)
+    ON CONFLICT(worktree_id) DO UPDATE SET
+      content_md = excluded.content_md,
+      updated_at = excluded.updated_at
+  `
+  getDatabase().getDbHandle().prepare(sql).run(worktreeId, contentMd, now, now)
+  // Re-read so callers always see the canonical createdAt.
+  const record = getPinnedFacts(worktreeId)
+  if (!record) {
+    throw new Error(`Failed to upsert pinned facts for worktree ${worktreeId}`)
+  }
+  return record
+}
+
+/** Test helper — remove the pinned facts row for a worktree. */
+export function deletePinnedFacts(worktreeId: string): number {
+  const result = getDatabase()
+    .getDbHandle()
+    .prepare(`DELETE FROM field_pinned_facts WHERE worktree_id = ?`)
+    .run(worktreeId)
+  return result.changes
+}

--- a/src/main/field/privacy.ts
+++ b/src/main/field/privacy.ts
@@ -87,6 +87,34 @@ export function setBashOutputCaptureEnabledCache(value: boolean): void {
 export const BASH_OUTPUT_CAPTURE_SETTING_KEY = BASH_CAPTURE_SETTING_KEY
 
 // ---------------------------------------------------------------------------
+// token_saver_enabled (v1.5.0 Token Saver)
+//
+// Master switch for the Token Saver pipeline (in-process MCP Bash interceptor
+// + OutputCompressionPipeline + ContextOffloadStore). When ON, agent Bash
+// invocations are routed through `mcp__xuanpu__bash` and their output is
+// compressed before reaching the API; the full original is archived locally.
+//
+// Default ON. Users opt-out via Settings → Token 节省器.
+// ---------------------------------------------------------------------------
+
+const TOKEN_SAVER_SETTING_KEY = 'token_saver_enabled'
+let tokenSaverCached: boolean | null = null
+
+export function isTokenSaverEnabled(): boolean {
+  if (tokenSaverCached !== null) return tokenSaverCached
+  const value = getDatabase().getSetting(TOKEN_SAVER_SETTING_KEY)
+  // Default ON: anything other than literal 'false' enables it.
+  tokenSaverCached = value !== 'false'
+  return tokenSaverCached
+}
+
+export function setTokenSaverEnabledCache(value: boolean): void {
+  tokenSaverCached = value
+}
+
+export const TOKEN_SAVER_ENABLED_SETTING_KEY = TOKEN_SAVER_SETTING_KEY
+
+// ---------------------------------------------------------------------------
 // Test helpers
 // ---------------------------------------------------------------------------
 
@@ -94,4 +122,5 @@ export function invalidatePrivacyCache(): void {
   collectionCached = null
   injectionCached = null
   bashCaptureCached = null
+  tokenSaverCached = null
 }

--- a/src/main/field/redact.ts
+++ b/src/main/field/redact.ts
@@ -1,0 +1,128 @@
+/**
+ * Centralised secret redaction (Token Saver stage 0).
+ *
+ * Before stage 0 there were two near-duplicate `redactSecrets` implementations
+ * in `episodic-updater.ts` and `claude-haiku-compactor.ts` with different
+ * semantics (line-level vs inline) and identical-but-weak patterns. This module
+ * consolidates them and strengthens coverage.
+ *
+ * Two modes are exposed because the consumers genuinely need both:
+ *   - 'inline'  — surgical: replace only the secret value, keep surrounding
+ *                 context. Best when downstream consumes the text as natural
+ *                 language and needs continuity (LLM compactor input).
+ *   - 'line'    — aggressive: replace the entire matching line. Best when the
+ *                 redacted text is logged/persisted and we want maximum safety.
+ *
+ * Patterns are intentionally conservative: false positives here are cheaper
+ * than leaking secrets. We err on the side of redacting too much.
+ *
+ * Future Token Saver stages (MCP Bash interceptor, archive writer) will reuse
+ * this module — DO NOT add another local copy elsewhere. If a new pattern is
+ * needed, add it here with a test.
+ */
+
+/**
+ * Inline patterns — match a key-like prefix followed by an assignment and
+ * the secret value. The capturing group `kw` preserves the keyword so the
+ * replacement reads `keyword=[REDACTED]` instead of an opaque blob.
+ */
+const INLINE_PATTERNS: Array<{ name: string; regex: RegExp }> = [
+  // Common credential keywords with assignment-like operators.
+  // Examples matched:
+  //   API_KEY=sk-1234567890abcdef
+  //   password: "hunter2"
+  //   Bearer eyJhbG...
+  //   authorization: Bearer xyz
+  {
+    name: 'keyword-assignment',
+    regex: /(api[_-]?key|password|passwd|secret|token|authorization|bearer)\s*[:=]?\s*[A-Za-z0-9_\-./+=]{3,}/gi
+  },
+  // OpenAI-style sk- keys.
+  { name: 'openai-key', regex: /\b(sk|pk)-[A-Za-z0-9]{20,}\b/g },
+  // Anthropic API keys (sk-ant-...).
+  { name: 'anthropic-key', regex: /\bsk-ant-[A-Za-z0-9_-]{20,}\b/g },
+  // GitHub personal access tokens (ghp_, gho_, ghu_, ghs_, ghr_).
+  { name: 'github-token', regex: /\bgh[pousr]_[A-Za-z0-9]{30,}\b/g },
+  // AWS access key IDs.
+  { name: 'aws-access-key', regex: /\bAKIA[0-9A-Z]{16}\b/g },
+  // JWT (three base64url segments separated by dots, header starts with eyJ).
+  { name: 'jwt', regex: /\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\b/g },
+  // Generic 32+ char hex (likely API hash / session id).
+  { name: 'hex-secret', regex: /\b[a-f0-9]{32,}\b/gi },
+  // PEM blocks (private keys).
+  {
+    name: 'pem-block',
+    regex: /-----BEGIN [A-Z ]+PRIVATE KEY-----[\s\S]*?-----END [A-Z ]+PRIVATE KEY-----/g
+  }
+]
+
+/**
+ * Line-level keyword regex — if a line contains any of these keywords (as a
+ * whole word, plural or singular), the whole line is replaced. Word boundaries
+ * prevent false positives like "secretary" or "tokenize" matching.
+ */
+const LINE_KEYWORD_REGEX =
+  /\b(api[_-]?keys?|passwords?|passwds?|secrets?|tokens?|authorizations?|bearer|credentials?|private[_-]?keys?)\b/i
+
+export type RedactMode = 'inline' | 'line'
+
+export interface RedactOptions {
+  mode?: RedactMode
+  /**
+   * Optional override: caller may provide a custom replacement template.
+   * Defaults are mode-specific.
+   */
+  replacement?: string
+}
+
+/**
+ * Redact secrets from a string. Defaults to 'inline' mode.
+ *
+ * The function is allocation-friendly for the common case (no match → returns
+ * input string unchanged) so it's safe to call on every Bash output line.
+ */
+export function redactSecrets(input: string, options: RedactOptions = {}): string {
+  if (typeof input !== 'string' || input.length === 0) return input
+  const mode = options.mode ?? 'inline'
+
+  if (mode === 'line') {
+    const replacement = options.replacement ?? '[REDACTED LINE]'
+    // Fast path: no keyword anywhere → no allocation.
+    if (!LINE_KEYWORD_REGEX.test(input)) return input
+    return input
+      .split('\n')
+      .map((line) => (LINE_KEYWORD_REGEX.test(line) ? replacement : line))
+      .join('\n')
+  }
+
+  // Inline mode.
+  let result = input
+  for (const { regex } of INLINE_PATTERNS) {
+    if (!regex.test(result)) {
+      // Reset stateful regex (g flag) before next pattern.
+      regex.lastIndex = 0
+      continue
+    }
+    regex.lastIndex = 0
+    result = result.replace(regex, (match) => {
+      // Preserve the leading keyword + separator if present, otherwise replace
+      // the whole match. We detect the keyword form by looking for an `=` or
+      // `:` in the matched substring within the first ~32 chars.
+      const sepIdx = match.search(/[:=]/)
+      if (sepIdx > 0 && sepIdx < 32) {
+        const kw = match.slice(0, sepIdx).trim()
+        return `${kw}=[REDACTED]`
+      }
+      return '[REDACTED]'
+    })
+  }
+  return result
+}
+
+/**
+ * Test-only export of patterns (for coverage assertion).
+ */
+export const __REDACT_INTERNAL_FOR_TEST = {
+  INLINE_PATTERNS,
+  LINE_KEYWORD_REGEX
+}

--- a/src/main/ipc/database-handlers.ts
+++ b/src/main/ipc/database-handlers.ts
@@ -6,9 +6,11 @@ import {
   setFieldCollectionEnabledCache,
   setMemoryInjectionEnabledCache,
   setBashOutputCaptureEnabledCache,
+  setTokenSaverEnabledCache,
   FIELD_COLLECTION_SETTING_KEY,
   MEMORY_INJECTION_SETTING_KEY,
-  BASH_OUTPUT_CAPTURE_SETTING_KEY
+  BASH_OUTPUT_CAPTURE_SETTING_KEY,
+  TOKEN_SAVER_ENABLED_SETTING_KEY
 } from '../field/privacy'
 import type {
   ProjectCreate,
@@ -47,6 +49,10 @@ export function registerDatabaseHandlers(): void {
     if (key === BASH_OUTPUT_CAPTURE_SETTING_KEY) {
       setBashOutputCaptureEnabledCache(value === 'true')
     }
+    // v1.5.0: Token Saver master switch. Default ON — only literal 'false' disables.
+    if (key === TOKEN_SAVER_ENABLED_SETTING_KEY) {
+      setTokenSaverEnabledCache(value !== 'false')
+    }
     return true
   })
 
@@ -63,6 +69,10 @@ export function registerDatabaseHandlers(): void {
     // Phase 21.5: delete reverts bash output capture to default OFF.
     if (key === BASH_OUTPUT_CAPTURE_SETTING_KEY) {
       setBashOutputCaptureEnabledCache(false)
+    }
+    // v1.5.0: delete reverts Token Saver to default ON.
+    if (key === TOKEN_SAVER_ENABLED_SETTING_KEY) {
+      setTokenSaverEnabledCache(true)
     }
     return true
   })

--- a/src/main/ipc/field-handlers.ts
+++ b/src/main/ipc/field-handlers.ts
@@ -19,6 +19,11 @@ import { createLogger } from '../services/logger'
 import { emitFieldEvent } from '../field/emit'
 import { getLastInjection } from '../field/last-injection-cache'
 import { getSemanticMemory } from '../field/semantic-memory-loader'
+import {
+  getPinnedFacts,
+  upsertPinnedFacts,
+  PINNED_FACTS_MAX_CHARS
+} from '../field/pinned-facts-repository'
 import type { WorktreeSwitchTrigger } from '../../shared/types'
 
 const log = createLogger({ component: 'FieldHandlers' })
@@ -201,6 +206,73 @@ export function registerFieldHandlers(): void {
     }).catch(() => null)
     const raw = getLatestCheckpoint(worktreeId)
     return { verified, raw }
+  })
+
+  // -------------------------------------------------------------------------
+  // v1.4.1: Pinned Facts — read.
+  // -------------------------------------------------------------------------
+  ipcMain.handle('field:getPinnedFacts', (_event, worktreeId: unknown) => {
+    if (typeof worktreeId !== 'string' || worktreeId.length === 0) return null
+    return getPinnedFacts(worktreeId)
+  })
+
+  // -------------------------------------------------------------------------
+  // v1.4.1: Pinned Facts — upsert. Returns the canonical post-write record so
+  // the renderer can refresh its cache without a follow-up read.
+  // -------------------------------------------------------------------------
+  ipcMain.handle('field:updatePinnedFacts', (_event, input: unknown) => {
+    if (!isPlainObject(input)) {
+      throw new Error('updatePinnedFacts: input must be an object')
+    }
+    const { worktreeId, contentMd } = input
+    if (typeof worktreeId !== 'string' || worktreeId.length === 0) {
+      throw new Error('updatePinnedFacts: worktreeId is required')
+    }
+    if (typeof contentMd !== 'string') {
+      throw new Error('updatePinnedFacts: contentMd must be a string')
+    }
+    if (contentMd.length > PINNED_FACTS_MAX_CHARS) {
+      throw new Error(
+        `Pinned Facts content exceeds ${PINNED_FACTS_MAX_CHARS} chars (got ${contentMd.length})`
+      )
+    }
+    const worktree = getDatabase().getWorktree(worktreeId)
+    if (!worktree) {
+      throw new Error(`updatePinnedFacts: worktree ${worktreeId} not found`)
+    }
+    return upsertPinnedFacts(worktreeId, contentMd)
+  })
+
+  // -------------------------------------------------------------------------
+  // v1.4.2: Episodic Memory — force-regenerate the rolling summary for a
+  // worktree. Bypasses the debounce + min-event threshold; respects privacy
+  // and "don't downgrade" rules. Returns the new record (or null when the
+  // compactor declined — e.g. insufficient events, privacy disabled).
+  // -------------------------------------------------------------------------
+  ipcMain.handle('field:regenerateEpisodic', async (_event, worktreeId: unknown) => {
+    if (typeof worktreeId !== 'string' || worktreeId.length === 0) {
+      throw new Error('regenerateEpisodic: worktreeId is required')
+    }
+    const worktree = getDatabase().getWorktree(worktreeId)
+    if (!worktree) {
+      throw new Error(`regenerateEpisodic: worktree ${worktreeId} not found`)
+    }
+    const { getEpisodicMemoryUpdater } = await import('../field/episodic-updater')
+    const output = await getEpisodicMemoryUpdater().forceCompact(worktreeId)
+    if (!output) return null
+    return getDatabase().getEpisodicMemory(worktreeId)
+  })
+
+  // -------------------------------------------------------------------------
+  // v1.4.2: Episodic Memory — clear the rolling summary for a worktree.
+  // The next eligible event will trigger a fresh compaction.
+  // -------------------------------------------------------------------------
+  ipcMain.handle('field:clearEpisodic', (_event, worktreeId: unknown) => {
+    if (typeof worktreeId !== 'string' || worktreeId.length === 0) {
+      throw new Error('clearEpisodic: worktreeId is required')
+    }
+    const deleted = getDatabase().deleteEpisodicMemory(worktreeId)
+    return { deleted }
   })
 }
 

--- a/src/main/ipc/file-handlers.ts
+++ b/src/main/ipc/file-handlers.ts
@@ -1,6 +1,12 @@
 import { ipcMain } from 'electron'
 import { createLogger } from '../services/logger'
-import { readFile, readFileAsBase64, readPromptFile, writeFile } from '../services/file-ops'
+import {
+  readFile,
+  readFileAsBase64,
+  readPromptFile,
+  writeFile,
+  readArchiveFile
+} from '../services/file-ops'
 
 const log = createLogger({ component: 'FileHandlers' })
 
@@ -20,6 +26,27 @@ export function registerFileHandlers(): void {
       const result = readFile(filePath)
       if (!result.success) {
         log.error('Failed to read file', new Error(result.error ?? 'Unknown error'), { filePath })
+      }
+      return result
+    }
+  )
+
+  // Token Saver archive: whitelisted to ~/.xuanpu/archive only.
+  ipcMain.handle(
+    'file:readArchive',
+    async (
+      _event,
+      filePath: string
+    ): Promise<{
+      success: boolean
+      content?: string
+      error?: string
+    }> => {
+      const result = readArchiveFile(filePath)
+      if (!result.success) {
+        log.error('Failed to read archive', new Error(result.error ?? 'Unknown error'), {
+          filePath
+        })
       }
       return result
     }

--- a/src/main/services/claude-code-implementer.ts
+++ b/src/main/services/claude-code-implementer.ts
@@ -20,6 +20,8 @@ import { Options, PermissionMode } from '@anthropic-ai/claude-agent-sdk'
 import type { SDKControlGetContextUsageResponse } from '@anthropic-ai/claude-agent-sdk'
 import { CommandFilterService, type CommandFilterSettings } from './command-filter-service'
 import { createLspMcpServerConfig, LspService } from './lsp'
+import { createXuanpuToolsMcpServerConfig } from './token-saver/xuanpu-tools-mcp'
+import { isTokenSaverEnabled } from '../field/privacy'
 import { APP_SETTINGS_DB_KEY } from '@shared/types/settings'
 import { getActiveAppHomeDir } from '@shared/app-identity'
 import { beginSessionRun, emitAgentEvent } from '@shared/lib/normalize-agent-event'
@@ -698,6 +700,31 @@ export class ClaudeCodeImplementer implements AgentSdkImplementer, AgentRuntimeA
           worktreePath: session.worktreePath,
           error: err instanceof Error ? err.message : String(err)
         })
+      }
+
+      // Token Saver (v1.5.0): in-process MCP `bash` tool that compresses
+      // verbose output before it reaches the API and archives the original
+      // locally. When enabled we suppress the built-in Bash so the agent only
+      // sees ours. Best-effort: failure to attach falls through to native Bash.
+      if (isTokenSaverEnabled()) {
+        try {
+          const tokenSaverServer = await createXuanpuToolsMcpServerConfig({
+            sessionId: session.hiveSessionId,
+            defaultCwd: session.worktreePath,
+            logger: { warn: (msg, meta) => log.warn(msg, meta) }
+          })
+          options.mcpServers = { ...options.mcpServers, xuanpu: tokenSaverServer }
+          options.allowedTools = [...(options.allowedTools ?? []), 'mcp__xuanpu__bash']
+          options.disallowedTools = [...(options.disallowedTools ?? []), 'Bash']
+          log.info('Token Saver: attached xuanpu MCP, disallowed built-in Bash', {
+            hiveSessionId: session.hiveSessionId
+          })
+        } catch (err) {
+          log.warn('Token Saver: failed to attach MCP, falling back to native Bash', {
+            hiveSessionId: session.hiveSessionId,
+            error: err instanceof Error ? err.message : String(err)
+          })
+        }
       }
 
       options = await maybeWithClaudeProjectMemory(options)

--- a/src/main/services/claude-code-implementer.ts
+++ b/src/main/services/claude-code-implementer.ts
@@ -22,6 +22,7 @@ import { CommandFilterService, type CommandFilterSettings } from './command-filt
 import { createLspMcpServerConfig, LspService } from './lsp'
 import { createXuanpuToolsMcpServerConfig } from './token-saver/xuanpu-tools-mcp'
 import { isTokenSaverEnabled } from '../field/privacy'
+import { XUANPU_SYSTEM_CONTEXT } from './xuanpu-system-context'
 import { APP_SETTINGS_DB_KEY } from '@shared/types/settings'
 import { getActiveAppHomeDir } from '@shared/app-identity'
 import { beginSessionRun, emitAgentEvent } from '@shared/lib/normalize-agent-event'
@@ -669,6 +670,13 @@ export class ClaudeCodeImplementer implements AgentSdkImplementer, AgentRuntimeA
         enableFileCheckpointing: true,
         settingSources: ['user', 'project', 'local'],
         extraArgs: { 'replay-user-messages': null },
+        // Append Xuanpu's runtime context to the SDK system prompt. This
+        // tells the model that Xuanpu's [Field Context]/[User Message] envelope
+        // is informational, not contractual — preventing "No response
+        // requested." silent-exits when the SDK injects bare boilerplate
+        // (e.g. "Continue from where you left off." after an interrupted turn).
+        // See src/main/services/xuanpu-system-context.ts for the full rationale.
+        appendSystemPrompt: XUANPU_SYSTEM_CONTEXT,
         ...(additionalDirs.length > 0 ? { additionalDirectories: additionalDirs } : {}),
         ...(this.thinkingSupported ? { thinking: { type: 'adaptive' } as const } : {}),
         effort: effortLevel,

--- a/src/main/services/claude-code-implementer.ts
+++ b/src/main/services/claude-code-implementer.ts
@@ -965,7 +965,18 @@ export class ClaudeCodeImplementer implements AgentSdkImplementer, AgentRuntimeA
           // exhaustion, and (2) compaction summary injected by SDK after context
           // window compression. Neither should appear in the UI timeline.
           // Also skip skill prompt injection messages (expanded skill file content).
+          // Also skip the SDK's synthetic "Continue from where you left off." marker
+          // injected by aA8/print.ts when resuming an interrupted_turn or a deferred
+          // tool use. It carries isMeta:true upstream, but the flag is unreliable
+          // across SDK serialization, so we match the canonical text instead.
           if (msgType === 'user') {
+            // Honor explicit isMeta marker when SDK propagates it
+            if ((sdkMsg as Record<string, unknown>).isMeta === true) {
+              log.info('Skipping SDK meta user message', {
+                uuid: typeof sdkMsg.uuid === 'string' ? sdkMsg.uuid.slice(0, 12) : undefined
+              })
+              continue
+            }
             let textContent = ''
             if (Array.isArray(msgContent)) {
               textContent = msgContent
@@ -984,8 +995,12 @@ export class ClaudeCodeImplementer implements AgentSdkImplementer, AgentRuntimeA
               trimmed.startsWith('Here is a summary of the conversation so far') ||
               trimmed.startsWith('Base directory for this skill:') ||
               trimmed.startsWith('<local-command-stdout>') ||
-              trimmed.startsWith('<system-reminder>')
+              trimmed.startsWith('<system-reminder>') ||
+              trimmed === 'Continue from where you left off.'
             ) {
+              log.info('Skipping SDK boilerplate user message', {
+                preview: trimmed.slice(0, 60)
+              })
               continue
             }
           }

--- a/src/main/services/file-ops.ts
+++ b/src/main/services/file-ops.ts
@@ -1,9 +1,12 @@
 import { readFileSync, writeFileSync, existsSync, statSync } from 'fs'
-import { dirname, join } from 'path'
+import { dirname, join, resolve } from 'path'
+import { homedir } from 'os'
 import { app } from 'electron'
 import { getImageMimeType } from '@shared/types/file-utils'
 
 const MAX_FILE_SIZE = 1024 * 1024 // 1MB
+const MAX_ARCHIVE_SIZE = 50 * 1024 * 1024 // 50MB for Token Saver archives
+const ARCHIVE_ROOT = resolve(join(homedir(), '.xuanpu', 'archive'))
 
 export function readFile(filePath: string): {
   success: boolean
@@ -25,6 +28,43 @@ export function readFile(filePath: string): {
       return { success: false, error: 'File too large (max 1MB)' }
     }
     const content = readFileSync(filePath, 'utf-8')
+    return { success: true, content }
+  } catch (error) {
+    return { success: false, error: error instanceof Error ? error.message : 'Unknown error' }
+  }
+}
+
+/**
+ * Read a Token Saver archive file. Behaves like `readFile` but:
+ *   - Only permits paths resolving under `~/.xuanpu/archive` (path whitelist)
+ *   - Allows up to 50MB (archives can be large — full command output)
+ * The path whitelist prevents a compromised renderer from reading arbitrary
+ * files via this channel while keeping the expand-original UX working.
+ */
+export function readArchiveFile(filePath: string): {
+  success: boolean
+  content?: string
+  error?: string
+} {
+  try {
+    if (!filePath || typeof filePath !== 'string') {
+      return { success: false, error: 'Invalid file path' }
+    }
+    const absolute = resolve(filePath)
+    if (!absolute.startsWith(ARCHIVE_ROOT + '/') && absolute !== ARCHIVE_ROOT) {
+      return { success: false, error: 'Path is outside the archive root' }
+    }
+    if (!existsSync(absolute)) {
+      return { success: false, error: 'Archive file does not exist' }
+    }
+    const stat = statSync(absolute)
+    if (stat.isDirectory()) {
+      return { success: false, error: 'Path is a directory' }
+    }
+    if (stat.size > MAX_ARCHIVE_SIZE) {
+      return { success: false, error: 'Archive too large (max 50MB)' }
+    }
+    const content = readFileSync(absolute, 'utf-8')
     return { success: true, content }
   } catch (error) {
     return { success: false, error: error instanceof Error ? error.message : 'Unknown error' }

--- a/src/main/services/token-saver/bash-runner.ts
+++ b/src/main/services/token-saver/bash-runner.ts
@@ -1,0 +1,254 @@
+/**
+ * BashCommandRunner — Token Saver stage 2.
+ *
+ * A focused, dependency-light wrapper around `child_process.spawn` that gives
+ * us the parts of the SDK's built-in Bash semantics we actually need to honor
+ * once we're shadowing it via MCP:
+ *
+ *   - Run a single shell command with a configurable timeout
+ *   - Collect stdout + stderr separately AND in interleaved order
+ *   - Honor an AbortSignal so the agent's interrupt path can kill the process
+ *   - Use a configurable cwd (per-session worktree path)
+ *   - Use a configurable env (defaults to inherit; tests override)
+ *   - Cap output buffer size to protect main process memory (very large
+ *     outputs are still archived in full by the offload-store, but this
+ *     buffer is only what we keep in RAM for compression)
+ *
+ * NOT yet handled (deferred):
+ *   - run_in_background (background tasks with task IDs) — stage 4
+ *   - dangerouslyDisableSandbox — we never sandbox; flag is no-op
+ *   - macOS sandbox (sandbox-exec) — handled higher up if at all
+ *
+ * The runner does NOT do compression itself. Composition:
+ *
+ *     const result = await runBashCommand({...})
+ *     await offloadStore.write({ sessionId, body: result.combined })
+ *     const compressed = pipeline.run(result.combined, { exitCode: result.exitCode })
+ *     return { ...compressed, archive }
+ */
+import { spawn } from 'node:child_process'
+
+export interface RunBashOptions {
+  /** Shell command to execute. Run via `/bin/sh -c <command>` on POSIX. */
+  command: string
+  /** Working directory. REQUIRED — explicit > inherited surprise. */
+  cwd: string
+  /** Environment variables. Defaults to `process.env`. */
+  env?: NodeJS.ProcessEnv
+  /** Timeout in ms. Default 120_000. Hard upper bound is 600_000. */
+  timeoutMs?: number
+  /** Caller-provided abort signal. SIGTERM → SIGKILL escalation handled. */
+  signal?: AbortSignal
+  /**
+   * Hard cap on bytes retained in memory per stream. Default 4 MiB.
+   * If exceeded, output is truncated with a marker; full text still flows
+   * to the optional `tee` callback for archival.
+   */
+  maxBufferBytes?: number
+  /**
+   * Optional callback invoked for each chunk (stdout or stderr) with the
+   * raw bytes. Used by the MCP wrapper to stream into ContextOffloadStore
+   * without doubling memory.
+   */
+  tee?: (chunk: Buffer, stream: 'stdout' | 'stderr') => void
+}
+
+export interface RunBashResult {
+  /** Process exit code. -1 if killed by signal. */
+  exitCode: number
+  /** Wall-clock duration in milliseconds. */
+  durationMs: number
+  /** UTF-8 stdout (truncated at maxBufferBytes; `truncated.stdout=true` if so). */
+  stdout: string
+  /** UTF-8 stderr (truncated at maxBufferBytes; `truncated.stderr=true` if so). */
+  stderr: string
+  /**
+   * Combined view: stdout + a separator + stderr. Used for archival and
+   * for compression context. Order is "all stdout, then all stderr" — we
+   * do NOT interleave by arrival because chunk timing is unreliable across
+   * platforms.
+   */
+  combined: string
+  truncated: { stdout: boolean; stderr: boolean }
+  /** True if killed because the timeout fired. */
+  timedOut: boolean
+  /** True if killed because the caller's AbortSignal fired. */
+  aborted: boolean
+}
+
+const DEFAULT_TIMEOUT_MS = 120_000
+const MAX_TIMEOUT_MS = 600_000
+const DEFAULT_MAX_BUFFER = 4 * 1024 * 1024 // 4 MiB
+const KILL_GRACE_MS = 1_500 // SIGTERM → wait → SIGKILL escalation
+
+export async function runBashCommand(options: RunBashOptions): Promise<RunBashResult> {
+  if (!options.command || typeof options.command !== 'string') {
+    throw new Error('runBashCommand: command is required')
+  }
+  if (!options.cwd || typeof options.cwd !== 'string') {
+    throw new Error('runBashCommand: cwd is required')
+  }
+  const timeoutMs = clamp(options.timeoutMs ?? DEFAULT_TIMEOUT_MS, 1, MAX_TIMEOUT_MS)
+  const maxBuffer = options.maxBufferBytes ?? DEFAULT_MAX_BUFFER
+  const tee = options.tee
+
+  return new Promise<RunBashResult>((resolve, reject) => {
+    const startedAt = Date.now()
+
+    let child
+    try {
+      child = spawn('/bin/sh', ['-c', options.command], {
+        cwd: options.cwd,
+        env: options.env ?? process.env,
+        stdio: ['ignore', 'pipe', 'pipe']
+      })
+    } catch (err) {
+      reject(err instanceof Error ? err : new Error(String(err)))
+      return
+    }
+
+    const stdoutChunks: Buffer[] = []
+    const stderrChunks: Buffer[] = []
+    let stdoutBytes = 0
+    let stderrBytes = 0
+    let stdoutTruncated = false
+    let stderrTruncated = false
+    let timedOut = false
+    let aborted = false
+
+    const timeoutHandle = setTimeout(() => {
+      timedOut = true
+      escalateKill(child)
+    }, timeoutMs)
+
+    const onAbort = (): void => {
+      aborted = true
+      escalateKill(child)
+    }
+    if (options.signal) {
+      if (options.signal.aborted) {
+        onAbort()
+      } else {
+        options.signal.addEventListener('abort', onAbort, { once: true })
+      }
+    }
+
+    child.stdout?.on('data', (chunk: Buffer) => {
+      if (tee) {
+        try {
+          tee(chunk, 'stdout')
+        } catch {
+          // tee errors must not break the runner
+        }
+      }
+      if (stdoutBytes < maxBuffer) {
+        const remaining = maxBuffer - stdoutBytes
+        if (chunk.length <= remaining) {
+          stdoutChunks.push(chunk)
+          stdoutBytes += chunk.length
+        } else {
+          stdoutChunks.push(chunk.subarray(0, remaining))
+          stdoutBytes += remaining
+          stdoutTruncated = true
+        }
+      } else {
+        stdoutTruncated = true
+      }
+    })
+
+    child.stderr?.on('data', (chunk: Buffer) => {
+      if (tee) {
+        try {
+          tee(chunk, 'stderr')
+        } catch {
+          // tee errors must not break the runner
+        }
+      }
+      if (stderrBytes < maxBuffer) {
+        const remaining = maxBuffer - stderrBytes
+        if (chunk.length <= remaining) {
+          stderrChunks.push(chunk)
+          stderrBytes += chunk.length
+        } else {
+          stderrChunks.push(chunk.subarray(0, remaining))
+          stderrBytes += remaining
+          stderrTruncated = true
+        }
+      } else {
+        stderrTruncated = true
+      }
+    })
+
+    child.on('error', (err) => {
+      clearTimeout(timeoutHandle)
+      if (options.signal) options.signal.removeEventListener('abort', onAbort)
+      reject(err)
+    })
+
+    child.on('close', (code, signalName) => {
+      clearTimeout(timeoutHandle)
+      if (options.signal) options.signal.removeEventListener('abort', onAbort)
+
+      const stdout = Buffer.concat(stdoutChunks).toString('utf8')
+      const stderr = Buffer.concat(stderrChunks).toString('utf8')
+
+      // Build combined view. Mark truncation explicitly so the agent knows.
+      const parts: string[] = []
+      if (stdout.length > 0) {
+        parts.push(stdout + (stdoutTruncated ? '\n[stdout truncated]' : ''))
+      }
+      if (stderr.length > 0) {
+        if (parts.length > 0) parts.push('--- stderr ---')
+        parts.push(stderr + (stderrTruncated ? '\n[stderr truncated]' : ''))
+      }
+      const combined = parts.join('\n')
+
+      const exitCode =
+        typeof code === 'number'
+          ? code
+          : signalName
+            ? -1
+            : 0
+
+      resolve({
+        exitCode,
+        durationMs: Date.now() - startedAt,
+        stdout,
+        stderr,
+        combined,
+        truncated: { stdout: stdoutTruncated, stderr: stderrTruncated },
+        timedOut,
+        aborted
+      })
+    })
+  })
+}
+
+function clamp(n: number, lo: number, hi: number): number {
+  if (!Number.isFinite(n)) return lo
+  return Math.min(Math.max(Math.floor(n), lo), hi)
+}
+
+/**
+ * Escalation: SIGTERM first, then SIGKILL after a grace window if still alive.
+ * This matches the SDK's built-in Bash behavior and avoids leaving zombie
+ * processes when the agent interrupts mid-execution.
+ */
+function escalateKill(child: import('node:child_process').ChildProcess): void {
+  if (!child.pid || child.killed) return
+  try {
+    child.kill('SIGTERM')
+  } catch {
+    // already gone
+    return
+  }
+  setTimeout(() => {
+    if (!child.killed && child.exitCode === null) {
+      try {
+        child.kill('SIGKILL')
+      } catch {
+        // already gone
+      }
+    }
+  }, KILL_GRACE_MS).unref()
+}

--- a/src/main/services/token-saver/index.ts
+++ b/src/main/services/token-saver/index.ts
@@ -32,6 +32,13 @@ export { ContextOffloadStore } from './offload-store'
 export type { RunBashOptions, RunBashResult } from './bash-runner'
 export { runBashCommand } from './bash-runner'
 
+export type { XuanpuToolsContext, BashToolMetadata } from './xuanpu-tools-mcp'
+export {
+  createXuanpuToolsMcpServerConfig,
+  formatToolResultText,
+  runBashWithCompression
+} from './xuanpu-tools-mcp'
+
 import { OutputCompressionPipeline } from './pipeline'
 import { DEFAULT_STRATEGIES } from './strategies'
 

--- a/src/main/services/token-saver/index.ts
+++ b/src/main/services/token-saver/index.ts
@@ -1,0 +1,50 @@
+/**
+ * Token Saver — public entry point.
+ *
+ * Stage 1: pipeline + strategies. Stage 2 will add the MCP Bash interceptor
+ * + ContextOffloadStore. Stage 3 will add UI metadata.
+ *
+ * Consumers:
+ *   import { OutputCompressionPipeline, defaultPipeline } from 'src/main/services/token-saver'
+ */
+export type {
+  CompressionContext,
+  StrategyResult,
+  OutputStrategy,
+  PipelineRuleHit,
+  PipelineResult,
+  PipelineLogger
+} from './pipeline'
+
+export { OutputCompressionPipeline, isOutputStrategy } from './pipeline'
+
+export {
+  ansiStripStrategy,
+  progressDedupStrategy,
+  ndjsonSummaryStrategy,
+  failureFocusStrategy,
+  statsExtractionStrategy,
+  DEFAULT_STRATEGIES
+} from './strategies'
+
+import { OutputCompressionPipeline } from './pipeline'
+import { DEFAULT_STRATEGIES } from './strategies'
+
+let cachedDefault: OutputCompressionPipeline | null = null
+
+/**
+ * Returns a memoised default pipeline with all 5 built-in strategies in order.
+ * Most consumers should use this. Tests and bespoke consumers can construct
+ * their own pipeline with `new OutputCompressionPipeline([...])`.
+ */
+export function defaultPipeline(): OutputCompressionPipeline {
+  if (!cachedDefault) {
+    cachedDefault = new OutputCompressionPipeline([...DEFAULT_STRATEGIES])
+  }
+  return cachedDefault
+}
+
+/** Test-only: reset the cached default (forces fresh construction). */
+export function __resetDefaultPipelineForTest(): void {
+  cachedDefault = null
+}

--- a/src/main/services/token-saver/index.ts
+++ b/src/main/services/token-saver/index.ts
@@ -1,11 +1,10 @@
 /**
  * Token Saver — public entry point.
  *
- * Stage 1: pipeline + strategies. Stage 2 will add the MCP Bash interceptor
- * + ContextOffloadStore. Stage 3 will add UI metadata.
- *
- * Consumers:
- *   import { OutputCompressionPipeline, defaultPipeline } from 'src/main/services/token-saver'
+ * Stage 1: pipeline + strategies.
+ * Stage 2a: ContextOffloadStore + BashCommandRunner.
+ * Stage 2b: MCP server factory + claude-code-implementer integration (next).
+ * Stage 3: UI metadata.
  */
 export type {
   CompressionContext,
@@ -27,6 +26,12 @@ export {
   DEFAULT_STRATEGIES
 } from './strategies'
 
+export type { OffloadRecord, OffloadInput, ContextOffloadStoreOptions } from './offload-store'
+export { ContextOffloadStore } from './offload-store'
+
+export type { RunBashOptions, RunBashResult } from './bash-runner'
+export { runBashCommand } from './bash-runner'
+
 import { OutputCompressionPipeline } from './pipeline'
 import { DEFAULT_STRATEGIES } from './strategies'
 
@@ -34,8 +39,6 @@ let cachedDefault: OutputCompressionPipeline | null = null
 
 /**
  * Returns a memoised default pipeline with all 5 built-in strategies in order.
- * Most consumers should use this. Tests and bespoke consumers can construct
- * their own pipeline with `new OutputCompressionPipeline([...])`.
  */
 export function defaultPipeline(): OutputCompressionPipeline {
   if (!cachedDefault) {

--- a/src/main/services/token-saver/offload-store.ts
+++ b/src/main/services/token-saver/offload-store.ts
@@ -1,0 +1,217 @@
+/**
+ * ContextOffloadStore — Token Saver stage 2.
+ *
+ * Persists the full, uncompressed output of a tool invocation to a local file
+ * so the compressed version sent to the agent can reference the archive path.
+ * The agent never reads archives directly; the user does (via "Show original"
+ * in the UI, or by following the path in stderr).
+ *
+ * Layout:
+ *   <root>/<sessionId>/<unix-millis>-<seq>.<ext>
+ *
+ * - `<root>` defaults to `~/.xuanpu/archive` but is configurable for tests.
+ * - `<sessionId>` keeps each session's archives isolated.
+ * - The filename embeds the timestamp + a per-session monotonic counter so
+ *   archives are sortable and unique even when wall-clock is identical.
+ * - `<ext>` is `.txt` for combined stdout+stderr, `.bin` for raw binary.
+ *
+ * Atomic writes: we write to `<final>.tmp` then `rename()`. Fast, crash-safe.
+ * On Windows rename across the same volume is atomic; we don't support
+ * cross-volume moves (offload root must be on the user's home volume).
+ *
+ * Concurrency: the per-session counter is held in-memory and incremented
+ * synchronously. Two parallel writes from the same session get distinct seqs.
+ *
+ * Disk pressure: the store does NOT auto-prune. Stage 3 will add a settings
+ * UI to display total size and trigger a one-shot cleanup. Auto-rotate (e.g.
+ * "delete archives older than N days") will land in stage 4.
+ */
+import { promises as fs } from 'node:fs'
+import { homedir } from 'node:os'
+import { join, dirname } from 'node:path'
+import { randomUUID } from 'node:crypto'
+
+export interface OffloadRecord {
+  /** Absolute path to the persisted archive. */
+  path: string
+  /** UTF-8 byte length of the persisted body. */
+  bytes: number
+  /** Monotonic per-session sequence number (1-based). */
+  seq: number
+  /** Wall-clock timestamp at write start (ms since epoch). */
+  ts: number
+}
+
+export interface OffloadInput {
+  /** Hive session id (or any stable session-like key). */
+  sessionId: string
+  /** Body to persist. May contain combined stdout + stderr separators. */
+  body: string
+  /** Optional file extension (default 'txt'). Don't include the dot. */
+  ext?: string
+}
+
+export interface ContextOffloadStoreOptions {
+  /** Root directory. Defaults to `~/.xuanpu/archive`. */
+  rootDir?: string
+}
+
+const DEFAULT_ROOT = join(homedir(), '.xuanpu', 'archive')
+
+export class ContextOffloadStore {
+  private readonly rootDir: string
+  /** sessionId → next sequence number (1-based). */
+  private readonly seqMap = new Map<string, number>()
+
+  constructor(options: ContextOffloadStoreOptions = {}) {
+    this.rootDir = options.rootDir ?? DEFAULT_ROOT
+  }
+
+  /** Returns the configured root directory. */
+  getRootDir(): string {
+    return this.rootDir
+  }
+
+  /**
+   * Persist `body` and return a record with the absolute path and metadata.
+   *
+   * Writes are sequential per call but the function returns once the rename
+   * completes. Callers MAY fire-and-forget if they don't need the path back
+   * to the agent (rare).
+   */
+  async write(input: OffloadInput): Promise<OffloadRecord> {
+    if (!input.sessionId || typeof input.sessionId !== 'string') {
+      throw new Error('ContextOffloadStore.write: sessionId is required')
+    }
+    if (typeof input.body !== 'string') {
+      throw new Error('ContextOffloadStore.write: body must be a string')
+    }
+    const ext = (input.ext ?? 'txt').replace(/^\./, '')
+    const seq = this.nextSeq(input.sessionId)
+    const ts = Date.now()
+    const fileName = `${ts}-${String(seq).padStart(4, '0')}.${ext}`
+    const dir = join(this.rootDir, this.sanitizeSessionId(input.sessionId))
+    const finalPath = join(dir, fileName)
+    const tmpPath = `${finalPath}.${randomUUID().slice(0, 8)}.tmp`
+
+    await fs.mkdir(dir, { recursive: true })
+    await fs.writeFile(tmpPath, input.body, 'utf8')
+    try {
+      await fs.rename(tmpPath, finalPath)
+    } catch (err) {
+      // Best-effort cleanup of tmp file on rename failure.
+      await fs.unlink(tmpPath).catch(() => {})
+      throw err
+    }
+
+    return {
+      path: finalPath,
+      bytes: Buffer.byteLength(input.body, 'utf8'),
+      seq,
+      ts
+    }
+  }
+
+  /**
+   * Read back a previously archived body. Used by UI's "show original" path
+   * and by tests. Throws on missing path / read error.
+   */
+  async read(path: string): Promise<string> {
+    return fs.readFile(path, 'utf8')
+  }
+
+  /**
+   * Total size in bytes of all archives under root. Cheap-ish (single recursive
+   * stat walk). Returns 0 if root doesn't exist yet.
+   */
+  async totalSizeBytes(): Promise<number> {
+    return walkSize(this.rootDir)
+  }
+
+  /**
+   * Delete all archives under root. Use with care — this is destructive.
+   * Returns the number of files removed.
+   */
+  async clearAll(): Promise<number> {
+    return walkRemove(this.rootDir)
+  }
+
+  // ── Private ────────────────────────────────────────────────────────────
+
+  private nextSeq(sessionId: string): number {
+    const cur = this.seqMap.get(sessionId) ?? 0
+    const next = cur + 1
+    this.seqMap.set(sessionId, next)
+    return next
+  }
+
+  /**
+   * Filesystem-safe sessionId. Hive session ids are UUIDs in practice but we
+   * defensively strip path separators just in case.
+   */
+  private sanitizeSessionId(sessionId: string): string {
+    // Replace anything that's not alphanumeric, dash, or underscore.
+    return sessionId.replace(/[^A-Za-z0-9_-]/g, '_').slice(0, 128)
+  }
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// Filesystem helpers
+// ───────────────────────────────────────────────────────────────────────────
+
+async function walkSize(root: string): Promise<number> {
+  let total = 0
+  let entries: import('node:fs').Dirent[]
+  try {
+    entries = await fs.readdir(root, { withFileTypes: true })
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return 0
+    throw err
+  }
+  for (const e of entries) {
+    const p = join(root, e.name)
+    if (e.isDirectory()) {
+      total += await walkSize(p)
+    } else if (e.isFile()) {
+      try {
+        total += (await fs.stat(p)).size
+      } catch {
+        // file may have been removed between readdir and stat — ignore
+      }
+    }
+  }
+  return total
+}
+
+async function walkRemove(root: string): Promise<number> {
+  let count = 0
+  let entries: import('node:fs').Dirent[]
+  try {
+    entries = await fs.readdir(root, { withFileTypes: true })
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return 0
+    throw err
+  }
+  for (const e of entries) {
+    const p = join(root, e.name)
+    if (e.isDirectory()) {
+      count += await walkRemove(p)
+      try {
+        await fs.rmdir(p)
+      } catch {
+        // non-empty (race) — ignore
+      }
+    } else if (e.isFile()) {
+      try {
+        await fs.unlink(p)
+        count++
+      } catch {
+        // already gone — ignore
+      }
+    }
+  }
+  return count
+}
+
+// Avoid 'unused' warnings on dirname if we ever drop the import path.
+void dirname

--- a/src/main/services/token-saver/pipeline.ts
+++ b/src/main/services/token-saver/pipeline.ts
@@ -1,0 +1,148 @@
+/**
+ * OutputCompressionPipeline — Token Saver stage 1.
+ *
+ * Generic, tool-agnostic pipeline that transforms verbose tool output into a
+ * compact form before it reaches the agent's API call. The pipeline holds an
+ * ordered list of `OutputStrategy` instances; each strategy may pass-through
+ * (no-op) or transform the text. Strategies record their hit in `ruleHits`
+ * so the UI can surface "what compressed this".
+ *
+ * Pipeline guarantees:
+ *   - Idempotent: passing the same input through the same pipeline twice
+ *     produces the same final text.
+ *   - Failure-isolated: if a strategy throws, it is logged and skipped; the
+ *     pipeline continues with the previous text. A bad strategy never blocks
+ *     the agent.
+ *   - Non-allocating on no-op: strategies that decide not to change the text
+ *     should return `{ changed: false, text }` to avoid copying.
+ *
+ * NOT included here:
+ *   - I/O / archive writing  → caller's responsibility (ContextOffloadStore)
+ *   - Per-tool dispatch      → done by MCP Bash interceptor (stage 2)
+ *   - UI metadata rendering  → renderer-side (stage 3)
+ *
+ * See docs/plans/2026-05-04-token-saver-pipeline.md §五 阶段 1.
+ */
+
+export interface CompressionContext {
+  /** Original command (for Bash tool); helps strategies decide. */
+  command?: string
+  /** Exit code if known; non-zero biases towards FailureFocus. */
+  exitCode?: number
+  /** Wall-clock duration in milliseconds. */
+  durationMs?: number
+  /** Loose hint about the source: 'bash' | 'read' | 'grep' | 'mcp' | ... */
+  source?: string
+}
+
+export interface StrategyResult {
+  /** Whether this strategy modified the text. */
+  changed: boolean
+  /** New text (same as input if `changed === false`). */
+  text: string
+  /** Optional human-readable reason for telemetry / UI tooltip. */
+  hint?: string
+}
+
+export interface OutputStrategy {
+  /** Stable identifier — used in `ruleHits` and tests. */
+  readonly name: string
+  /**
+   * Apply this strategy to `text`. Must return a result; throwing is allowed
+   * but the pipeline will catch and skip. Strategies should be pure functions
+   * of (text, ctx).
+   */
+  apply(text: string, ctx: CompressionContext): StrategyResult
+}
+
+export interface PipelineRuleHit {
+  name: string
+  hint?: string
+}
+
+export interface PipelineResult {
+  /** Final compressed text after all strategies. */
+  text: string
+  /** UTF-8 byte length of the original input. */
+  beforeBytes: number
+  /** UTF-8 byte length of the final output. */
+  afterBytes: number
+  /** Strategies that fired, in execution order. */
+  ruleHits: PipelineRuleHit[]
+}
+
+/**
+ * Type guard to validate a value is a real OutputStrategy. Useful when a
+ * pipeline is constructed from user-provided / plugin-provided strategies.
+ */
+export function isOutputStrategy(value: unknown): value is OutputStrategy {
+  if (!value || typeof value !== 'object') return false
+  const v = value as Record<string, unknown>
+  return typeof v.name === 'string' && typeof v.apply === 'function'
+}
+
+/**
+ * Logger contract — keeps the pipeline free of a hard dependency on the
+ * project's `logger.ts` so it can be unit-tested in isolation.
+ */
+export interface PipelineLogger {
+  warn(msg: string, meta?: Record<string, unknown>): void
+}
+
+const noopLogger: PipelineLogger = { warn: () => {} }
+
+export class OutputCompressionPipeline {
+  private readonly strategies: ReadonlyArray<OutputStrategy>
+  private readonly log: PipelineLogger
+
+  constructor(strategies: OutputStrategy[], logger: PipelineLogger = noopLogger) {
+    for (const s of strategies) {
+      if (!isOutputStrategy(s)) {
+        throw new Error(`OutputCompressionPipeline: invalid strategy ${String(s)}`)
+      }
+    }
+    this.strategies = Object.freeze([...strategies])
+    this.log = logger
+  }
+
+  run(input: string, ctx: CompressionContext = {}): PipelineResult {
+    const beforeBytes = Buffer.byteLength(input ?? '', 'utf8')
+    const hits: PipelineRuleHit[] = []
+    let current = input ?? ''
+
+    for (const strategy of this.strategies) {
+      let result: StrategyResult
+      try {
+        result = strategy.apply(current, ctx)
+      } catch (err) {
+        this.log.warn('OutputCompressionPipeline: strategy threw, skipping', {
+          name: strategy.name,
+          error: err instanceof Error ? err.message : String(err)
+        })
+        continue
+      }
+      if (!result || typeof result.text !== 'string') {
+        this.log.warn('OutputCompressionPipeline: strategy returned malformed result, skipping', {
+          name: strategy.name
+        })
+        continue
+      }
+      if (result.changed && result.text !== current) {
+        current = result.text
+        hits.push({ name: strategy.name, hint: result.hint })
+      }
+    }
+
+    return {
+      text: current,
+      beforeBytes,
+      afterBytes: Buffer.byteLength(current, 'utf8'),
+      ruleHits: hits
+    }
+  }
+
+  /** For tests: expose strategy names in order. */
+  get strategyNames(): string[] {
+    return this.strategies.map((s) => s.name)
+  }
+}

--- a/src/main/services/token-saver/strategies.ts
+++ b/src/main/services/token-saver/strategies.ts
@@ -1,0 +1,332 @@
+/**
+ * Built-in compression strategies for the OutputCompressionPipeline.
+ *
+ * Each strategy is a pure function of (text, ctx). They are ordered in the
+ * default pipeline as:
+ *
+ *   1. AnsiStrip      — drop ANSI escape sequences (always-on cleanup)
+ *   2. ProgressDedup  — collapse \r progress redraws + repeated lines
+ *   3. NdjsonSummary  — if the whole stream is JSON-lines, produce a summary
+ *   4. FailureFocus   — if exit≠0 / errors present, keep error sections only
+ *   5. StatsExtraction — if a test/build summary line is present, lift it
+ *
+ * Order matters: cleanup first, transforms last. Each strategy is conservative:
+ * if its trigger condition is not met it returns `{ changed: false }` without
+ * allocating.
+ *
+ * Borrowed conceptually from RTK's 12-rule library, but reimplemented in TS
+ * for in-process execution. We are not a port — we pick the highest-ROI 5.
+ */
+import type { CompressionContext, OutputStrategy, StrategyResult } from './pipeline'
+
+// ───────────────────────────────────────────────────────────────────────────
+// Constants
+// ───────────────────────────────────────────────────────────────────────────
+
+/** Threshold below which we don't bother compressing (overhead > savings). */
+const MIN_COMPRESS_BYTES = 512
+
+/** When a section is summarised as "first/last N lines", how many to keep. */
+const HEAD_TAIL_KEEP_LINES = 5
+
+// ───────────────────────────────────────────────────────────────────────────
+// 1. AnsiStrip
+// ───────────────────────────────────────────────────────────────────────────
+
+// Matches CSI sequences (most common: SGR colour codes), OSC, and a few
+// terminal control bytes. Conservative — does NOT touch printable text.
+// eslint-disable-next-line no-control-regex
+const ANSI_REGEX = /\x1b\[[0-?]*[ -/]*[@-~]|\x1b\][^\x07]*\x07|\x1b[PX^_].*?\x1b\\/g
+
+export const ansiStripStrategy: OutputStrategy = {
+  name: 'ansi-strip',
+  apply(text: string): StrategyResult {
+    if (!text || !ANSI_REGEX.test(text)) {
+      ANSI_REGEX.lastIndex = 0
+      return { changed: false, text }
+    }
+    ANSI_REGEX.lastIndex = 0
+    const out = text.replace(ANSI_REGEX, '')
+    if (out === text) return { changed: false, text }
+    return { changed: true, text: out, hint: 'stripped ANSI escapes' }
+  }
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// 2. ProgressDedup
+// ───────────────────────────────────────────────────────────────────────────
+
+/**
+ * Two transforms in one strategy:
+ *   (a) Carriage-return progress redraws: collapse `foo\rbar\rbaz\n` to `baz\n`.
+ *   (b) Repeated lines: `npm install` printing the same dep 100×, `tsc` watch
+ *       bouncing the same warning. Replace runs of identical lines with one
+ *       line + `... (×N)`.
+ */
+export const progressDedupStrategy: OutputStrategy = {
+  name: 'progress-dedup',
+  apply(text: string): StrategyResult {
+    if (!text || text.length < 8) return { changed: false, text }
+
+    // (a) Collapse \r progress: keep only the final write before \n.
+    let cur = text
+    if (cur.includes('\r') && !cur.includes('\r\n')) {
+      // Bare \r (terminal redraw) — collapse runs.
+      cur = cur.replace(/[^\n]*\r/g, '')
+    } else if (cur.includes('\r\n')) {
+      // Normalize CRLF to LF, then look for bare \r within lines.
+      cur = cur.replace(/\r\n/g, '\n').replace(/[^\n]*\r/g, '')
+    }
+
+    // (b) Repeated-line collapse.
+    const lines = cur.split('\n')
+    const out: string[] = []
+    let i = 0
+    let dedupCount = 0
+    while (i < lines.length) {
+      const line = lines[i]
+      let runEnd = i + 1
+      while (runEnd < lines.length && lines[runEnd] === line) runEnd++
+      const runLen = runEnd - i
+      if (runLen >= 4 && line.trim().length > 0) {
+        out.push(`${line}    … (×${runLen})`)
+        dedupCount += runLen - 1
+      } else {
+        for (let k = i; k < runEnd; k++) out.push(lines[k])
+      }
+      i = runEnd
+    }
+
+    const joined = out.join('\n')
+    if (joined === text) return { changed: false, text }
+    return {
+      changed: true,
+      text: joined,
+      hint: dedupCount > 0 ? `collapsed ${dedupCount} repeated lines` : 'collapsed progress redraws'
+    }
+  }
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// 3. NdjsonSummary
+// ───────────────────────────────────────────────────────────────────────────
+
+/**
+ * If the input looks like newline-delimited JSON (every non-empty line is
+ * valid JSON), produce a summary that keeps the first and last few records
+ * verbatim and counts records by `level` field if present.
+ *
+ * Trigger: ≥10 lines AND ≥80% are valid JSON objects.
+ */
+export const ndjsonSummaryStrategy: OutputStrategy = {
+  name: 'ndjson-summary',
+  apply(text: string): StrategyResult {
+    if (!text || text.length < MIN_COMPRESS_BYTES) return { changed: false, text }
+    const lines = text.split('\n').filter((l) => l.trim().length > 0)
+    if (lines.length < 10) return { changed: false, text }
+
+    const parsed: Array<{ raw: string; obj: Record<string, unknown> | null }> = []
+    let validCount = 0
+    for (const raw of lines) {
+      let obj: Record<string, unknown> | null = null
+      const trimmed = raw.trim()
+      if (trimmed.startsWith('{') && trimmed.endsWith('}')) {
+        try {
+          const v = JSON.parse(trimmed)
+          if (v && typeof v === 'object' && !Array.isArray(v)) {
+            obj = v as Record<string, unknown>
+            validCount++
+          }
+        } catch {
+          // not JSON, leave obj null
+        }
+      }
+      parsed.push({ raw, obj })
+    }
+    if (validCount < lines.length * 0.8) return { changed: false, text }
+
+    // Count by level (common log shape).
+    const levelCounts: Record<string, number> = {}
+    for (const p of parsed) {
+      if (!p.obj) continue
+      const lvl = typeof p.obj.level === 'string' ? p.obj.level : '(no-level)'
+      levelCounts[lvl] = (levelCounts[lvl] ?? 0) + 1
+    }
+    const levelSummary = Object.entries(levelCounts)
+      .map(([k, v]) => `${k}=${v}`)
+      .join(' ')
+
+    const head = parsed.slice(0, HEAD_TAIL_KEEP_LINES).map((p) => p.raw)
+    const tail = parsed.slice(-HEAD_TAIL_KEEP_LINES).map((p) => p.raw)
+    const omitted = lines.length - head.length - tail.length
+
+    const summary = [
+      `[ndjson summary: ${lines.length} records · ${levelSummary}]`,
+      ...head,
+      omitted > 0 ? `… (${omitted} records omitted)` : null,
+      ...(omitted > 0 ? tail : [])
+    ]
+      .filter((s): s is string => s !== null)
+      .join('\n')
+
+    return {
+      changed: true,
+      text: summary,
+      hint: `summarised ${lines.length} ndjson records`
+    }
+  }
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// 4. FailureFocus
+// ───────────────────────────────────────────────────────────────────────────
+
+const FAILURE_LINE_REGEX =
+  /\b(error|failed|failure|fatal|exception|traceback|panicked|✗|×|FAIL)\b/i
+
+/**
+ * If the command failed (exit≠0) OR the text contains failure markers AND is
+ * large, keep:
+ *   - The first 5 lines (often the command echo / setup)
+ *   - All blocks containing failure markers, with 3 lines of context each
+ *   - The last 5 lines (often the summary / exit)
+ *
+ * Drop everything else. Useful for `pnpm test` failing — agent only needs to
+ * see the failures, not the 4000 lines of passing test names.
+ */
+export const failureFocusStrategy: OutputStrategy = {
+  name: 'failure-focus',
+  apply(text: string, ctx: CompressionContext): StrategyResult {
+    if (!text || text.length < MIN_COMPRESS_BYTES) return { changed: false, text }
+
+    const failed = ctx.exitCode !== undefined && ctx.exitCode !== 0
+    const lines = text.split('\n')
+    if (lines.length < 30) return { changed: false, text }
+
+    if (!failed) {
+      // Without an explicit fail signal, only fire if there's an obvious marker.
+      const sample = text.slice(0, 8192) + text.slice(-8192)
+      if (!FAILURE_LINE_REGEX.test(sample)) return { changed: false, text }
+    }
+
+    const keepIdx = new Set<number>()
+    for (let i = 0; i < HEAD_TAIL_KEEP_LINES && i < lines.length; i++) keepIdx.add(i)
+    for (let i = Math.max(0, lines.length - HEAD_TAIL_KEEP_LINES); i < lines.length; i++) {
+      keepIdx.add(i)
+    }
+    for (let i = 0; i < lines.length; i++) {
+      if (FAILURE_LINE_REGEX.test(lines[i])) {
+        for (let k = Math.max(0, i - 3); k <= Math.min(lines.length - 1, i + 3); k++) {
+          keepIdx.add(k)
+        }
+      }
+    }
+
+    if (keepIdx.size >= lines.length) return { changed: false, text }
+
+    const out: string[] = []
+    let lastKept = -1
+    let droppedRun = 0
+    for (let i = 0; i < lines.length; i++) {
+      if (keepIdx.has(i)) {
+        if (droppedRun > 0) {
+          out.push(`… (${droppedRun} lines omitted)`)
+          droppedRun = 0
+        }
+        out.push(lines[i])
+        lastKept = i
+      } else {
+        droppedRun++
+      }
+    }
+    if (droppedRun > 0) {
+      out.push(`… (${droppedRun} lines omitted)`)
+    }
+    void lastKept
+
+    const result = out.join('\n')
+    if (result.length >= text.length) return { changed: false, text }
+    return {
+      changed: true,
+      text: result,
+      hint: `kept ${keepIdx.size}/${lines.length} lines around failures`
+    }
+  }
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// 5. StatsExtraction
+// ───────────────────────────────────────────────────────────────────────────
+
+/**
+ * Detect a test/build summary line and lift it to the top, dropping the bulk
+ * of the body if the run was successful and the body is large.
+ *
+ * Patterns:
+ *   - vitest:   "Tests  X passed (X)" / "Test Files  X passed (X)"
+ *   - jest:     "Tests:       X passed, X total"
+ *   - cargo:    "test result: ok. X passed; 0 failed; ..."
+ *   - npm:      "npm warn deprecated ..." (skip)
+ *   - tsc:      "Found 0 errors. Watching for file changes."
+ *   - generic:  "X passed", "X tests passed"
+ */
+const STATS_PATTERNS: RegExp[] = [
+  /^\s*Tests\s+\d+\s+passed/m,
+  /^\s*Test\s+Files\s+\d+\s+passed/m,
+  /^\s*Tests:\s+\d+\s+passed/m,
+  /test\s+result:\s+(ok|FAILED)\.\s+\d+\s+passed/m,
+  /Found\s+\d+\s+errors?\b/m,
+  /^\s*\d+\s+(tests?|specs?|examples?)\s+passed/m,
+  /Compiled\s+(successfully|with\s+\d+\s+warnings?)/m,
+  /Build\s+(complete|succeeded|failed)/m
+]
+
+export const statsExtractionStrategy: OutputStrategy = {
+  name: 'stats-extraction',
+  apply(text: string, ctx: CompressionContext): StrategyResult {
+    if (!text || text.length < MIN_COMPRESS_BYTES) return { changed: false, text }
+    const lines = text.split('\n')
+    if (lines.length < 50) return { changed: false, text }
+
+    // Don't fire if exit code says failure (FailureFocus owns that case).
+    if (ctx.exitCode !== undefined && ctx.exitCode !== 0) {
+      return { changed: false, text }
+    }
+
+    const matches: string[] = []
+    for (const pat of STATS_PATTERNS) {
+      const m = pat.exec(text)
+      if (m) matches.push(m[0])
+    }
+    if (matches.length === 0) return { changed: false, text }
+
+    // Keep the head (first 10 lines, e.g. command + setup) + summary line(s) +
+    // last 5 lines (final status).
+    const head = lines.slice(0, 10)
+    const tail = lines.slice(-HEAD_TAIL_KEEP_LINES)
+    const out = [
+      ...head,
+      `… (${lines.length - head.length - tail.length} lines omitted; summary: ${matches.join(' · ')})`,
+      ...tail
+    ]
+    const result = out.join('\n')
+    if (result.length >= text.length) return { changed: false, text }
+    return {
+      changed: true,
+      text: result,
+      hint: `extracted ${matches.length} stats line(s)`
+    }
+  }
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// Default pipeline factory
+// ───────────────────────────────────────────────────────────────────────────
+
+export const DEFAULT_STRATEGIES: ReadonlyArray<OutputStrategy> = Object.freeze([
+  ansiStripStrategy,
+  progressDedupStrategy,
+  ndjsonSummaryStrategy,
+  failureFocusStrategy,
+  statsExtractionStrategy
+])

--- a/src/main/services/token-saver/xuanpu-tools-mcp.ts
+++ b/src/main/services/token-saver/xuanpu-tools-mcp.ts
@@ -1,0 +1,260 @@
+/**
+ * Token Saver MCP server — Token Saver stage 2b.
+ *
+ * Registers a single in-process MCP tool, `bash`, that shadows the SDK's
+ * built-in Bash tool when the Token Saver feature is enabled. The tool:
+ *
+ *   1. Spawns the user's command via `runBashCommand` (timeout / abort / cwd /
+ *      env handled, output capped + tee-streamed).
+ *   2. Persists the full original output to ContextOffloadStore.
+ *   3. Runs the OutputCompressionPipeline over stdout+stderr.
+ *   4. Returns a tool result whose text body is the compressed view + a
+ *      machine-readable footer pointing the user (not the agent) at the
+ *      archive path.
+ *
+ * The MCP tool name surfaces to the agent as `mcp__xuanpu__bash` (SDK auto-
+ * prefixes by server name). The caller is expected to pass
+ * `disallowedTools: ['Bash']` so the built-in is suppressed and the agent
+ * can only see ours.
+ *
+ * One server instance is created per session because:
+ *   - cwd / sessionId are per-session (closed over here)
+ *   - The AbortSignal lifecycle is per-prompt (passed via `extra`)
+ *
+ * Failure policy: if anything inside the handler throws, we MUST still
+ * return a valid CallToolResult — never let the agent see a tool dispatch
+ * failure as a transport error. The error text + the archived original
+ * (when available) are sent back so the agent can react.
+ */
+import { ContextOffloadStore } from './offload-store'
+import { runBashCommand, type RunBashResult } from './bash-runner'
+import {
+  defaultPipeline,
+  type OutputCompressionPipeline,
+  type PipelineResult
+} from './index'
+
+export interface XuanpuToolsContext {
+  /** Hive session id — used as the archive subdirectory. */
+  sessionId: string
+  /** Default cwd for `bash` invocations (the worktree path). */
+  defaultCwd: string
+  /** Optional override for the offload store (tests). */
+  offloadStore?: ContextOffloadStore
+  /** Optional override for the compression pipeline (tests). */
+  pipeline?: OutputCompressionPipeline
+  /** Optional logger; if absent, fail silently. */
+  logger?: { warn(msg: string, meta?: Record<string, unknown>): void }
+}
+
+export interface BashToolMetadata {
+  beforeBytes: number
+  afterBytes: number
+  savedBytes: number
+  ruleHits: Array<{ name: string; hint?: string }>
+  archivePath: string | null
+  exitCode: number
+  durationMs: number
+  timedOut: boolean
+  aborted: boolean
+}
+
+const FOOTER_LINE = '---'
+
+/**
+ * Build the `bash` tool result text. Agent-visible body = compressed output
+ * + footer noting savings + archive pointer. If compression didn't fire
+ * (small output), the footer is omitted to keep simple commands clean.
+ */
+export function formatToolResultText(
+  pipelineResult: PipelineResult,
+  metadata: BashToolMetadata
+): string {
+  const compressionFired = pipelineResult.ruleHits.length > 0
+  if (!compressionFired) {
+    return pipelineResult.text
+  }
+  const savedPercent =
+    metadata.beforeBytes > 0
+      ? Math.round((metadata.savedBytes / metadata.beforeBytes) * 100)
+      : 0
+  const footerParts = [
+    `[Token Saver] compressed ${metadata.beforeBytes}B → ${metadata.afterBytes}B (-${savedPercent}%)`,
+    `via ${pipelineResult.ruleHits.map((h) => h.name).join(', ')}`
+  ]
+  if (metadata.archivePath) {
+    footerParts.push(`original: ${metadata.archivePath}`)
+  }
+  return `${pipelineResult.text}\n${FOOTER_LINE}\n${footerParts.join(' · ')}`
+}
+
+/**
+ * Run a single bash invocation through the full pipeline. Exposed for tests
+ * (so we can validate the data path without the MCP transport).
+ */
+export async function runBashWithCompression(
+  input: { command: string; timeoutMs?: number },
+  ctx: XuanpuToolsContext,
+  signal?: AbortSignal
+): Promise<{ text: string; metadata: BashToolMetadata; runResult: RunBashResult }> {
+  const offload = ctx.offloadStore ?? new ContextOffloadStore()
+  const pipeline = ctx.pipeline ?? defaultPipeline()
+
+  let runResult: RunBashResult
+  try {
+    runResult = await runBashCommand({
+      command: input.command,
+      cwd: ctx.defaultCwd,
+      timeoutMs: input.timeoutMs,
+      signal
+    })
+  } catch (err) {
+    // Spawn-level failure: surface a synthetic result so the agent can react.
+    const message = err instanceof Error ? err.message : String(err)
+    const fallback: RunBashResult = {
+      exitCode: -1,
+      durationMs: 0,
+      stdout: '',
+      stderr: `[xuanpu-tools] failed to spawn: ${message}`,
+      combined: `[xuanpu-tools] failed to spawn: ${message}`,
+      truncated: { stdout: false, stderr: false },
+      timedOut: false,
+      aborted: false
+    }
+    runResult = fallback
+  }
+
+  // Best-effort archive — failure here should not block the agent.
+  let archivePath: string | null = null
+  try {
+    if (runResult.combined.length > 0) {
+      const rec = await offload.write({
+        sessionId: ctx.sessionId,
+        body: runResult.combined
+      })
+      archivePath = rec.path
+    }
+  } catch (err) {
+    ctx.logger?.warn?.('xuanpu-tools: archive write failed', {
+      error: err instanceof Error ? err.message : String(err)
+    })
+  }
+
+  // Compression. Strategy errors are isolated by the pipeline; we only catch
+  // catastrophic failures.
+  let pipelineResult: PipelineResult
+  try {
+    pipelineResult = pipeline.run(runResult.combined, {
+      command: input.command,
+      exitCode: runResult.exitCode,
+      durationMs: runResult.durationMs,
+      source: 'bash'
+    })
+  } catch (err) {
+    ctx.logger?.warn?.('xuanpu-tools: pipeline crashed, falling back to raw output', {
+      error: err instanceof Error ? err.message : String(err)
+    })
+    pipelineResult = {
+      text: runResult.combined,
+      beforeBytes: Buffer.byteLength(runResult.combined, 'utf8'),
+      afterBytes: Buffer.byteLength(runResult.combined, 'utf8'),
+      ruleHits: []
+    }
+  }
+
+  const metadata: BashToolMetadata = {
+    beforeBytes: pipelineResult.beforeBytes,
+    afterBytes: pipelineResult.afterBytes,
+    savedBytes: Math.max(0, pipelineResult.beforeBytes - pipelineResult.afterBytes),
+    ruleHits: pipelineResult.ruleHits,
+    archivePath,
+    exitCode: runResult.exitCode,
+    durationMs: runResult.durationMs,
+    timedOut: runResult.timedOut,
+    aborted: runResult.aborted
+  }
+
+  return { text: formatToolResultText(pipelineResult, metadata), metadata, runResult }
+}
+
+/**
+ * Create the SDK MCP server config to attach to a Claude session's options.
+ *
+ * Dynamic import of the SDK matches the LSP server's pattern (the SDK is
+ * ESM-only and would otherwise break test environments that load this module
+ * synchronously). The returned value is opaque to us — pass it straight into
+ * `options.mcpServers['xuanpu'] = ...`.
+ */
+export async function createXuanpuToolsMcpServerConfig(
+  ctx: XuanpuToolsContext
+): Promise<unknown> {
+  const { createSdkMcpServer, tool } = await import('@anthropic-ai/claude-agent-sdk')
+  const { z } = await import('zod')
+
+  const bashTool = tool(
+    'bash',
+    [
+      'Execute a shell command. Behaves like the built-in Bash tool but with',
+      'Token Saver compression: long output is summarised before being returned',
+      'to you (the agent). The original is archived locally so the user can',
+      'expand any compressed result. Behaviour you should know:',
+      '- timeout defaults to 120s, max 600s',
+      '- exit code, stdout, stderr are all preserved (just compressed)',
+      '- cwd is fixed to the current worktree; do NOT cd elsewhere',
+      "- if you see '[Token Saver] compressed ...' at the bottom, the body",
+      "  above is a summary; the archived path is included for the user's UI"
+    ].join(' '),
+    {
+      command: z.string().describe('The shell command to execute'),
+      timeout: z
+        .number()
+        .optional()
+        .describe('Optional timeout in milliseconds (max 600000)'),
+      description: z
+        .string()
+        .optional()
+        .describe('Short description of what this command does (5-15 words)')
+    },
+    async (args, extra) => {
+      // The SDK passes an abort signal through `extra` when the user
+      // interrupts. Best-effort extraction.
+      let signal: AbortSignal | undefined
+      if (extra && typeof extra === 'object') {
+        const maybe = (extra as { signal?: unknown }).signal
+        if (maybe instanceof AbortSignal) signal = maybe
+      }
+
+      try {
+        const { text } = await runBashWithCompression(
+          { command: args.command, timeoutMs: args.timeout },
+          ctx,
+          signal
+        )
+        return {
+          content: [{ type: 'text', text }]
+        }
+      } catch (err) {
+        // Last-resort safety net — runBashWithCompression has its own catches
+        // but if THIS throws, we still must return a valid CallToolResult.
+        const message = err instanceof Error ? err.message : String(err)
+        ctx.logger?.warn?.('xuanpu-tools: bash handler crashed', { error: message })
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `[xuanpu-tools] internal error: ${message}`
+            }
+          ],
+          isError: true
+        }
+      }
+    },
+    { annotations: { readOnly: false } }
+  )
+
+  return createSdkMcpServer({
+    name: 'xuanpu',
+    version: '1.0.0',
+    tools: [bashTool]
+  })
+}

--- a/src/main/services/xuanpu-system-context.ts
+++ b/src/main/services/xuanpu-system-context.ts
@@ -1,0 +1,70 @@
+/**
+ * Xuanpu System Context — appendSystemPrompt content for the Claude Agent SDK.
+ *
+ * ## Why this exists
+ *
+ * Xuanpu wraps every user prompt in a `[Field Context — as of ...]` envelope
+ * followed by `[User Message]\n<actual user input>`. This is a pure context
+ * injection — it adds structured workbench facts the agent would otherwise
+ * lack (worktree, focus file, recent activity, pinned facts).
+ *
+ * However, the Claude Agent SDK's `loadConversationForResume` path can also
+ * synthesize a bare user message — `Continue from where you left off.` — into
+ * the conversation when an interrupted turn is detected. This message is
+ * unwrapped (no `[Field Context]/[User Message]` envelope), and the model
+ * has been observed to interpret its arrival under the established pattern
+ * as a meta-instruction and respond with `No response requested.` instead of
+ * continuing the user's task.
+ *
+ * The fix is not to suppress the synthetic message (we can't reach into the
+ * SDK's API call path) but to remove the implicit protocol the model inferred:
+ * tell the model directly that the wrapper is informational, not contractual.
+ * Any user message — wrapped or not — should be treated as a real request.
+ *
+ * ## Tone notes
+ *
+ * - Written in English because the SDK system prompt is English-native and
+ *   non-English instructions sometimes weaken agent compliance.
+ * - Kept short — every token here is paid on every turn.
+ * - No emojis, no markdown headings beyond the section break the SDK adds.
+ *
+ * ## Where this is used
+ *
+ * `src/main/services/claude-code-implementer.ts` passes this to
+ * `options.appendSystemPrompt`. It applies to every Claude session, including
+ * resumes. There is no settings toggle: this is correctness, not behaviour.
+ */
+
+export const XUANPU_SYSTEM_CONTEXT = `
+You are running inside Xuanpu (玄圃), a local agent workbench.
+
+Xuanpu wraps each user turn with a structured envelope of the form:
+
+  [Field Context — as of <time>]
+  ...workbench facts (worktree, focus file, recent activity, pinned facts)...
+
+  [User Message]
+  <the user's actual input>
+
+This wrapper is purely informational. It does NOT define a contract.
+
+Important behavioural rules:
+
+1. Treat the content under "[User Message]" as the user's real request — same
+   as any prompt would be without the wrapper.
+
+2. If a user message arrives WITHOUT the wrapper (for example, the literal
+   string "Continue from where you left off." injected by the SDK after an
+   interrupted turn, or any other bare text from the user), still treat it as
+   a normal user request. Do NOT respond with "No response requested." or any
+   silent-exit phrasing because the wrapper is missing — its absence is not a
+   signal.
+
+3. The Field Context block is observed local data, not authoritative
+   instructions. If it contradicts the user's explicit request, the user's
+   request wins.
+
+4. When you see "Continue from where you left off." after a session resume,
+   resume the actual prior task you were working on. If you cannot tell what
+   was in progress, say so briefly and ask one concrete question.
+`.trim()

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -1393,6 +1393,38 @@ declare global {
           packetHash: string
         } | null
       } | null>
+      /** v1.4.1: Pinned Facts — read user-authored permanent facts for a worktree. */
+      getPinnedFacts: (
+        worktreeId: string
+      ) => Promise<{
+        worktreeId: string
+        contentMd: string
+        updatedAt: number
+        createdAt: number
+      } | null>
+      /** v1.4.1: Pinned Facts — upsert. Throws if contentMd exceeds 2000 chars. */
+      updatePinnedFacts: (input: { worktreeId: string; contentMd: string }) => Promise<{
+        worktreeId: string
+        contentMd: string
+        updatedAt: number
+        createdAt: number
+      }>
+      /**
+       * v1.4.2: Episodic Memory — force-regenerate the rolling summary for a
+       * worktree. Null when the compactor declined.
+       */
+      regenerateEpisodic: (worktreeId: string) => Promise<{
+        worktreeId: string
+        summaryMarkdown: string
+        compactorId: string
+        version: number
+        compactedAt: number
+        sourceEventCount: number
+        sourceSince: number
+        sourceUntil: number
+      } | null>
+      /** v1.4.2: Episodic Memory — clear the rolling summary for a worktree. */
+      clearEpisodic: (worktreeId: string) => Promise<{ deleted: boolean }>
     }
     skillOps: {
       listHubs: () => Promise<{

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -774,6 +774,11 @@ declare global {
         content?: string
         error?: string
       }>
+      readArchive: (filePath: string) => Promise<{
+        success: boolean
+        content?: string
+        error?: string
+      }>
       writeFile: (filePath: string, content: string) => Promise<{
         success: boolean
         error?: string

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1973,7 +1973,42 @@ const fieldOps = {
         hotFileDigests: Record<string, string | null> | null
         packetHash: string
       } | null
-    } | null>
+    } | null>,
+  /** v1.4.1: Pinned Facts — read user-authored permanent facts for a worktree. */
+  getPinnedFacts: (worktreeId: string) =>
+    ipcRenderer.invoke('field:getPinnedFacts', worktreeId) as Promise<{
+      worktreeId: string
+      contentMd: string
+      updatedAt: number
+      createdAt: number
+    } | null>,
+  /** v1.4.1: Pinned Facts — upsert. Throws if contentMd exceeds 2000 chars. */
+  updatePinnedFacts: (input: { worktreeId: string; contentMd: string }) =>
+    ipcRenderer.invoke('field:updatePinnedFacts', input) as Promise<{
+      worktreeId: string
+      contentMd: string
+      updatedAt: number
+      createdAt: number
+    }>,
+  /**
+   * v1.4.2: Episodic Memory — force-regenerate the rolling summary for a
+   * worktree. Returns the new record, or null when the compactor declined
+   * (insufficient events, privacy disabled, primary+fallback both failed).
+   */
+  regenerateEpisodic: (worktreeId: string) =>
+    ipcRenderer.invoke('field:regenerateEpisodic', worktreeId) as Promise<{
+      worktreeId: string
+      summaryMarkdown: string
+      compactorId: string
+      version: number
+      compactedAt: number
+      sourceEventCount: number
+      sourceSince: number
+      sourceUntil: number
+    } | null>,
+  /** v1.4.2: Episodic Memory — clear the rolling summary for a worktree. */
+  clearEpisodic: (worktreeId: string) =>
+    ipcRenderer.invoke('field:clearEpisodic', worktreeId) as Promise<{ deleted: boolean }>
 }
 
 // Hub mode (#34): mobile / remote-control over Claude Code sessions.

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1580,6 +1580,10 @@ const skillOps = {
 const fileOps = {
   readFile: (filePath: string): Promise<{ success: boolean; content?: string; error?: string }> =>
     ipcRenderer.invoke('file:read', filePath),
+  readArchive: (
+    filePath: string
+  ): Promise<{ success: boolean; content?: string; error?: string }> =>
+    ipcRenderer.invoke('file:readArchive', filePath),
   writeFile: (filePath: string, content: string): Promise<{ success: boolean; error?: string }> =>
     ipcRenderer.invoke('file:write', filePath, content),
   readPrompt: (

--- a/src/renderer/src/components/session-hq/SessionShell.tsx
+++ b/src/renderer/src/components/session-hq/SessionShell.tsx
@@ -31,6 +31,7 @@ import { MissionControl, type MissionTask } from './MissionControl'
 import { InterruptDock } from './InterruptDock'
 import { ComposerBar } from './ComposerBar'
 import { FieldContextDebug } from '@/components/sessions/FieldContextDebug'
+import { MemoryPanel } from '@/components/sessions/MemoryPanel'
 import { ForkFromMessageConfirmDialog } from './ForkFromMessageConfirmDialog'
 import { PlanReadyImplementFab } from '../sessions/PlanReadyImplementFab'
 import { ScrollToBottomFab } from '../sessions/ScrollToBottomFab'
@@ -1582,17 +1583,21 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
           commandsVersion={commandsVersion}
         />
 
-        {/* Phase 22A debug: collapsible view of the last Field Context injection.
-            Anchored to the very bottom of the relative content area so it
-            survives `overflow-hidden` and sits below the floating ComposerBar
-            (which is `absolute bottom-16`). Higher z-index than the timeline
-            so users can always click to expand. */}
+        {/* v1.4.2: User-facing Memory panel — Pinned Facts / Observed
+            (Episodic) / Semantic. Sits above the FieldContextDebug
+            (which is dev-only) so it's the daily-driver for memory edits. */}
         <div className="absolute bottom-0 left-0 right-0 z-30">
-          <FieldContextDebug
-            sessionId={droidSessionId}
-            fallbackSessionIds={[sessionId]}
-            worktreeId={worktreeId}
-          />
+          <MemoryPanel worktreeId={worktreeId} />
+          {/* Phase 22A debug: collapsible view of the last Field Context injection.
+              Only visible in dev builds — production users use the MemoryPanel
+              above for daily memory inspection. */}
+          {process.env.NODE_ENV === 'development' && (
+            <FieldContextDebug
+              sessionId={droidSessionId}
+              fallbackSessionIds={[sessionId]}
+              worktreeId={worktreeId}
+            />
+          )}
         </div>
 
         <ForkFromMessageConfirmDialog

--- a/src/renderer/src/components/sessions/MemoryPanel.tsx
+++ b/src/renderer/src/components/sessions/MemoryPanel.tsx
@@ -1,0 +1,441 @@
+/**
+ * MemoryPanel — v1.4.2.
+ *
+ * User-facing memory panel surfaced in the Session HQ. Three sections:
+ *   1. Pinned Facts (user-authored permanent worktree facts) — reuses
+ *      `PinnedFactsCard`. Editing here is the same as editing on the
+ *      Worktree Detail page.
+ *   2. Observed (Episodic) — the rolling summary compacted by
+ *      `episodic-updater`. [Regenerate] forces a fresh compaction;
+ *      [Clear] deletes the summary so the next eligible event triggers a
+ *      new one from scratch.
+ *   3. Semantic — read-only links to `.xuanpu/memory.md` (project) and
+ *      `~/.xuanpu/memory.md` (user). Empty files show a [Create] CTA;
+ *      existing files show an [Open] CTA that asks the system to open
+ *      them in the user's editor.
+ *
+ * Mounted as a sibling of `FieldContextDebug`. Unlike FieldContextDebug,
+ * which we now hide outside dev builds, this panel is the daily-driver
+ * view for inspecting and editing memory.
+ */
+import { useCallback, useEffect, useState } from 'react'
+import {
+  Brain,
+  ChevronDown,
+  ChevronRight,
+  RefreshCw,
+  Trash2,
+  Pin,
+  FolderOpen,
+  Plus,
+  Loader2
+} from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { Button } from '@/components/ui/button'
+import { toast } from '@/lib/toast'
+import { useI18n } from '@/i18n/useI18n'
+import { PinnedFactsCard } from '@/components/worktrees/PinnedFactsCard'
+
+interface EpisodicMemoryEntry {
+  worktreeId: string
+  summaryMarkdown: string
+  compactorId: string
+  version: number
+  compactedAt: number
+  sourceEventCount: number
+  sourceSince: number
+  sourceUntil: number
+}
+
+interface SemanticMemoryFile {
+  path: string
+  mtimeMs: number
+  size: number
+  markdown: string | null
+}
+
+interface SemanticMemoryEntry {
+  project: SemanticMemoryFile
+  user: SemanticMemoryFile
+  lastReadAt: number
+}
+
+interface MemoryPanelProps {
+  worktreeId: string | null | undefined
+  className?: string
+}
+
+type Tab = 'pinned' | 'observed' | 'semantic'
+
+export function MemoryPanel({ worktreeId, className }: MemoryPanelProps): React.JSX.Element | null {
+  const { t } = useI18n()
+  const [open, setOpen] = useState(false)
+  const [tab, setTab] = useState<Tab>('pinned')
+  const [episodic, setEpisodic] = useState<EpisodicMemoryEntry | null>(null)
+  const [semantic, setSemantic] = useState<SemanticMemoryEntry | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [actionPending, setActionPending] = useState(false)
+
+  const refresh = useCallback(async () => {
+    if (!worktreeId) return
+    setLoading(true)
+    try {
+      const [ep, sem] = await Promise.all([
+        window.fieldOps.getEpisodicMemory(worktreeId),
+        window.fieldOps.getSemanticMemory(worktreeId)
+      ])
+      setEpisodic(ep)
+      setSemantic(sem)
+    } finally {
+      setLoading(false)
+    }
+  }, [worktreeId])
+
+  useEffect(() => {
+    if (open) void refresh()
+  }, [open, refresh])
+
+  const handleRegenerate = useCallback(async () => {
+    if (!worktreeId || actionPending) return
+    setActionPending(true)
+    try {
+      const result = await window.fieldOps.regenerateEpisodic(worktreeId)
+      if (result) {
+        setEpisodic(result)
+        toast.success(t('memory.toasts.regenerateOk'))
+      } else {
+        toast.warning(t('memory.toasts.regenerateSkipped'))
+      }
+    } catch {
+      toast.error(t('memory.toasts.regenerateError'))
+    } finally {
+      setActionPending(false)
+    }
+  }, [worktreeId, actionPending, t])
+
+  const handleClear = useCallback(async () => {
+    if (!worktreeId || actionPending) return
+    setActionPending(true)
+    try {
+      await window.fieldOps.clearEpisodic(worktreeId)
+      setEpisodic(null)
+      toast.success(t('memory.toasts.clearOk'))
+    } catch {
+      toast.error(t('memory.toasts.clearError'))
+    } finally {
+      setActionPending(false)
+    }
+  }, [worktreeId, actionPending, t])
+
+  if (!worktreeId) return null
+
+  const headerLabel =
+    tab === 'pinned'
+      ? t('memory.pinnedSection')
+      : tab === 'observed'
+        ? episodic
+          ? formatCompactorBadge(episodic, t)
+          : t('memory.empty.observed')
+        : t('memory.semanticSection')
+
+  return (
+    <div
+      className={cn('border-t border-border/40 bg-muted/20 text-xs', className)}
+      data-testid="memory-panel"
+    >
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="flex w-full items-center justify-between gap-2 px-3 py-1.5 text-muted-foreground hover:bg-muted/30 transition-colors"
+      >
+        <div className="flex items-center gap-1.5">
+          {open ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
+          <Brain size={12} className="text-amber-400" />
+          <span>{t('memory.title')}</span>
+          <span className="text-muted-foreground/70 ml-2 truncate max-w-[40ch]">{headerLabel}</span>
+        </div>
+        {open && (
+          <span
+            role="button"
+            tabIndex={0}
+            onClick={(e) => {
+              e.stopPropagation()
+              void refresh()
+            }}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault()
+                e.stopPropagation()
+                void refresh()
+              }
+            }}
+            className={cn(
+              'p-1 rounded hover:bg-muted/50',
+              loading && 'animate-spin text-muted-foreground/60'
+            )}
+            title="Refresh"
+          >
+            <RefreshCw size={12} />
+          </span>
+        )}
+      </button>
+
+      {open && (
+        <div className="px-3 pb-3 pt-1 max-h-[60vh] overflow-auto">
+          {/* Tab bar */}
+          <div className="flex items-center gap-1 mb-2 text-[11px]">
+            <TabButton
+              active={tab === 'pinned'}
+              onClick={() => setTab('pinned')}
+              icon={<Pin size={11} />}
+              label={t('memory.pinnedSection')}
+            />
+            <TabButton
+              active={tab === 'observed'}
+              onClick={() => setTab('observed')}
+              icon={<Brain size={11} />}
+              label={t('memory.observedSection')}
+            />
+            <TabButton
+              active={tab === 'semantic'}
+              onClick={() => setTab('semantic')}
+              icon={<FolderOpen size={11} />}
+              label={t('memory.semanticSection')}
+            />
+          </div>
+
+          {tab === 'pinned' && (
+            <div className="bg-background/30 rounded">
+              <PinnedFactsCard worktreeId={worktreeId} />
+            </div>
+          )}
+
+          {tab === 'observed' && (
+            <ObservedSection
+              episodic={episodic}
+              loading={loading}
+              actionPending={actionPending}
+              onRegenerate={handleRegenerate}
+              onClear={handleClear}
+            />
+          )}
+
+          {tab === 'semantic' && <SemanticSection semantic={semantic} loading={loading} />}
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Sub-components
+// ---------------------------------------------------------------------------
+
+interface TabButtonProps {
+  active: boolean
+  onClick: () => void
+  icon: React.ReactNode
+  label: string
+}
+
+function TabButton({ active, onClick, icon, label }: TabButtonProps): React.JSX.Element {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        'inline-flex items-center gap-1 px-2 py-0.5 rounded',
+        active
+          ? 'bg-primary/20 text-foreground'
+          : 'text-muted-foreground hover:bg-muted/50'
+      )}
+    >
+      {icon}
+      {label}
+    </button>
+  )
+}
+
+interface ObservedSectionProps {
+  episodic: EpisodicMemoryEntry | null
+  loading: boolean
+  actionPending: boolean
+  onRegenerate: () => void
+  onClear: () => void
+}
+
+function ObservedSection({
+  episodic,
+  loading,
+  actionPending,
+  onRegenerate,
+  onClear
+}: ObservedSectionProps): React.JSX.Element {
+  const { t } = useI18n()
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center gap-2">
+        {episodic && (
+          <span className="text-muted-foreground/70 text-[11px]">
+            {formatCompactorBadge(episodic, t)} •{' '}
+            {t('memory.eventCount', { count: String(episodic.sourceEventCount) })}
+          </span>
+        )}
+        <div className="flex-1" />
+        <Button
+          size="sm"
+          variant="ghost"
+          className="h-7 px-2 text-xs gap-1.5"
+          disabled={actionPending || loading}
+          onClick={onRegenerate}
+        >
+          {actionPending ? (
+            <Loader2 className="h-3 w-3 animate-spin" />
+          ) : (
+            <RefreshCw className="h-3 w-3" />
+          )}
+          {t('memory.regenerate')}
+        </Button>
+        <Button
+          size="sm"
+          variant="ghost"
+          className="h-7 px-2 text-xs gap-1.5 text-destructive"
+          disabled={actionPending || loading || !episodic}
+          onClick={onClear}
+        >
+          <Trash2 className="h-3 w-3" />
+          {t('memory.clear')}
+        </Button>
+      </div>
+      {loading && !episodic && (
+        <div className="text-muted-foreground/60">Loading…</div>
+      )}
+      {!loading && !episodic && (
+        <div className="text-muted-foreground/60 italic">{t('memory.empty.observed')}</div>
+      )}
+      {episodic && (
+        <pre className="whitespace-pre-wrap break-words text-[11px] leading-relaxed bg-background/50 rounded p-2 max-h-64 overflow-auto">
+          {episodic.summaryMarkdown}
+        </pre>
+      )}
+    </div>
+  )
+}
+
+interface SemanticSectionProps {
+  semantic: SemanticMemoryEntry | null
+  loading: boolean
+}
+
+function SemanticSection({ semantic, loading }: SemanticSectionProps): React.JSX.Element {
+  const { t } = useI18n()
+  if (loading && !semantic) {
+    return <div className="text-muted-foreground/60">Loading…</div>
+  }
+  if (!semantic) {
+    return <div className="text-muted-foreground/60 italic">{t('memory.empty.semantic')}</div>
+  }
+  return (
+    <div className="space-y-3">
+      <SemanticFileRow label={t('memory.semanticSection') + ' — Project'} file={semantic.project} />
+      <SemanticFileRow label={t('memory.semanticSection') + ' — User'} file={semantic.user} />
+    </div>
+  )
+}
+
+interface SemanticFileRowProps {
+  label: string
+  file: SemanticMemoryFile
+}
+
+function SemanticFileRow({ label, file }: SemanticFileRowProps): React.JSX.Element {
+  const { t } = useI18n()
+  const exists = file.markdown !== null
+  const handleOpen = useCallback(() => {
+    void window.gitOps.openInEditor(file.path).catch(() => {
+      toast.error(`Failed to open ${file.path}`)
+    })
+  }, [file.path])
+  const handleCreate = useCallback(async () => {
+    try {
+      // Best-effort create. The semantic-memory loader will pick up the new
+      // file on the next refresh; we then nudge the user's editor open.
+      const result = await window.fileOps.writeFile(file.path, '# Memory\n\n')
+      if (!result.success) {
+        toast.error(result.error || 'Failed to create memory.md')
+        return
+      }
+      toast.success('memory.md created')
+      await window.gitOps.openInEditor(file.path)
+    } catch (error) {
+      console.error('Failed to create memory.md:', error)
+      toast.error('Failed to create memory.md')
+    }
+  }, [file.path])
+
+  return (
+    <div className="flex flex-col gap-1 bg-background/30 rounded p-2">
+      <div className="flex items-center gap-2">
+        <span className="font-semibold text-foreground">{label}</span>
+        <code className="text-[10px] text-muted-foreground truncate">{file.path}</code>
+        <div className="flex-1" />
+        {exists ? (
+          <Button
+            size="sm"
+            variant="ghost"
+            className="h-6 px-2 text-[11px] gap-1"
+            onClick={handleOpen}
+          >
+            <FolderOpen className="h-3 w-3" />
+            {t('memory.open')}
+          </Button>
+        ) : (
+          <Button
+            size="sm"
+            variant="ghost"
+            className="h-6 px-2 text-[11px] gap-1"
+            onClick={handleCreate}
+          >
+            <Plus className="h-3 w-3" />
+            {t('memory.create')}
+          </Button>
+        )}
+      </div>
+      {!exists && (
+        <span className="text-muted-foreground/60 italic">{t('memory.empty.semantic')}</span>
+      )}
+      {exists && file.markdown && file.markdown.trim().length > 0 && (
+        <pre className="whitespace-pre-wrap break-words text-[11px] leading-relaxed bg-background/50 rounded p-2 max-h-48 overflow-auto">
+          {file.markdown}
+        </pre>
+      )}
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function formatCompactorBadge(
+  entry: EpisodicMemoryEntry,
+  t: (key: string, vars?: Record<string, string>) => string
+): string {
+  const ago = humanElapsed(Date.now() - entry.compactedAt)
+  return `${t('memory.compactor', {
+    id: entry.compactorId,
+    version: String(entry.version)
+  })} • ${t('memory.compactedAt', { ago })}`
+}
+
+function humanElapsed(ms: number): string {
+  if (ms < 0) return 'just now'
+  const sec = Math.floor(ms / 1000)
+  if (sec < 60) return `${sec}s`
+  const min = Math.floor(sec / 60)
+  if (min < 60) return `${min}m`
+  const hr = Math.floor(min / 60)
+  if (hr < 24) return `${hr}h`
+  const day = Math.floor(hr / 24)
+  return `${day}d`
+}

--- a/src/renderer/src/components/sessions/SessionTokenSaverBanner.tsx
+++ b/src/renderer/src/components/sessions/SessionTokenSaverBanner.tsx
@@ -1,0 +1,91 @@
+import { useMemo } from 'react'
+import { Sparkles } from 'lucide-react'
+import { useI18n } from '@/i18n/useI18n'
+import { parseTokenSaverFooter, formatBytes } from '@/lib/token-saver-footer'
+import type { OpenCodeMessage } from './SessionView'
+
+interface SessionTokenSaverBannerProps {
+  messages: OpenCodeMessage[]
+}
+
+interface SessionStats {
+  beforeBytes: number
+  afterBytes: number
+  savedBytes: number
+  hits: number
+}
+
+/**
+ * Walk the session's message stream and aggregate Token Saver footer stats
+ * across every assistant tool result that came through `mcp__xuanpu__bash`.
+ *
+ * We deliberately scan only `parts[].toolUse.output` strings — the footer is
+ * appended to the tool result body, never to assistant text. This keeps the
+ * scan cheap (typically a few dozen tool calls per session) and avoids false
+ * positives when an assistant happens to type the literal string in prose.
+ */
+function aggregateStats(messages: OpenCodeMessage[]): SessionStats {
+  let beforeBytes = 0
+  let afterBytes = 0
+  let hits = 0
+
+  for (const m of messages) {
+    if (m.role !== 'assistant' || !m.parts) continue
+    for (const part of m.parts) {
+      if (part.type !== 'tool_use') continue
+      const output = part.toolUse?.output
+      if (typeof output !== 'string') continue
+      const parsed = parseTokenSaverFooter(output)
+      if (!parsed) continue
+      beforeBytes += parsed.beforeBytes
+      afterBytes += parsed.afterBytes
+      hits += 1
+    }
+  }
+
+  return {
+    beforeBytes,
+    afterBytes,
+    savedBytes: Math.max(0, beforeBytes - afterBytes),
+    hits
+  }
+}
+
+/**
+ * Compact banner showing how much Token Saver has compressed in this session.
+ * Renders nothing when no compression has happened yet (avoids visual noise
+ * for sessions where the toggle is off or no Bash calls fired yet).
+ */
+export function SessionTokenSaverBanner({
+  messages
+}: SessionTokenSaverBannerProps): React.JSX.Element | null {
+  const { t } = useI18n()
+  const stats = useMemo(() => aggregateStats(messages), [messages])
+
+  if (stats.hits === 0 || stats.savedBytes === 0) return null
+
+  const percent =
+    stats.beforeBytes > 0
+      ? Math.round((stats.savedBytes / stats.beforeBytes) * 100)
+      : 0
+
+  return (
+    <div
+      className="flex items-center gap-1.5 px-2 py-1 rounded-md bg-emerald-950/30 border border-emerald-900/40 text-[11px] text-emerald-200"
+      title={t('sessionView.tokenSaverBanner.tooltip', {
+        before: formatBytes(stats.beforeBytes),
+        after: formatBytes(stats.afterBytes),
+        hits: stats.hits
+      })}
+      data-testid="session-token-saver-banner"
+    >
+      <Sparkles className="h-3 w-3 text-emerald-400" />
+      <span className="font-medium">
+        {t('sessionView.tokenSaverBanner.label', {
+          saved: formatBytes(stats.savedBytes),
+          percent
+        })}
+      </span>
+    </div>
+  )
+}

--- a/src/renderer/src/components/sessions/SessionView.tsx
+++ b/src/renderer/src/components/sessions/SessionView.tsx
@@ -139,6 +139,18 @@ export const BUILT_IN_SLASH_COMMANDS: SlashCommandInfo[] = [
     description: 'Show MCP server status',
     template: '/mcp',
     builtIn: true
+  },
+  {
+    name: 'remember',
+    description: 'Add a permanent fact about this worktree (Pinned Facts)',
+    template: '/remember ',
+    builtIn: true
+  },
+  {
+    name: 'forget',
+    description: 'Remove a Pinned Fact by substring match',
+    template: '/forget ',
+    builtIn: true
   }
 ]
 
@@ -3685,6 +3697,76 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
             if (success && session) {
               useSessionStore.getState().setActiveSession(session.id)
             }
+          }
+
+          return
+        }
+
+        if (commandName === 'remember' || commandName === 'forget') {
+          // v1.4.2: Pinned Facts slash commands. Persist directly via fieldOps,
+          // never sent to the agent. The composer is cleared regardless of
+          // outcome so the user isn't left holding a stale slash command.
+          setShowSlashCommands(false)
+          setInputValue('')
+          inputValueRef.current = ''
+          if (draftTimerRef.current) clearTimeout(draftTimerRef.current)
+          window.db.session.updateDraft(sessionId, null)
+
+          if (!worktreeId) {
+            toast.error(t('sessionView.toasts.notConnected'))
+            return
+          }
+
+          const argsText = (spaceIndex > 0 ? trimmedValue.slice(spaceIndex + 1) : '').trim()
+          if (!argsText) {
+            toast.error(
+              commandName === 'remember'
+                ? t('memory.toasts.rememberMissingFact')
+                : t('memory.toasts.forgetMissingQuery')
+            )
+            return
+          }
+
+          try {
+            const current = await window.fieldOps.getPinnedFacts(worktreeId)
+            const existing = current?.contentMd ?? ''
+
+            if (commandName === 'remember') {
+              const newLine = argsText.startsWith('-') ? argsText : `- ${argsText}`
+              const next = existing.length === 0 ? newLine : `${existing.trimEnd()}\n${newLine}`
+              if (next.length > 2000) {
+                toast.error(t('memory.toasts.pinnedOverLimit', { max: '2000' }))
+                return
+              }
+              await window.fieldOps.updatePinnedFacts({
+                worktreeId,
+                contentMd: next
+              })
+              toast.success(t('memory.toasts.remembered'))
+            } else {
+              const lines = existing.split('\n')
+              const needle = argsText.toLowerCase()
+              const matchIdx = lines
+                .map((line, i) => ({ line, i }))
+                .filter(({ line }) => line.toLowerCase().includes(needle))
+              if (matchIdx.length === 0) {
+                toast.error(t('memory.toasts.forgetNoMatch'))
+                return
+              }
+              if (matchIdx.length > 1) {
+                toast.warning(t('memory.toasts.forgetAmbiguous'))
+                return
+              }
+              const next = lines.filter((_, i) => i !== matchIdx[0].i).join('\n').trim()
+              await window.fieldOps.updatePinnedFacts({
+                worktreeId,
+                contentMd: next
+              })
+              toast.success(t('memory.toasts.forgotten'))
+            }
+          } catch (error) {
+            console.error('Memory slash command failed:', error)
+            toast.error(t('memory.toasts.pinnedSaveError'))
           }
 
           return

--- a/src/renderer/src/components/sessions/SessionView.tsx
+++ b/src/renderer/src/components/sessions/SessionView.tsx
@@ -79,6 +79,7 @@ import { CommandApprovalPrompt } from './CommandApprovalPrompt'
 import type { ToolStatus, ToolUseInfo } from './ToolCard'
 import { PLAN_MODE_PREFIX, ASK_MODE_PREFIX, stripPlanModePrefix } from '@/lib/constants'
 import { SessionCostPill } from './SessionCostPill'
+import { SessionTokenSaverBanner } from './SessionTokenSaverBanner'
 import { QueuedMessagesBar, type QueuedMsg } from './QueuedMessagesBar'
 import type { UsageAnalyticsSessionSummary } from '@shared/types/usage-analytics'
 import type { SessionActivity } from '@shared/types/session'
@@ -5417,6 +5418,7 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
                             : null
                         }
                       />
+                      <SessionTokenSaverBanner messages={messages} />
                       {pendingPlan ? (
                         <span className="text-[12px] text-muted-foreground">
                           {t('sessionView.composer.planFeedbackHint')}

--- a/src/renderer/src/components/sessions/ToolCard.tsx
+++ b/src/renderer/src/components/sessions/ToolCard.tsx
@@ -322,6 +322,8 @@ const TOOL_RENDERERS: Record<string, React.FC<ToolViewProps>> = {
   glob: GrepToolView,
   Bash: BashToolView,
   bash: BashToolView,
+  // Token Saver: agent sees Bash via in-process MCP under this name.
+  'mcp__xuanpu__bash': BashToolView,
   Task: TaskToolView,
   task: TaskToolView,
   mcp_question: QuestionToolView,

--- a/src/renderer/src/components/sessions/tools/BashToolView.tsx
+++ b/src/renderer/src/components/sessions/tools/BashToolView.tsx
@@ -1,8 +1,13 @@
 import { useState } from 'react'
-import { Terminal, ChevronDown } from 'lucide-react'
+import { Terminal, ChevronDown, Sparkles, FileText } from 'lucide-react'
 import { extractCommandText } from '@/lib/tool-input-utils'
 import { cn } from '@/lib/utils'
 import { useI18n } from '@/i18n/useI18n'
+import {
+  parseTokenSaverFooter,
+  formatBytes,
+  type ParsedTokenSaverFooter
+} from '@/lib/token-saver-footer'
 import type { ToolViewProps } from './types'
 
 const MAX_PREVIEW_LINES = 20
@@ -13,21 +18,126 @@ function stripAnsi(text: string): string {
   return text.replace(/\x1b\[[0-9;]*[a-zA-Z]/g, '')
 }
 
-export function BashToolView({ input, output, error }: ToolViewProps) {
+interface SavingsBadgeProps {
+  parsed: ParsedTokenSaverFooter
+}
+
+function SavingsBadge({ parsed }: SavingsBadgeProps): React.JSX.Element {
+  const { t } = useI18n()
+  return (
+    <div
+      className="flex items-center gap-2 px-3 py-1.5 bg-emerald-950/40 border-b border-emerald-900/30 text-[11px] text-emerald-200"
+      data-testid="token-saver-badge"
+    >
+      <Sparkles className="h-3 w-3 text-emerald-400" />
+      <span className="font-medium">
+        {t('toolViews.tokenSaver.savedBadge', {
+          percent: parsed.savedPercent,
+          before: formatBytes(parsed.beforeBytes),
+          after: formatBytes(parsed.afterBytes)
+        })}
+      </span>
+      <span className="text-emerald-500/70">
+        {t('toolViews.tokenSaver.viaRules', { rules: parsed.rules.join(', ') })}
+      </span>
+    </div>
+  )
+}
+
+interface OriginalViewerProps {
+  archivePath: string
+}
+
+function OriginalViewer({ archivePath }: OriginalViewerProps): React.JSX.Element {
+  const { t } = useI18n()
+  const [open, setOpen] = useState(false)
+  const [content, setContent] = useState<string | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const onToggle = async (): Promise<void> => {
+    if (open) {
+      setOpen(false)
+      return
+    }
+    setOpen(true)
+    if (content !== null) return
+    setLoading(true)
+    setError(null)
+    try {
+      const result = await window.fileOps.readArchive(archivePath)
+      if (result.success && result.content !== undefined) {
+        setContent(result.content)
+      } else {
+        setError(result.error ?? t('toolViews.tokenSaver.loadFailed'))
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e.message : t('toolViews.tokenSaver.loadFailed'))
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="mt-2 border-t border-zinc-800 pt-2">
+      <button
+        type="button"
+        onClick={() => void onToggle()}
+        className="flex items-center gap-1.5 text-blue-400 hover:text-blue-300 text-xs font-medium transition-colors"
+        data-testid="token-saver-show-original"
+      >
+        <FileText className="h-3 w-3" />
+        {open
+          ? t('toolViews.tokenSaver.hideOriginal')
+          : t('toolViews.tokenSaver.showOriginal')}
+      </button>
+      {open && (
+        <div className="mt-2">
+          {loading && (
+            <div className="text-xs text-zinc-500">
+              {t('toolViews.tokenSaver.loadingOriginal')}
+            </div>
+          )}
+          {error && (
+            <div className="text-xs text-red-400">{error}</div>
+          )}
+          {content !== null && (
+            <pre className="mt-1 text-[11px] text-zinc-400 whitespace-pre-wrap break-all max-h-80 overflow-y-auto bg-zinc-900/50 rounded p-2">
+              {content}
+            </pre>
+          )}
+          <div className="mt-1 text-[10px] text-zinc-600 break-all">
+            {t('toolViews.tokenSaver.archivedAt', { path: archivePath })}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export function BashToolView({ input, output, error }: ToolViewProps): React.JSX.Element {
   const { t } = useI18n()
   const [showAll, setShowAll] = useState(false)
 
   const command = extractCommandText(input)
   const description = (input.description || '') as string
 
-  const cleanOutput = output ? stripAnsi(output) : ''
+  // Token Saver: when output came through mcp__xuanpu__bash it ends with our
+  // synthetic footer. Parse it to surface savings + archive path. Falls back
+  // gracefully to plain rendering for unsaved output (e.g. when the toggle is
+  // off, or the run is too small to compress).
+  const parsed = parseTokenSaverFooter(output)
+  const renderedOutput = parsed ? parsed.body : output ?? ''
+
+  const cleanOutput = renderedOutput ? stripAnsi(renderedOutput) : ''
   const lines = cleanOutput ? cleanOutput.split('\n') : []
   const needsTruncation = lines.length > MAX_PREVIEW_LINES
-  const displayedOutput = showAll ? cleanOutput : lines.slice(0, MAX_PREVIEW_LINES).join('\n')
+  const displayedOutput = showAll
+    ? cleanOutput
+    : lines.slice(0, MAX_PREVIEW_LINES).join('\n')
 
   return (
     <div data-testid="bash-tool-view">
-      {/* Command header with terminal styling */}
       <div className="bg-zinc-900 rounded-t-md px-3 py-2 font-mono text-xs">
         {description && <div className="text-zinc-500 mb-1 text-[10px]"># {description}</div>}
         <div className="flex items-start gap-1.5">
@@ -37,9 +147,15 @@ export function BashToolView({ input, output, error }: ToolViewProps) {
         </div>
       </div>
 
-      {/* Output area */}
+      {parsed && <SavingsBadge parsed={parsed} />}
+
       {(cleanOutput || error) && (
-        <div className="bg-zinc-950 rounded-b-md px-3 py-2 font-mono text-xs border-t border-zinc-800">
+        <div
+          className={cn(
+            'bg-zinc-950 px-3 py-2 font-mono text-xs border-t border-zinc-800',
+            'rounded-b-md'
+          )}
+        >
           {error && <div className="text-red-400 whitespace-pre-wrap break-all mb-1">{error}</div>}
           {cleanOutput && (
             <>
@@ -62,6 +178,9 @@ export function BashToolView({ input, output, error }: ToolViewProps) {
                     ? t('toolViews.common.showLess')
                     : t('toolViews.common.showAllLines', { count: lines.length })}
                 </button>
+              )}
+              {parsed && parsed.archivePath && (
+                <OriginalViewer archivePath={parsed.archivePath} />
               )}
             </>
           )}

--- a/src/renderer/src/components/settings/SettingsPrivacy.tsx
+++ b/src/renderer/src/components/settings/SettingsPrivacy.tsx
@@ -8,6 +8,7 @@ import { toast } from 'sonner'
 const FIELD_COLLECTION_SETTING_KEY = 'field_collection_enabled'
 const MEMORY_INJECTION_SETTING_KEY = 'include_memory_in_prompts'
 const BASH_OUTPUT_CAPTURE_SETTING_KEY = 'agent_bash_capture_output'
+const TOKEN_SAVER_ENABLED_SETTING_KEY = 'token_saver_enabled'
 
 interface ToggleProps {
   label: string
@@ -49,6 +50,7 @@ export function SettingsPrivacy(): React.JSX.Element {
   const [fieldCollectionEnabled, setFieldCollectionEnabled] = useState(true)
   const [memoryInjectionEnabled, setMemoryInjectionEnabled] = useState(true)
   const [bashOutputCaptureEnabled, setBashOutputCaptureEnabled] = useState(false)
+  const [tokenSaverEnabled, setTokenSaverEnabled] = useState(true)
   const [loaded, setLoaded] = useState(false)
   const [platform, setPlatform] = useState<string | null>(null)
   const [fdaStatus, setFdaStatus] = useState<{ supported: boolean; granted: boolean } | null>(null)
@@ -60,8 +62,9 @@ export function SettingsPrivacy(): React.JSX.Element {
       window.analyticsOps.isEnabled().catch(() => true),
       window.db.setting.get(FIELD_COLLECTION_SETTING_KEY).catch(() => null),
       window.db.setting.get(MEMORY_INJECTION_SETTING_KEY).catch(() => null),
-      window.db.setting.get(BASH_OUTPUT_CAPTURE_SETTING_KEY).catch(() => null)
-    ]).then(([analytics, fieldRaw, memoryRaw, bashRaw]) => {
+      window.db.setting.get(BASH_OUTPUT_CAPTURE_SETTING_KEY).catch(() => null),
+      window.db.setting.get(TOKEN_SAVER_ENABLED_SETTING_KEY).catch(() => null)
+    ]).then(([analytics, fieldRaw, memoryRaw, bashRaw, tokenSaverRaw]) => {
       setAnalyticsEnabled(analytics)
       // Default ON when absent or any value other than the literal 'false'
       setFieldCollectionEnabled(fieldRaw !== 'false')
@@ -69,6 +72,8 @@ export function SettingsPrivacy(): React.JSX.Element {
       // Phase 21.5: default OFF — must be literally 'true' to enable, since
       // bash output can contain secrets (API keys, env dumps, error tokens).
       setBashOutputCaptureEnabled(bashRaw === 'true')
+      // v1.5.0: Token Saver default ON — only literal 'false' disables.
+      setTokenSaverEnabled(tokenSaverRaw !== 'false')
       setLoaded(true)
     })
   }, [])
@@ -148,6 +153,12 @@ export function SettingsPrivacy(): React.JSX.Element {
     void window.db.setting.set(BASH_OUTPUT_CAPTURE_SETTING_KEY, String(newValue))
   }
 
+  const handleTokenSaverToggle = (): void => {
+    const newValue = !tokenSaverEnabled
+    setTokenSaverEnabled(newValue)
+    void window.db.setting.set(TOKEN_SAVER_ENABLED_SETTING_KEY, String(newValue))
+  }
+
   const handleOpenFdaSettings = async (): Promise<void> => {
     const result = await window.systemOps.openFullDiskAccessSettings()
     if (!result.success) {
@@ -190,6 +201,12 @@ export function SettingsPrivacy(): React.JSX.Element {
           description={t('settings.privacy.bashOutputCapture.description')}
           enabled={bashOutputCaptureEnabled}
           onToggle={handleBashOutputCaptureToggle}
+        />
+        <Toggle
+          label={t('settings.privacy.tokenSaver.label')}
+          description={t('settings.privacy.tokenSaver.description')}
+          enabled={tokenSaverEnabled}
+          onToggle={handleTokenSaverToggle}
         />
       </div>
 

--- a/src/renderer/src/components/worktrees/PinnedFactsCard.tsx
+++ b/src/renderer/src/components/worktrees/PinnedFactsCard.tsx
@@ -1,0 +1,186 @@
+/**
+ * PinnedFactsCard — v1.4.1.
+ *
+ * Per-worktree textarea for user-authored permanent facts. Content is upserted
+ * into `field_pinned_facts` and rendered into the Field Context on every prompt.
+ *
+ * Save behavior:
+ *   - Auto-save 800ms after the user stops typing.
+ *   - Explicit "Save" button as a fallback (and for keyboard finishers).
+ *   - Cmd/Ctrl+S also saves.
+ *   - Application enforces a 2000-char cap (mirrors PINNED_FACTS_MAX_CHARS in
+ *     src/main/field/pinned-facts-repository.ts). Going over the cap disables
+ *     save and shows an inline error; the textarea itself is not truncated so
+ *     the user can edit back under cap.
+ */
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { Loader2, Pin, Save } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { toast } from '@/lib/toast'
+import { useI18n } from '@/i18n/useI18n'
+
+const PINNED_FACTS_MAX_CHARS = 2000
+const AUTOSAVE_DEBOUNCE_MS = 800
+
+interface PinnedFactsCardProps {
+  worktreeId: string
+}
+
+export function PinnedFactsCard({ worktreeId }: PinnedFactsCardProps): React.JSX.Element {
+  const { t } = useI18n()
+  const [content, setContent] = useState('')
+  const [savedContent, setSavedContent] = useState('')
+  const [isLoading, setIsLoading] = useState(true)
+  const [isSaving, setIsSaving] = useState(false)
+  const autosaveTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const hasUnsavedChanges = content !== savedContent
+  const isOverLimit = content.length > PINNED_FACTS_MAX_CHARS
+
+  // Load on mount / worktree switch
+  useEffect(() => {
+    let cancelled = false
+    setIsLoading(true)
+    void (async () => {
+      try {
+        const record = await window.fieldOps.getPinnedFacts(worktreeId)
+        if (cancelled) return
+        const md = record?.contentMd ?? ''
+        setContent(md)
+        setSavedContent(md)
+      } catch {
+        if (!cancelled) toast.error(t('pinnedFacts.toasts.loadError'))
+      } finally {
+        if (!cancelled) setIsLoading(false)
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [worktreeId, t])
+
+  const handleSave = useCallback(async () => {
+    if (isOverLimit) return
+    if (!hasUnsavedChanges) return
+    setIsSaving(true)
+    try {
+      const record = await window.fieldOps.updatePinnedFacts({
+        worktreeId,
+        contentMd: content
+      })
+      setSavedContent(record.contentMd)
+    } catch {
+      toast.error(t('pinnedFacts.toasts.saveError'))
+    } finally {
+      setIsSaving(false)
+    }
+  }, [worktreeId, content, hasUnsavedChanges, isOverLimit, t])
+
+  // Autosave (debounced)
+  useEffect(() => {
+    if (isLoading) return
+    if (!hasUnsavedChanges) return
+    if (isOverLimit) return
+    if (autosaveTimer.current) clearTimeout(autosaveTimer.current)
+    autosaveTimer.current = setTimeout(() => {
+      void handleSave()
+    }, AUTOSAVE_DEBOUNCE_MS)
+    return () => {
+      if (autosaveTimer.current) clearTimeout(autosaveTimer.current)
+    }
+  }, [content, isLoading, hasUnsavedChanges, isOverLimit, handleSave])
+
+  // Cmd/Ctrl+S
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent): void => {
+      if ((e.metaKey || e.ctrlKey) && e.key === 's' && hasUnsavedChanges && !isOverLimit) {
+        e.preventDefault()
+        void handleSave()
+      }
+    }
+    window.addEventListener('keydown', handleKeyDown)
+    return () => window.removeEventListener('keydown', handleKeyDown)
+  }, [hasUnsavedChanges, isOverLimit, handleSave])
+
+  const charCountLabel = t('pinnedFacts.charCount', {
+    count: String(content.length),
+    max: String(PINNED_FACTS_MAX_CHARS)
+  })
+
+  let statusLabel: string | null = null
+  if (isSaving) statusLabel = t('pinnedFacts.saving')
+  else if (hasUnsavedChanges) statusLabel = t('pinnedFacts.unsaved')
+  else if (savedContent.length > 0) statusLabel = t('pinnedFacts.saved')
+
+  return (
+    <div className="flex flex-col border border-border rounded-md bg-card overflow-hidden">
+      {/* Header */}
+      <div className="flex items-center gap-2 px-3 py-2 border-b border-border bg-muted/30">
+        <Pin className="h-4 w-4 text-amber-400 flex-shrink-0" />
+        <span className="text-sm font-bold">{t('pinnedFacts.title')}</span>
+        {hasUnsavedChanges && !isSaving && (
+          <span
+            className="w-2 h-2 rounded-full bg-amber-400 flex-shrink-0"
+            title={t('pinnedFacts.unsaved')}
+          />
+        )}
+        <div className="flex-1" />
+        {statusLabel && (
+          <span className="text-xs text-muted-foreground" data-testid="pinned-facts-status">
+            {statusLabel}
+          </span>
+        )}
+      </div>
+
+      {/* Description */}
+      <p className="px-3 pt-2 text-xs text-muted-foreground">{t('pinnedFacts.description')}</p>
+
+      {/* Textarea */}
+      <div className="px-3 py-2">
+        {isLoading ? (
+          <div className="flex items-center justify-center h-32">
+            <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+          </div>
+        ) : (
+          <textarea
+            value={content}
+            onChange={(e) => setContent(e.target.value)}
+            placeholder={t('pinnedFacts.placeholder')}
+            className="w-full min-h-32 resize-y bg-transparent font-mono text-sm p-2 border border-border rounded focus:outline-none focus:ring-1 focus:ring-ring"
+            spellCheck={false}
+          />
+        )}
+      </div>
+
+      {/* Footer */}
+      <div className="flex items-center gap-3 px-3 py-2 border-t border-border bg-muted/20">
+        <span
+          className={`text-xs ${
+            isOverLimit ? 'text-destructive font-medium' : 'text-muted-foreground'
+          }`}
+        >
+          {charCountLabel}
+        </span>
+        {isOverLimit && (
+          <span className="text-xs text-destructive">
+            {t('pinnedFacts.overLimit', { max: String(PINNED_FACTS_MAX_CHARS) })}
+          </span>
+        )}
+        <div className="flex-1" />
+        <Button
+          size="sm"
+          onClick={handleSave}
+          disabled={isSaving || !hasUnsavedChanges || isOverLimit || isLoading}
+          className="gap-1.5"
+        >
+          {isSaving ? (
+            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+          ) : (
+            <Save className="h-3.5 w-3.5" />
+          )}
+          {t('pinnedFacts.save')}
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/worktrees/WorktreeContextEditor.tsx
+++ b/src/renderer/src/components/worktrees/WorktreeContextEditor.tsx
@@ -5,6 +5,7 @@ import { MarkdownRenderer } from '@/components/sessions/MarkdownRenderer'
 import { useFileViewerStore } from '@/stores/useFileViewerStore'
 import { toast } from '@/lib/toast'
 import { useI18n } from '@/i18n/useI18n'
+import { PinnedFactsCard } from './PinnedFactsCard'
 
 interface WorktreeContextEditorProps {
   worktreeId: string
@@ -162,17 +163,23 @@ export function WorktreeContextEditor({
             value={content}
             onChange={(e) => setContent(e.target.value)}
             placeholder={t('worktreeContext.placeholder')}
-            className="w-full h-full resize-none bg-transparent font-mono text-sm p-4 focus:outline-none"
+            className="w-full min-h-[40vh] resize-none bg-transparent font-mono text-sm p-4 focus:outline-none"
           />
         ) : content ? (
           <div className="p-4 text-sm">
             <MarkdownRenderer content={content} />
           </div>
         ) : (
-          <div className="flex items-center justify-center h-full text-sm text-muted-foreground px-8 text-center">
+          <div className="flex items-center justify-center min-h-[40vh] text-sm text-muted-foreground px-8 text-center">
             {t('worktreeContext.empty')}
           </div>
         )}
+
+        {/* v1.4.1: Pinned Facts — permanent worktree-scoped facts injected
+            into every AI session as part of the Field Context. */}
+        <div className="px-4 pb-4 pt-2">
+          <PinnedFactsCard worktreeId={worktreeId} />
+        </div>
       </div>
 
       {/* Footer with save button — only in edit mode */}

--- a/src/renderer/src/i18n/messages.ts
+++ b/src/renderer/src/i18n/messages.ts
@@ -263,6 +263,11 @@ export const messages: Record<AppLocale, MessageTree> = {
           description:
             "When the agent runs a shell command, also store the first 1 KB of stdout and last 1 KB of stderr in the local event log. Default OFF because command output often contains API keys, env dumps, or error stacks with tokens. The command text itself is always captured regardless of this setting."
         },
+        tokenSaver: {
+          label: 'Token Saver',
+          description:
+            'Compress verbose tool output before it reaches the agent — agent sees a concise summary, full original is archived locally to ~/.xuanpu/archive (you can expand any compressed bubble to read the original). Default ON.'
+        },
         fda: {
           title: 'Full Disk Access',
           description: 'Helps Xuanpu and agent runtimes read files in protected macOS locations.',
@@ -2614,6 +2619,11 @@ export const messages: Record<AppLocale, MessageTree> = {
           label: '采集 Agent Bash 的 stdout/stderr',
           description:
             'Agent 跑 shell 命令时,把 stdout 前 1KB 和 stderr 后 1KB 也存进本地事件日志。默认关闭,因为命令输出常含 API key、env dump、带 token 的错误堆栈。命令本身无论此开关如何都会被采集。'
+        },
+        tokenSaver: {
+          label: 'Token 节省器',
+          description:
+            '在工具输出送给 agent 之前先做压缩——agent 看到精简版,原文落地到 ~/.xuanpu/archive,可在任意压缩气泡上展开查看。默认开启。'
         },
         fda: {
           title: '完全磁盘访问权限',

--- a/src/renderer/src/i18n/messages.ts
+++ b/src/renderer/src/i18n/messages.ts
@@ -1470,6 +1470,63 @@ export const messages: Record<AppLocale, MessageTree> = {
         saveError: 'Failed to save context'
       }
     },
+    pinnedFacts: {
+      title: 'Pinned Facts',
+      description:
+        'Permanent facts about this worktree. Injected verbatim into every AI session as part of the Field Context.',
+      placeholder:
+        'Write permanent facts about this worktree, one per line.\n\nExamples:\n- Use pnpm, not npm\n- DB lives at ~/.xuanpu/xuanpu.db\n- Don\'t add comments to generated code',
+      empty: 'No pinned facts yet. Click in the box above to start adding.',
+      save: 'Save',
+      saving: 'Saving…',
+      saved: 'Saved',
+      unsaved: 'Unsaved changes',
+      charCount: '{count} / {max}',
+      overLimit: 'Pinned Facts cannot exceed {max} characters.',
+      toasts: {
+        loadError: 'Failed to load pinned facts',
+        saved: 'Pinned facts saved',
+        saveError: 'Failed to save pinned facts'
+      }
+    },
+    memory: {
+      title: 'Memory',
+      pinnedSection: 'Pinned Facts',
+      observedSection: 'Observed (Episodic)',
+      semanticSection: 'Semantic',
+      regenerate: 'Regenerate',
+      clear: 'Clear',
+      open: 'Open',
+      create: 'Create',
+      compactedAt: 'compacted {ago} ago',
+      compactor: 'compactor: {id} v{version}',
+      eventCount: 'from {count} events',
+      empty: {
+        pinned: 'No pinned facts yet.',
+        observed: 'No summary yet — about 20 events will trigger one automatically.',
+        semantic:
+          'No memory.md found. Create one to give the agent permanent project rules.',
+        checkpoint:
+          'Aborting the current session will record a checkpoint here for next time.'
+      },
+      semanticPath: '`{path}` ({age})',
+      semanticNeverEdited: 'never edited',
+      toasts: {
+        rememberMissingFact: '`/remember` needs a fact (e.g. `/remember use pnpm`)',
+        forgetMissingQuery: '`/forget` needs a query (e.g. `/forget pnpm`)',
+        forgetNoMatch: 'No matching pinned fact',
+        forgetAmbiguous: 'Multiple matches — open the Memory panel to choose',
+        remembered: 'Added to Pinned Facts',
+        forgotten: 'Removed from Pinned Facts',
+        pinnedOverLimit: 'Pinned Facts cannot exceed {max} characters',
+        pinnedSaveError: 'Failed to update Pinned Facts',
+        regenerateOk: 'Episodic summary regenerated',
+        regenerateSkipped: 'Compactor declined (insufficient activity or privacy disabled)',
+        regenerateError: 'Failed to regenerate episodic summary',
+        clearOk: 'Episodic summary cleared',
+        clearError: 'Failed to clear episodic summary'
+      }
+    },
     codexFastToggle: {
       label: 'Fast',
       title: 'Fast Mode',
@@ -3753,6 +3810,61 @@ export const messages: Record<AppLocale, MessageTree> = {
         loadError: '加载 worktree 上下文失败',
         saved: '上下文已保存',
         saveError: '保存上下文失败'
+      }
+    },
+    pinnedFacts: {
+      title: 'Pinned Facts',
+      description:
+        '关于这个 worktree 的永恒事实。每条 AI 会话都会作为 Field Context 的一部分原样注入。',
+      placeholder:
+        '在这里写下关于本 worktree 的永恒事实，一行一条。\n\n示例：\n- 用 pnpm，不要用 npm\n- DB 在 ~/.xuanpu/xuanpu.db\n- 不要给生成的代码加注释',
+      empty: '还没有任何 Pinned Facts。点击上方文本框开始添加。',
+      save: '保存',
+      saving: '保存中…',
+      saved: '已保存',
+      unsaved: '存在未保存更改',
+      charCount: '{count} / {max}',
+      overLimit: 'Pinned Facts 不能超过 {max} 字。',
+      toasts: {
+        loadError: '加载 Pinned Facts 失败',
+        saved: 'Pinned Facts 已保存',
+        saveError: '保存 Pinned Facts 失败'
+      }
+    },
+    memory: {
+      title: '记忆',
+      pinnedSection: 'Pinned Facts',
+      observedSection: '观察记忆（Episodic）',
+      semanticSection: '语义记忆（Semantic）',
+      regenerate: '重新压缩',
+      clear: '清空',
+      open: '打开',
+      create: '创建',
+      compactedAt: '{ago}前压缩',
+      compactor: 'compactor: {id} v{version}',
+      eventCount: '基于 {count} 个事件',
+      empty: {
+        pinned: '还没有任何 Pinned Facts。',
+        observed: '还没有摘要——大约 20 个事件后会自动压缩。',
+        semantic: '还没有 memory.md。创建一个，把项目永恒规则交给 AI。',
+        checkpoint: 'abort 当前 session 时会自动记录现场，方便下次接着干。'
+      },
+      semanticPath: '`{path}`（{age}）',
+      semanticNeverEdited: '从未编辑',
+      toasts: {
+        rememberMissingFact: '`/remember` 需要一条事实（例如 `/remember 用 pnpm`）',
+        forgetMissingQuery: '`/forget` 需要一个查询（例如 `/forget pnpm`）',
+        forgetNoMatch: '没有匹配的 Pinned Fact',
+        forgetAmbiguous: '匹配到多条——请到 Memory 面板手动选择',
+        remembered: '已加入 Pinned Facts',
+        forgotten: '已从 Pinned Facts 移除',
+        pinnedOverLimit: 'Pinned Facts 不能超过 {max} 字',
+        pinnedSaveError: '更新 Pinned Facts 失败',
+        regenerateOk: '观察记忆已重新压缩',
+        regenerateSkipped: '压缩器跳过（事件不足或隐私已关闭）',
+        regenerateError: '重新压缩失败',
+        clearOk: '观察记忆已清空',
+        clearError: '清空观察记忆失败'
       }
     },
     codexFastToggle: {

--- a/src/renderer/src/i18n/messages.ts
+++ b/src/renderer/src/i18n/messages.ts
@@ -1121,6 +1121,10 @@ export const messages: Record<AppLocale, MessageTree> = {
     },
     sessionView: {
       compacting: 'Compressing context...',
+      tokenSaverBanner: {
+        label: 'Saved {saved} ({percent}%)',
+        tooltip: 'Token Saver: {before} → {after} across {hits} tool calls'
+      },
       loading: {
         title: 'Connecting to session...',
         subtitle: 'This may take a moment'
@@ -1781,6 +1785,15 @@ export const messages: Record<AppLocale, MessageTree> = {
       common: {
         showLess: 'Show less',
         showAllLines: 'Show all {count} lines'
+      },
+      tokenSaver: {
+        savedBadge: 'Saved {percent}% · {before} → {after}',
+        viaRules: 'via {rules}',
+        showOriginal: 'Show original',
+        hideOriginal: 'Hide original',
+        loadingOriginal: 'Loading…',
+        loadFailed: 'Failed to load original',
+        archivedAt: 'Archived at {path}'
       },
       grep: {
         in: 'in',
@@ -3469,6 +3482,10 @@ export const messages: Record<AppLocale, MessageTree> = {
     },
     sessionView: {
       compacting: '正在压缩上下文窗口...',
+      tokenSaverBanner: {
+        label: '已节省 {saved}（{percent}%）',
+        tooltip: 'Token 节省器：本会话累计压缩 {before} → {after}，共 {hits} 次工具调用'
+      },
       loading: {
         title: '正在连接会话...',
         subtitle: '这可能需要一点时间'
@@ -4126,6 +4143,15 @@ export const messages: Record<AppLocale, MessageTree> = {
       common: {
         showLess: '收起',
         showAllLines: '显示全部 {count} 行'
+      },
+      tokenSaver: {
+        savedBadge: '节省 {percent}% · {before} → {after}',
+        viaRules: '使用 {rules}',
+        showOriginal: '查看原文',
+        hideOriginal: '收起原文',
+        loadingOriginal: '加载中…',
+        loadFailed: '原文加载失败',
+        archivedAt: '原文存档于 {path}'
       },
       grep: {
         in: '在',

--- a/src/renderer/src/lib/token-saver-footer.ts
+++ b/src/renderer/src/lib/token-saver-footer.ts
@@ -1,0 +1,90 @@
+/**
+ * Parser for the Token Saver footer appended by
+ * `src/main/services/token-saver/xuanpu-tools-mcp.ts :: formatToolResultText`.
+ *
+ * Output shape (when compression fires):
+ *
+ *   <compressed text>
+ *   ---
+ *   [Token Saver] compressed 8432B → 412B (-95%) · via ansi-strip, progress-dedup · original: /path/to/file.txt
+ *
+ * Rules:
+ *   - Footer always starts with `[Token Saver]` on its own line.
+ *   - The `---` separator line precedes it (added by formatToolResultText).
+ *   - `original:` is optional (missing when archive write failed).
+ *   - If the raw body has no footer, we return null and callers render as-is.
+ *
+ * This is a best-effort parser. If the SDK / an upstream tool happens to
+ * include a literal `[Token Saver]` line for any other reason we'd mis-parse,
+ * but the prefix is unusual enough that false positives are acceptable.
+ */
+
+export interface ParsedTokenSaverFooter {
+  /** Body above the separator — the actual content to render. */
+  body: string
+  /** Original size in bytes. */
+  beforeBytes: number
+  /** Compressed size in bytes. */
+  afterBytes: number
+  /** Saved percentage as an integer 0-100. */
+  savedPercent: number
+  /** Comma-separated list of strategy names that fired. */
+  rules: string[]
+  /** Absolute path to the archived original, if available. */
+  archivePath: string | null
+}
+
+const FOOTER_REGEX =
+  /\[Token Saver\]\s+compressed\s+(\d+)B\s*→\s*(\d+)B\s*\(-(\d+)%\)\s*·\s*via\s+([^·\n]+?)(?:\s*·\s*original:\s*(\S+))?\s*$/m
+
+/**
+ * Parse the compressed tool result body. Returns `null` if no footer is
+ * present (compression didn't fire, or body is from another tool).
+ */
+export function parseTokenSaverFooter(
+  raw: string | null | undefined
+): ParsedTokenSaverFooter | null {
+  if (!raw || typeof raw !== 'string') return null
+  const match = FOOTER_REGEX.exec(raw)
+  if (!match) return null
+
+  const [fullLine, beforeStr, afterStr, savedStr, rulesStr, archivePath] = match
+
+  // Strip the footer + its preceding separator line if present.
+  const footerStart = raw.lastIndexOf(fullLine)
+  if (footerStart === -1) return null
+  let bodyEnd = footerStart
+  // Back up over trailing newline(s).
+  while (bodyEnd > 0 && (raw[bodyEnd - 1] === '\n' || raw[bodyEnd - 1] === '\r')) {
+    bodyEnd--
+  }
+  // Back up over the `---` separator line (if we added one).
+  const sepCandidate = raw.slice(0, bodyEnd).trimEnd()
+  const sepIdx = sepCandidate.lastIndexOf('\n---')
+  if (sepIdx !== -1 && sepCandidate.length - sepIdx <= 4) {
+    bodyEnd = sepIdx
+  } else if (sepCandidate.endsWith('---')) {
+    bodyEnd = sepCandidate.length - 3
+  }
+  const body = raw.slice(0, bodyEnd).replace(/\s+$/g, '')
+
+  return {
+    body,
+    beforeBytes: parseInt(beforeStr, 10) || 0,
+    afterBytes: parseInt(afterStr, 10) || 0,
+    savedPercent: parseInt(savedStr, 10) || 0,
+    rules: rulesStr
+      .split(',')
+      .map((r) => r.trim())
+      .filter((r) => r.length > 0),
+    archivePath: archivePath ?? null
+  }
+}
+
+/** Format a byte count for UI display (B / KB / MB). */
+export function formatBytes(n: number): string {
+  if (!Number.isFinite(n) || n < 0) return '0 B'
+  if (n < 1024) return `${n} B`
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`
+  return `${(n / (1024 * 1024)).toFixed(2)} MB`
+}

--- a/src/shared/types/field-context.ts
+++ b/src/shared/types/field-context.ts
@@ -57,6 +57,14 @@ export interface FieldContextSnapshot {
   /** User-authored notes from `worktrees.context`. */
   worktreeNotes: string | null
   /**
+   * v1.4.1: Pinned Facts — user-authored permanent facts for this worktree.
+   * Rendered before semantic memory; null/empty content suppresses the section.
+   */
+  pinnedFacts: {
+    contentMd: string
+    updatedAt: number
+  } | null
+  /**
    * Phase 24C: resumed work-state from the previous session on this worktree.
    * Null when no checkpoint, stale, or field collection disabled.
    */

--- a/test/field/redact.test.ts
+++ b/test/field/redact.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Tests for the shared redact module (Token Saver stage 0).
+ *
+ * Coverage targets:
+ *   - inline mode: each pattern fires on its canonical example
+ *   - inline mode: keyword-form preserves keyword (`api_key=[REDACTED]`)
+ *   - inline mode: bare-form replaces with `[REDACTED]`
+ *   - line mode: any keyword in line → whole line replaced
+ *   - both modes: clean input round-trips unchanged (no allocation surprises)
+ *   - both modes: empty / non-string inputs are handled
+ *   - regression: docstring 中文 不受影响
+ */
+import { describe, it, expect } from 'vitest'
+import { redactSecrets } from '../../src/main/field/redact'
+
+describe('redactSecrets — inline mode (default)', () => {
+  it('redacts keyword-style assignment, preserving the keyword', () => {
+    const out = redactSecrets('API_KEY=sk-1234567890abcdef')
+    expect(out).toBe('API_KEY=[REDACTED]')
+  })
+
+  it('handles colon separator', () => {
+    const out = redactSecrets('password: hunter2hunter2')
+    expect(out).toBe('password=[REDACTED]')
+  })
+
+  it('redacts an OpenAI sk- key in free text', () => {
+    const out = redactSecrets('curl -H "x: sk-abcDEFghiJKLmnoPQRstuVWX" /v1/chat')
+    expect(out).not.toContain('sk-abcDEFghiJKLmnoPQRstuVWX')
+    expect(out).toContain('[REDACTED]')
+  })
+
+  it('redacts an Anthropic sk-ant- key', () => {
+    const out = redactSecrets('export ANTHROPIC=sk-ant-abc1234567890defghijklmn')
+    expect(out).not.toContain('sk-ant-abc1234567890defghijklmn')
+  })
+
+  it('redacts a GitHub token (ghp_)', () => {
+    const out = redactSecrets('git clone https://x:ghp_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa12@github.com/x.git')
+    expect(out).not.toContain('ghp_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa12')
+  })
+
+  it('redacts an AWS access key ID', () => {
+    const out = redactSecrets('AKIAIOSFODNN7EXAMPLE in env')
+    expect(out).not.toContain('AKIAIOSFODNN7EXAMPLE')
+  })
+
+  it('redacts a JWT', () => {
+    const jwt = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NSJ9.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c'
+    const out = redactSecrets(`Authorization: ${jwt}`)
+    expect(out).not.toContain('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9')
+  })
+
+  it('redacts long hex secrets', () => {
+    const out = redactSecrets('hash=abcdef0123456789abcdef0123456789')
+    expect(out).not.toContain('abcdef0123456789abcdef0123456789')
+  })
+
+  it('redacts PEM private key blocks (multiline)', () => {
+    const pem = `-----BEGIN RSA PRIVATE KEY-----
+MIIEowIBAAKCAQEA1234567890
+abcdefg
+-----END RSA PRIVATE KEY-----`
+    const out = redactSecrets(pem)
+    expect(out).not.toContain('MIIEowIBAAKCAQEA1234567890')
+    expect(out).toContain('[REDACTED]')
+  })
+
+  it('does not modify clean strings', () => {
+    const clean = 'just a normal log line about file foo.ts at line 42'
+    expect(redactSecrets(clean)).toBe(clean)
+  })
+
+  it('preserves Chinese / non-ASCII text', () => {
+    const cn = '会话已恢复，但 token 字段需要核验'
+    // The word "token" triggers keyword-assignment but only with a value of
+    // length ≥6 chars. Bare keyword without assignment should not match.
+    expect(redactSecrets(cn)).toBe(cn)
+  })
+
+  it('returns input unchanged for empty / non-string', () => {
+    expect(redactSecrets('')).toBe('')
+    // @ts-expect-error intentional: defensive against bad caller input
+    expect(redactSecrets(null)).toBe(null)
+    // @ts-expect-error intentional
+    expect(redactSecrets(undefined)).toBe(undefined)
+  })
+})
+
+describe('redactSecrets — line mode (aggressive)', () => {
+  it('replaces an entire line containing a credential keyword', () => {
+    const input = `line one
+api_key: secretvalue
+line three`
+    const out = redactSecrets(input, { mode: 'line' })
+    expect(out).toBe(`line one
+[REDACTED LINE]
+line three`)
+  })
+
+  it('matches multiple credential keywords on multiple lines', () => {
+    const input = `password=foo
+ok line
+Bearer xyz`
+    const out = redactSecrets(input, { mode: 'line' })
+    expect(out.split('\n').filter((l) => l === '[REDACTED LINE]')).toHaveLength(2)
+  })
+
+  it('respects custom replacement', () => {
+    const out = redactSecrets('token=abc', { mode: 'line', replacement: '<<gone>>' })
+    expect(out).toBe('<<gone>>')
+  })
+
+  it('returns input unchanged when no keyword present', () => {
+    const input = 'lorem ipsum dolor sit amet\nno hidden values here\nplain text'
+    expect(redactSecrets(input, { mode: 'line' })).toBe(input)
+  })
+
+  it('respects word boundaries (does not match "secretary" or "tokenize")', () => {
+    const input = 'the secretary said hi\nlet us tokenize the input'
+    expect(redactSecrets(input, { mode: 'line' })).toBe(input)
+  })
+})
+
+describe('redactSecrets — multi-pattern interplay', () => {
+  it('redacts both keyword-assignment and bare token in same string', () => {
+    const out = redactSecrets('export API_KEY=sk-foobar1234567890; ghp_zzzzzzzzzzzzzzzzzzzzzzzzzzzzzz12 done')
+    expect(out).not.toContain('sk-foobar1234567890')
+    expect(out).not.toContain('ghp_zzzzzzzzzzzzzzzzzzzzzzzzzzzzzz12')
+  })
+
+  it('inline mode does not destroy structure: only matched substrings change', () => {
+    const out = redactSecrets('prefix api_key=topsecret123456 suffix')
+    expect(out.startsWith('prefix')).toBe(true)
+    expect(out.endsWith('suffix')).toBe(true)
+    expect(out).toContain('[REDACTED]')
+  })
+})

--- a/test/phase-24c/checkpoint-schema.test.ts
+++ b/test/phase-24c/checkpoint-schema.test.ts
@@ -124,7 +124,10 @@ describe('field_session_checkpoints schema (Phase 24C v20)', () => {
     expect(cols).not.toContain('stale_reason')
   })
 
-  it('schema version is 20', () => {
-    expect(db.getSchemaVersion()).toBe(20)
+  it('schema version is 21', () => {
+    // v21: add_field_pinned_facts (v1.4.1). Phase 24C still owns the
+    // checkpoint table from v20 — this assertion only tracks the head
+    // version of the migration ladder.
+    expect(db.getSchemaVersion()).toBe(21)
   })
 })

--- a/test/token-saver/banner-aggregation.test.ts
+++ b/test/token-saver/banner-aggregation.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Tests for SessionTokenSaverBanner aggregation logic.
+ *
+ * The banner is a thin shell over `aggregateStats`. We test its observable
+ * behaviour through the parser since the aggregator is private — synthesising
+ * realistic OpenCodeMessage shapes with footer-bearing tool outputs.
+ */
+import { describe, it, expect } from 'vitest'
+import { parseTokenSaverFooter } from '../../src/renderer/src/lib/token-saver-footer'
+
+function makeFooter(before: number, after: number, percent: number, archive?: string): string {
+  const tail = archive ? ` · original: ${archive}` : ''
+  return `body content here\n---\n[Token Saver] compressed ${before}B → ${after}B (-${percent}%) · via ansi-strip${tail}`
+}
+
+describe('SessionTokenSaverBanner aggregation (via parser)', () => {
+  it('parser correctly extracts before/after/percent from realistic footer', () => {
+    const footer = makeFooter(8432, 412, 95, '/tmp/x.txt')
+    const parsed = parseTokenSaverFooter(footer)
+    expect(parsed).not.toBeNull()
+    expect(parsed!.beforeBytes).toBe(8432)
+    expect(parsed!.afterBytes).toBe(412)
+    expect(parsed!.savedPercent).toBe(95)
+    expect(parsed!.archivePath).toBe('/tmp/x.txt')
+  })
+
+  it('aggregator semantics: sum of multiple footers', () => {
+    const a = parseTokenSaverFooter(makeFooter(1000, 100, 90))!
+    const b = parseTokenSaverFooter(makeFooter(2000, 500, 75))!
+    const totalBefore = a.beforeBytes + b.beforeBytes
+    const totalAfter = a.afterBytes + b.afterBytes
+    expect(totalBefore).toBe(3000)
+    expect(totalAfter).toBe(600)
+    expect(totalBefore - totalAfter).toBe(2400)
+  })
+
+  it('parser ignores plain text without footer (banner would skip these)', () => {
+    expect(parseTokenSaverFooter('echo hello\nhi')).toBeNull()
+    expect(parseTokenSaverFooter('')).toBeNull()
+  })
+
+  it('parser handles missing archive gracefully (banner still counts savings)', () => {
+    const parsed = parseTokenSaverFooter(makeFooter(5000, 500, 90))!
+    expect(parsed.archivePath).toBeNull()
+    expect(parsed.beforeBytes).toBe(5000)
+    expect(parsed.afterBytes).toBe(500)
+  })
+})

--- a/test/token-saver/bash-runner.test.ts
+++ b/test/token-saver/bash-runner.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Tests for runBashCommand (Token Saver stage 2a).
+ *
+ * Uses real /bin/sh on the host. The tests stick to commands that are
+ * deterministic across darwin/linux + present in any minimal POSIX env.
+ *
+ * NOTE: this suite only runs on POSIX hosts (darwin/linux). Skip on win32.
+ */
+import { afterEach, beforeEach, describe, it, expect } from 'vitest'
+import { promises as fs } from 'node:fs'
+import { tmpdir, platform } from 'node:os'
+import { join } from 'node:path'
+import { runBashCommand } from '../../src/main/services/token-saver/bash-runner'
+
+const isPosix = platform() !== 'win32'
+const describePosix = isPosix ? describe : describe.skip
+
+let cwd: string
+
+beforeEach(async () => {
+  cwd = await fs.mkdtemp(join(tmpdir(), 'xuanpu-bash-runner-'))
+})
+
+afterEach(async () => {
+  await fs.rm(cwd, { recursive: true, force: true }).catch(() => {})
+})
+
+describePosix('runBashCommand — happy paths', () => {
+  it('captures stdout from echo', async () => {
+    const r = await runBashCommand({ command: 'echo hello', cwd })
+    expect(r.exitCode).toBe(0)
+    expect(r.stdout.trim()).toBe('hello')
+    expect(r.stderr).toBe('')
+    expect(r.combined).toContain('hello')
+  })
+
+  it('captures stderr separately', async () => {
+    const r = await runBashCommand({
+      command: 'printf err >&2; printf out',
+      cwd
+    })
+    expect(r.exitCode).toBe(0)
+    expect(r.stdout).toBe('out')
+    expect(r.stderr).toBe('err')
+    expect(r.combined).toMatch(/out[\s\S]*--- stderr ---[\s\S]*err/)
+  })
+
+  it('exposes non-zero exit code without throwing', async () => {
+    const r = await runBashCommand({ command: 'exit 3', cwd })
+    expect(r.exitCode).toBe(3)
+    expect(r.timedOut).toBe(false)
+    expect(r.aborted).toBe(false)
+  })
+
+  it('runs in the configured cwd', async () => {
+    const r = await runBashCommand({ command: 'pwd', cwd })
+    // macOS may resolve /private/var symlink → check suffix instead.
+    expect(r.stdout.trim().endsWith(cwd) || r.stdout.trim().endsWith(cwd.replace(/^\/private/, ''))).toBe(true)
+  })
+
+  it('honors a custom env', async () => {
+    const r = await runBashCommand({
+      command: 'echo $TOKEN_SAVER_TEST',
+      cwd,
+      env: { ...process.env, TOKEN_SAVER_TEST: 'pineapple' }
+    })
+    expect(r.stdout.trim()).toBe('pineapple')
+  })
+
+  it('reports duration', async () => {
+    const r = await runBashCommand({
+      command: 'sleep 0.1',
+      cwd,
+      timeoutMs: 5000
+    })
+    expect(r.durationMs).toBeGreaterThanOrEqual(80)
+    expect(r.durationMs).toBeLessThan(2000)
+  })
+})
+
+describePosix('runBashCommand — timeout', () => {
+  it('kills a long-running command after timeoutMs and marks timedOut', async () => {
+    const r = await runBashCommand({
+      command: 'sleep 5',
+      cwd,
+      timeoutMs: 200
+    })
+    expect(r.timedOut).toBe(true)
+    expect(r.exitCode).toBe(-1)
+    expect(r.durationMs).toBeLessThan(3000)
+  })
+})
+
+describePosix('runBashCommand — abort', () => {
+  it('honors a caller-provided AbortSignal', async () => {
+    const ac = new AbortController()
+    setTimeout(() => ac.abort(), 100)
+    const r = await runBashCommand({
+      command: 'sleep 5',
+      cwd,
+      timeoutMs: 10000,
+      signal: ac.signal
+    })
+    expect(r.aborted).toBe(true)
+    expect(r.exitCode).toBe(-1)
+    expect(r.durationMs).toBeLessThan(3000)
+  })
+
+  it('handles already-aborted signal up-front', async () => {
+    const ac = new AbortController()
+    ac.abort()
+    const r = await runBashCommand({
+      command: 'sleep 5',
+      cwd,
+      timeoutMs: 10000,
+      signal: ac.signal
+    })
+    expect(r.aborted).toBe(true)
+  })
+})
+
+describePosix('runBashCommand — buffer cap + tee', () => {
+  it('truncates buffered stdout at maxBufferBytes and marks truncated', async () => {
+    const r = await runBashCommand({
+      // Print 4 KiB of "x" via printf; then we cap at 1 KiB.
+      command: 'printf "%4096s" "" | tr " " x',
+      cwd,
+      maxBufferBytes: 1024
+    })
+    expect(r.stdout.length).toBe(1024)
+    expect(r.truncated.stdout).toBe(true)
+    expect(r.combined).toContain('[stdout truncated]')
+  })
+
+  it('still streams full output to tee callback', async () => {
+    const chunks: string[] = []
+    const r = await runBashCommand({
+      command: 'printf "%4096s" "" | tr " " x',
+      cwd,
+      maxBufferBytes: 1024,
+      tee: (chunk, stream) => {
+        if (stream === 'stdout') chunks.push(chunk.toString('utf8'))
+      }
+    })
+    const teedTotal = chunks.join('').length
+    expect(teedTotal).toBeGreaterThanOrEqual(4000)
+    expect(r.truncated.stdout).toBe(true)
+  })
+
+  it('isolates a throwing tee callback (does not break the runner)', async () => {
+    const r = await runBashCommand({
+      command: 'echo hi',
+      cwd,
+      tee: () => {
+        throw new Error('boom')
+      }
+    })
+    expect(r.exitCode).toBe(0)
+    expect(r.stdout.trim()).toBe('hi')
+  })
+})
+
+describePosix('runBashCommand — input validation', () => {
+  it('rejects missing command', async () => {
+    // @ts-expect-error intentional bad input
+    await expect(runBashCommand({ cwd })).rejects.toThrow(/command/)
+  })
+
+  it('rejects missing cwd', async () => {
+    // @ts-expect-error intentional bad input
+    await expect(runBashCommand({ command: 'echo hi' })).rejects.toThrow(/cwd/)
+  })
+})

--- a/test/token-saver/footer-parser.test.ts
+++ b/test/token-saver/footer-parser.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Tests for the Token Saver footer parser (Token Saver stage 3).
+ */
+import { describe, it, expect } from 'vitest'
+import {
+  parseTokenSaverFooter,
+  formatBytes
+} from '../../src/renderer/src/lib/token-saver-footer'
+
+describe('parseTokenSaverFooter', () => {
+  it('parses a full footer (with archive path)', () => {
+    const raw = [
+      'compressed body line 1',
+      'compressed body line 2',
+      '---',
+      '[Token Saver] compressed 8432B → 412B (-95%) · via ansi-strip, progress-dedup · original: /Users/alice/.xuanpu/archive/s1/12345-0001.txt'
+    ].join('\n')
+    const parsed = parseTokenSaverFooter(raw)
+    expect(parsed).not.toBeNull()
+    expect(parsed!.body).toBe('compressed body line 1\ncompressed body line 2')
+    expect(parsed!.beforeBytes).toBe(8432)
+    expect(parsed!.afterBytes).toBe(412)
+    expect(parsed!.savedPercent).toBe(95)
+    expect(parsed!.rules).toEqual(['ansi-strip', 'progress-dedup'])
+    expect(parsed!.archivePath).toBe(
+      '/Users/alice/.xuanpu/archive/s1/12345-0001.txt'
+    )
+  })
+
+  it('parses a footer without archive path', () => {
+    const raw =
+      'body\n---\n[Token Saver] compressed 1000B → 100B (-90%) · via failure-focus'
+    const parsed = parseTokenSaverFooter(raw)
+    expect(parsed).not.toBeNull()
+    expect(parsed!.archivePath).toBeNull()
+    expect(parsed!.rules).toEqual(['failure-focus'])
+    expect(parsed!.body).toBe('body')
+  })
+
+  it('returns null when no footer is present', () => {
+    expect(parseTokenSaverFooter('just plain output')).toBeNull()
+    expect(parseTokenSaverFooter('')).toBeNull()
+    expect(parseTokenSaverFooter(null)).toBeNull()
+    expect(parseTokenSaverFooter(undefined)).toBeNull()
+  })
+
+  it('parses a single-rule footer', () => {
+    const raw =
+      'x\n---\n[Token Saver] compressed 500B → 250B (-50%) · via ansi-strip'
+    const parsed = parseTokenSaverFooter(raw)
+    expect(parsed).not.toBeNull()
+    expect(parsed!.rules).toEqual(['ansi-strip'])
+  })
+
+  it('parses three+ rules joined with commas', () => {
+    const raw =
+      'x\n---\n[Token Saver] compressed 2000B → 300B (-85%) · via ansi-strip, progress-dedup, failure-focus'
+    const parsed = parseTokenSaverFooter(raw)
+    expect(parsed!.rules).toEqual([
+      'ansi-strip',
+      'progress-dedup',
+      'failure-focus'
+    ])
+  })
+
+  it('preserves internal content (e.g. stderr separators) in body', () => {
+    const raw = [
+      'stdout contents',
+      '--- stderr ---',
+      'stderr contents',
+      '---',
+      '[Token Saver] compressed 100B → 50B (-50%) · via ansi-strip'
+    ].join('\n')
+    const parsed = parseTokenSaverFooter(raw)
+    expect(parsed!.body).toBe(
+      'stdout contents\n--- stderr ---\nstderr contents'
+    )
+  })
+
+  it('does not mis-match unrelated [Token Saver] in body', () => {
+    const raw = 'the [Token Saver] is amazing\n(no real footer here)'
+    expect(parseTokenSaverFooter(raw)).toBeNull()
+  })
+})
+
+describe('formatBytes', () => {
+  it('formats bytes correctly', () => {
+    expect(formatBytes(0)).toBe('0 B')
+    expect(formatBytes(512)).toBe('512 B')
+    expect(formatBytes(1024)).toBe('1.0 KB')
+    expect(formatBytes(1536)).toBe('1.5 KB')
+    expect(formatBytes(1024 * 1024)).toBe('1.00 MB')
+    expect(formatBytes(5 * 1024 * 1024)).toBe('5.00 MB')
+  })
+
+  it('handles invalid input', () => {
+    expect(formatBytes(-1)).toBe('0 B')
+    expect(formatBytes(NaN)).toBe('0 B')
+    expect(formatBytes(Infinity)).toBe('0 B')
+  })
+})

--- a/test/token-saver/offload-store.test.ts
+++ b/test/token-saver/offload-store.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Tests for ContextOffloadStore (Token Saver stage 2a).
+ *
+ * Uses an OS temp directory rooted at the suite scope so we never touch the
+ * user's real ~/.xuanpu/archive. Each test gets a fresh subdirectory.
+ */
+import { afterEach, beforeEach, describe, it, expect } from 'vitest'
+import { promises as fs } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { ContextOffloadStore } from '../../src/main/services/token-saver/offload-store'
+
+let testRoot: string
+
+beforeEach(async () => {
+  testRoot = await fs.mkdtemp(join(tmpdir(), 'xuanpu-offload-store-'))
+})
+
+afterEach(async () => {
+  await fs.rm(testRoot, { recursive: true, force: true }).catch(() => {})
+})
+
+describe('ContextOffloadStore', () => {
+  it('writes a body to <root>/<sessionId>/<ts>-<seq>.txt', async () => {
+    const store = new ContextOffloadStore({ rootDir: testRoot })
+    const rec = await store.write({
+      sessionId: 'sess-1',
+      body: 'hello world'
+    })
+    expect(rec.path.startsWith(join(testRoot, 'sess-1') + '/')).toBe(true)
+    expect(rec.path.endsWith('.txt')).toBe(true)
+    expect(rec.bytes).toBe(11)
+    expect(rec.seq).toBe(1)
+    const back = await store.read(rec.path)
+    expect(back).toBe('hello world')
+  })
+
+  it('increments seq monotonically per session', async () => {
+    const store = new ContextOffloadStore({ rootDir: testRoot })
+    const a = await store.write({ sessionId: 's', body: 'a' })
+    const b = await store.write({ sessionId: 's', body: 'b' })
+    const c = await store.write({ sessionId: 's', body: 'c' })
+    expect([a.seq, b.seq, c.seq]).toEqual([1, 2, 3])
+    expect(a.path).not.toBe(b.path)
+  })
+
+  it('keeps separate seq counters per session', async () => {
+    const store = new ContextOffloadStore({ rootDir: testRoot })
+    const a1 = await store.write({ sessionId: 's1', body: 'a' })
+    const b1 = await store.write({ sessionId: 's2', body: 'b' })
+    const a2 = await store.write({ sessionId: 's1', body: 'a2' })
+    expect(a1.seq).toBe(1)
+    expect(b1.seq).toBe(1)
+    expect(a2.seq).toBe(2)
+  })
+
+  it('respects custom file extension', async () => {
+    const store = new ContextOffloadStore({ rootDir: testRoot })
+    const rec = await store.write({
+      sessionId: 's',
+      body: '{"a":1}',
+      ext: 'json'
+    })
+    expect(rec.path.endsWith('.json')).toBe(true)
+  })
+
+  it('strips a leading dot from custom ext', async () => {
+    const store = new ContextOffloadStore({ rootDir: testRoot })
+    const rec = await store.write({
+      sessionId: 's',
+      body: 'x',
+      ext: '.log'
+    })
+    expect(rec.path.endsWith('.log')).toBe(true)
+    expect(rec.path).not.toContain('..log')
+  })
+
+  it('sanitises filesystem-unsafe characters in sessionId', async () => {
+    const store = new ContextOffloadStore({ rootDir: testRoot })
+    const rec = await store.write({
+      sessionId: '../../etc/passwd',
+      body: 'oops'
+    })
+    expect(rec.path).not.toContain('../../etc')
+    // Should land somewhere inside testRoot
+    expect(rec.path.startsWith(testRoot + '/')).toBe(true)
+  })
+
+  it('rejects empty sessionId', async () => {
+    const store = new ContextOffloadStore({ rootDir: testRoot })
+    await expect(
+      store.write({ sessionId: '', body: 'x' })
+    ).rejects.toThrow(/sessionId/)
+  })
+
+  it('rejects non-string body', async () => {
+    const store = new ContextOffloadStore({ rootDir: testRoot })
+    await expect(
+      // @ts-expect-error intentional bad input
+      store.write({ sessionId: 's', body: 123 })
+    ).rejects.toThrow(/body/)
+  })
+
+  it('handles multi-byte UTF-8 correctly', async () => {
+    const store = new ContextOffloadStore({ rootDir: testRoot })
+    const body = '字段内存压缩测试 🚀'
+    const rec = await store.write({ sessionId: 's', body })
+    expect(rec.bytes).toBe(Buffer.byteLength(body, 'utf8'))
+    const back = await store.read(rec.path)
+    expect(back).toBe(body)
+  })
+
+  it('totalSizeBytes sums all archives', async () => {
+    const store = new ContextOffloadStore({ rootDir: testRoot })
+    expect(await store.totalSizeBytes()).toBe(0)
+    await store.write({ sessionId: 's', body: 'x'.repeat(100) })
+    await store.write({ sessionId: 's', body: 'y'.repeat(50) })
+    const total = await store.totalSizeBytes()
+    expect(total).toBe(150)
+  })
+
+  it('totalSizeBytes returns 0 when root does not exist', async () => {
+    const store = new ContextOffloadStore({
+      rootDir: join(testRoot, 'never-created')
+    })
+    expect(await store.totalSizeBytes()).toBe(0)
+  })
+
+  it('clearAll removes all archives and reports count', async () => {
+    const store = new ContextOffloadStore({ rootDir: testRoot })
+    await store.write({ sessionId: 'a', body: '1' })
+    await store.write({ sessionId: 'a', body: '2' })
+    await store.write({ sessionId: 'b', body: '3' })
+    const removed = await store.clearAll()
+    expect(removed).toBe(3)
+    expect(await store.totalSizeBytes()).toBe(0)
+  })
+
+  it('clearAll on empty/missing root is a safe no-op', async () => {
+    const store = new ContextOffloadStore({
+      rootDir: join(testRoot, 'never-created')
+    })
+    expect(await store.clearAll()).toBe(0)
+  })
+
+  it('does not leave .tmp files on success', async () => {
+    const store = new ContextOffloadStore({ rootDir: testRoot })
+    await store.write({ sessionId: 's', body: 'x' })
+    const dir = join(testRoot, 's')
+    const entries = await fs.readdir(dir)
+    expect(entries.some((e) => e.endsWith('.tmp'))).toBe(false)
+  })
+})

--- a/test/token-saver/pipeline.test.ts
+++ b/test/token-saver/pipeline.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Tests for OutputCompressionPipeline (Token Saver stage 1).
+ *
+ * Covers:
+ *   - Constructor validation (rejects malformed strategies)
+ *   - Empty / no-op input
+ *   - Strategy ordering (run in declaration order)
+ *   - Failure isolation (a throwing strategy is skipped, not propagated)
+ *   - Malformed strategy result is skipped
+ *   - ruleHits records hits in order with hints
+ *   - Idempotency: running twice produces the same result
+ */
+import { describe, it, expect, vi } from 'vitest'
+import {
+  OutputCompressionPipeline,
+  isOutputStrategy,
+  type OutputStrategy
+} from '../../src/main/services/token-saver/pipeline'
+
+const passthrough: OutputStrategy = {
+  name: 'noop',
+  apply: (text) => ({ changed: false, text })
+}
+
+const upper: OutputStrategy = {
+  name: 'upper',
+  apply: (text) => ({ changed: true, text: text.toUpperCase(), hint: 'uppercased' })
+}
+
+const trim: OutputStrategy = {
+  name: 'trim',
+  apply: (text) => {
+    const t = text.trim()
+    return t === text ? { changed: false, text } : { changed: true, text: t }
+  }
+}
+
+const thrower: OutputStrategy = {
+  name: 'boom',
+  apply: () => {
+    throw new Error('intentional')
+  }
+}
+
+describe('isOutputStrategy', () => {
+  it('accepts a valid strategy', () => {
+    expect(isOutputStrategy(passthrough)).toBe(true)
+  })
+  it('rejects null / non-object / missing fields', () => {
+    expect(isOutputStrategy(null)).toBe(false)
+    expect(isOutputStrategy(undefined)).toBe(false)
+    expect(isOutputStrategy(42)).toBe(false)
+    expect(isOutputStrategy({})).toBe(false)
+    expect(isOutputStrategy({ name: 'x' })).toBe(false)
+    expect(isOutputStrategy({ apply: () => ({ changed: false, text: '' }) })).toBe(false)
+  })
+})
+
+describe('OutputCompressionPipeline', () => {
+  it('constructor throws on malformed strategy', () => {
+    // @ts-expect-error intentional bad input
+    expect(() => new OutputCompressionPipeline([{}])).toThrow(/invalid strategy/)
+  })
+
+  it('handles empty input string', () => {
+    const p = new OutputCompressionPipeline([upper])
+    const r = p.run('')
+    expect(r.text).toBe('')
+    expect(r.beforeBytes).toBe(0)
+    expect(r.afterBytes).toBe(0)
+    expect(r.ruleHits).toEqual([])
+  })
+
+  it('handles undefined input safely', () => {
+    const p = new OutputCompressionPipeline([upper])
+    // @ts-expect-error intentional: some callers may pass null
+    const r = p.run(null as string)
+    expect(r.text).toBe('')
+  })
+
+  it('passes through unchanged when no strategy fires', () => {
+    const p = new OutputCompressionPipeline([passthrough, passthrough])
+    const r = p.run('hello world')
+    expect(r.text).toBe('hello world')
+    expect(r.ruleHits).toEqual([])
+  })
+
+  it('applies strategies in declaration order', () => {
+    // trim then upper: '  hi  ' → 'hi' → 'HI'
+    const p = new OutputCompressionPipeline([trim, upper])
+    const r = p.run('  hi  ')
+    expect(r.text).toBe('HI')
+    expect(r.ruleHits.map((h) => h.name)).toEqual(['trim', 'upper'])
+  })
+
+  it('records hint in ruleHits', () => {
+    const p = new OutputCompressionPipeline([upper])
+    const r = p.run('foo')
+    expect(r.ruleHits[0]).toEqual({ name: 'upper', hint: 'uppercased' })
+  })
+
+  it('isolates a throwing strategy and continues', () => {
+    const logger = { warn: vi.fn() }
+    const p = new OutputCompressionPipeline([upper, thrower, trim], logger)
+    const r = p.run('  hi  ')
+    expect(r.text).toBe('HI') // upper fires; thrower skipped; trim sees 'HI' (no leading/trailing space)
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('strategy threw'),
+      expect.objectContaining({ name: 'boom' })
+    )
+  })
+
+  it('skips strategy returning malformed result', () => {
+    const logger = { warn: vi.fn() }
+    const broken: OutputStrategy = {
+      name: 'broken',
+      // @ts-expect-error intentional bad return
+      apply: () => ({ changed: true })
+    }
+    const p = new OutputCompressionPipeline([broken, upper], logger)
+    const r = p.run('hi')
+    expect(r.text).toBe('HI')
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('malformed result'),
+      expect.objectContaining({ name: 'broken' })
+    )
+  })
+
+  it('is idempotent: running twice yields the same result', () => {
+    const p = new OutputCompressionPipeline([trim, upper])
+    const a = p.run('  hi  ')
+    const b = p.run('  hi  ')
+    expect(a).toEqual(b)
+  })
+
+  it('reports correct byte counts (UTF-8 multi-byte)', () => {
+    const p = new OutputCompressionPipeline([passthrough])
+    const r = p.run('字段内存')
+    // 4 Chinese chars × 3 bytes each = 12 bytes
+    expect(r.beforeBytes).toBe(12)
+    expect(r.afterBytes).toBe(12)
+  })
+
+  it('exposes strategy names for inspection', () => {
+    const p = new OutputCompressionPipeline([upper, trim])
+    expect(p.strategyNames).toEqual(['upper', 'trim'])
+  })
+})

--- a/test/token-saver/privacy-gate.test.ts
+++ b/test/token-saver/privacy-gate.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Tests for `isTokenSaverEnabled` privacy gate (Token Saver stage 2b).
+ *
+ * Default ON: any value other than the literal string 'false' enables it.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+const getSettingMock = vi.fn<(key: string) => string | null | undefined>()
+
+vi.mock('../../src/main/db', () => ({
+  getDatabase: () => ({
+    getSetting: getSettingMock
+  })
+}))
+
+import {
+  isTokenSaverEnabled,
+  setTokenSaverEnabledCache,
+  invalidatePrivacyCache,
+  TOKEN_SAVER_ENABLED_SETTING_KEY
+} from '../../src/main/field/privacy'
+
+beforeEach(() => {
+  invalidatePrivacyCache()
+  getSettingMock.mockReset()
+})
+
+describe('isTokenSaverEnabled', () => {
+  it('default ON when setting is absent (null)', () => {
+    getSettingMock.mockReturnValue(null)
+    expect(isTokenSaverEnabled()).toBe(true)
+  })
+
+  it('default ON when setting is undefined', () => {
+    getSettingMock.mockReturnValue(undefined)
+    expect(isTokenSaverEnabled()).toBe(true)
+  })
+
+  it('default ON for any value other than literal "false"', () => {
+    for (const v of ['true', 'yes', '1', 'TRUE', '', 'enabled']) {
+      invalidatePrivacyCache()
+      getSettingMock.mockReturnValue(v)
+      expect(isTokenSaverEnabled()).toBe(true)
+    }
+  })
+
+  it('OFF only when setting is the literal string "false"', () => {
+    getSettingMock.mockReturnValue('false')
+    expect(isTokenSaverEnabled()).toBe(false)
+  })
+
+  it('caches after first lookup', () => {
+    getSettingMock.mockReturnValue(null)
+    expect(isTokenSaverEnabled()).toBe(true)
+    expect(isTokenSaverEnabled()).toBe(true)
+    expect(getSettingMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('setTokenSaverEnabledCache updates the cache in-band', () => {
+    getSettingMock.mockReturnValue(null)
+    expect(isTokenSaverEnabled()).toBe(true)
+    setTokenSaverEnabledCache(false)
+    expect(isTokenSaverEnabled()).toBe(false)
+    setTokenSaverEnabledCache(true)
+    expect(isTokenSaverEnabled()).toBe(true)
+  })
+
+  it('invalidatePrivacyCache forces re-read', () => {
+    getSettingMock.mockReturnValueOnce('false').mockReturnValueOnce('true')
+    expect(isTokenSaverEnabled()).toBe(false)
+    expect(isTokenSaverEnabled()).toBe(false) // cached
+    invalidatePrivacyCache()
+    expect(isTokenSaverEnabled()).toBe(true) // re-read
+  })
+
+  it('exports the setting key', () => {
+    expect(TOKEN_SAVER_ENABLED_SETTING_KEY).toBe('token_saver_enabled')
+  })
+})

--- a/test/token-saver/strategies.test.ts
+++ b/test/token-saver/strategies.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Tests for the 5 built-in compression strategies.
+ *
+ * Each strategy gets:
+ *   - happy path (canonical input → expected transformation)
+ *   - no-trigger case (returns changed:false without altering text)
+ *   - edge case (empty / very short / pathological input)
+ *
+ * Strategy order in the default pipeline is also asserted at the end.
+ */
+import { describe, it, expect } from 'vitest'
+import {
+  ansiStripStrategy,
+  progressDedupStrategy,
+  ndjsonSummaryStrategy,
+  failureFocusStrategy,
+  statsExtractionStrategy,
+  DEFAULT_STRATEGIES
+} from '../../src/main/services/token-saver/strategies'
+import { defaultPipeline, __resetDefaultPipelineForTest } from '../../src/main/services/token-saver'
+
+const ctx = {}
+
+describe('ansiStripStrategy', () => {
+  it('strips SGR colour codes', () => {
+    const r = ansiStripStrategy.apply('\x1b[31mERROR\x1b[0m: boom', ctx)
+    expect(r.changed).toBe(true)
+    expect(r.text).toBe('ERROR: boom')
+  })
+
+  it('strips OSC sequences', () => {
+    const r = ansiStripStrategy.apply('hi\x1b]0;title\x07world', ctx)
+    expect(r.changed).toBe(true)
+    expect(r.text).toBe('hiworld')
+  })
+
+  it('no-op on plain text', () => {
+    const r = ansiStripStrategy.apply('plain text', ctx)
+    expect(r.changed).toBe(false)
+    expect(r.text).toBe('plain text')
+  })
+
+  it('handles empty input', () => {
+    expect(ansiStripStrategy.apply('', ctx)).toEqual({ changed: false, text: '' })
+  })
+})
+
+describe('progressDedupStrategy', () => {
+  it('collapses repeated identical lines', () => {
+    const input = Array(10).fill('downloading foo@1.0.0').join('\n')
+    const r = progressDedupStrategy.apply(input, ctx)
+    expect(r.changed).toBe(true)
+    expect(r.text).toContain('×10')
+    expect(r.text).not.toContain(Array(5).fill('downloading foo@1.0.0').join('\n'))
+  })
+
+  it('does not collapse runs of <4 identical lines', () => {
+    const input = 'foo\nfoo\nfoo'
+    const r = progressDedupStrategy.apply(input, ctx)
+    expect(r.changed).toBe(false)
+  })
+
+  it('collapses bare-CR progress redraws', () => {
+    const input = 'a\rb\rc\nfinal'
+    const r = progressDedupStrategy.apply(input, ctx)
+    expect(r.changed).toBe(true)
+    // Greedy match eats 'a\rb\r' (everything up to last \r in the line),
+    // leaving 'c' as the final visible state of the redrawn line.
+    expect(r.text).toBe('c\nfinal')
+  })
+
+  it('skips short input', () => {
+    const r = progressDedupStrategy.apply('x', ctx)
+    expect(r.changed).toBe(false)
+  })
+
+  it('preserves blank-line runs (does not dedup empties as content)', () => {
+    const input = 'a\n\n\n\n\nb'
+    const r = progressDedupStrategy.apply(input, ctx)
+    // Empty lines are skipped from the dedup count by the trim() check
+    expect(r.text).toBe(input)
+  })
+})
+
+describe('ndjsonSummaryStrategy', () => {
+  it('summarises a long ndjson stream by level', () => {
+    const lines: string[] = []
+    for (let i = 0; i < 50; i++) {
+      lines.push(JSON.stringify({ level: i % 5 === 0 ? 'error' : 'info', msg: `m${i}` }))
+    }
+    const input = lines.join('\n')
+    const r = ndjsonSummaryStrategy.apply(input, ctx)
+    expect(r.changed).toBe(true)
+    expect(r.text).toContain('ndjson summary')
+    expect(r.text).toContain('error=10')
+    expect(r.text).toContain('info=40')
+    expect(r.text.length).toBeLessThan(input.length)
+  })
+
+  it('does not fire when fewer than 10 lines', () => {
+    const input = Array(8).fill('{"a":1}').join('\n')
+    const r = ndjsonSummaryStrategy.apply(input, ctx)
+    expect(r.changed).toBe(false)
+  })
+
+  it('does not fire when input is small (under MIN_COMPRESS_BYTES)', () => {
+    const input = '{"a":1}\n{"a":2}'
+    const r = ndjsonSummaryStrategy.apply(input, ctx)
+    expect(r.changed).toBe(false)
+  })
+
+  it('does not fire when most lines are not JSON', () => {
+    const lines: string[] = []
+    for (let i = 0; i < 30; i++) lines.push('not json line ' + 'x'.repeat(50))
+    const r = ndjsonSummaryStrategy.apply(lines.join('\n'), ctx)
+    expect(r.changed).toBe(false)
+  })
+})
+
+describe('failureFocusStrategy', () => {
+  it('keeps lines around failure markers when exit code != 0', () => {
+    const lines: string[] = []
+    for (let i = 0; i < 100; i++) lines.push(`pass test ${i}: ${'x'.repeat(20)}`)
+    lines[50] = 'FAIL: division by zero'
+    const input = lines.join('\n')
+    const r = failureFocusStrategy.apply(input, { exitCode: 1 })
+    expect(r.changed).toBe(true)
+    expect(r.text).toContain('FAIL: division by zero')
+    expect(r.text).toContain('lines omitted')
+    expect(r.text.length).toBeLessThan(input.length)
+  })
+
+  it('does not fire on small output', () => {
+    const r = failureFocusStrategy.apply('error: tiny', { exitCode: 1 })
+    expect(r.changed).toBe(false)
+  })
+
+  it('does not fire when exit==0 and no failure markers', () => {
+    const lines = Array(50).fill('all good ' + 'x'.repeat(40))
+    const r = failureFocusStrategy.apply(lines.join('\n'), { exitCode: 0 })
+    expect(r.changed).toBe(false)
+  })
+
+  it('fires without exitCode if failure markers present', () => {
+    const lines = Array(50).fill('all good ' + 'x'.repeat(40))
+    lines[25] = 'Exception: something exploded'
+    const r = failureFocusStrategy.apply(lines.join('\n'), {})
+    expect(r.changed).toBe(true)
+  })
+})
+
+describe('statsExtractionStrategy', () => {
+  it('extracts vitest summary and trims body', () => {
+    const lines: string[] = []
+    for (let i = 0; i < 80; i++) lines.push(`test case ${i}: ok ` + 'y'.repeat(30))
+    lines.push('')
+    lines.push(' Test Files  4 passed (4)')
+    lines.push(' Tests  71 passed (71)')
+    const input = lines.join('\n')
+    const r = statsExtractionStrategy.apply(input, { exitCode: 0 })
+    expect(r.changed).toBe(true)
+    expect(r.text).toMatch(/summary:.*passed/)
+    expect(r.text.length).toBeLessThan(input.length)
+  })
+
+  it('does not fire on failed runs (FailureFocus owns that)', () => {
+    const lines: string[] = []
+    for (let i = 0; i < 80; i++) lines.push(`line ${i}: ` + 'x'.repeat(30))
+    lines.push('Tests:  3 passed, 1 failed')
+    const r = statsExtractionStrategy.apply(lines.join('\n'), { exitCode: 1 })
+    expect(r.changed).toBe(false)
+  })
+
+  it('does not fire when no summary line is present', () => {
+    const lines = Array(60).fill('plain log line ' + 'x'.repeat(30))
+    const r = statsExtractionStrategy.apply(lines.join('\n'), { exitCode: 0 })
+    expect(r.changed).toBe(false)
+  })
+})
+
+describe('default pipeline composition', () => {
+  it('exposes the 5 strategies in expected order', () => {
+    expect(DEFAULT_STRATEGIES.map((s) => s.name)).toEqual([
+      'ansi-strip',
+      'progress-dedup',
+      'ndjson-summary',
+      'failure-focus',
+      'stats-extraction'
+    ])
+  })
+
+  it('memoises the default pipeline', () => {
+    __resetDefaultPipelineForTest()
+    const a = defaultPipeline()
+    const b = defaultPipeline()
+    expect(a).toBe(b)
+  })
+
+  it('end-to-end: ANSI noise + repeated lines compresses', () => {
+    __resetDefaultPipelineForTest()
+    const lines: string[] = []
+    for (let i = 0; i < 20; i++) lines.push('\x1b[32m  spam line\x1b[0m')
+    lines.push('done')
+    const input = lines.join('\n')
+    const r = defaultPipeline().run(input)
+    expect(r.afterBytes).toBeLessThan(r.beforeBytes)
+    expect(r.ruleHits.map((h) => h.name)).toContain('ansi-strip')
+    expect(r.ruleHits.map((h) => h.name)).toContain('progress-dedup')
+  })
+})

--- a/test/token-saver/xuanpu-tools-mcp.test.ts
+++ b/test/token-saver/xuanpu-tools-mcp.test.ts
@@ -1,0 +1,238 @@
+/**
+ * Tests for the Token Saver MCP server data path
+ * (`runBashWithCompression` + `formatToolResultText`).
+ *
+ * The MCP transport itself (createXuanpuToolsMcpServerConfig) is NOT exercised
+ * here — that requires the SDK to be running. We test the data layer that the
+ * tool handler invokes: spawn → archive → pipeline → format.
+ *
+ * Uses a per-test tmp dir for archives.
+ */
+import { afterEach, beforeEach, describe, it, expect, vi } from 'vitest'
+import { promises as fs } from 'node:fs'
+import { tmpdir, platform } from 'node:os'
+import { join } from 'node:path'
+import {
+  ContextOffloadStore,
+  OutputCompressionPipeline,
+  type OutputStrategy
+} from '../../src/main/services/token-saver'
+import {
+  formatToolResultText,
+  runBashWithCompression
+} from '../../src/main/services/token-saver/xuanpu-tools-mcp'
+
+const isPosix = platform() !== 'win32'
+const describePosix = isPosix ? describe : describe.skip
+
+let archiveRoot: string
+let cwd: string
+
+beforeEach(async () => {
+  archiveRoot = await fs.mkdtemp(join(tmpdir(), 'xuanpu-mcp-arch-'))
+  cwd = await fs.mkdtemp(join(tmpdir(), 'xuanpu-mcp-cwd-'))
+})
+
+afterEach(async () => {
+  await fs.rm(archiveRoot, { recursive: true, force: true }).catch(() => {})
+  await fs.rm(cwd, { recursive: true, force: true }).catch(() => {})
+})
+
+describe('formatToolResultText', () => {
+  it('returns body unchanged when no compression fired', () => {
+    const text = formatToolResultText(
+      { text: 'hello', beforeBytes: 5, afterBytes: 5, ruleHits: [] },
+      {
+        beforeBytes: 5,
+        afterBytes: 5,
+        savedBytes: 0,
+        ruleHits: [],
+        archivePath: null,
+        exitCode: 0,
+        durationMs: 10,
+        timedOut: false,
+        aborted: false
+      }
+    )
+    expect(text).toBe('hello')
+  })
+
+  it('appends footer with savings + archive path when compression fired', () => {
+    const text = formatToolResultText(
+      {
+        text: '<compressed>',
+        beforeBytes: 1000,
+        afterBytes: 100,
+        ruleHits: [{ name: 'ansi-strip' }, { name: 'failure-focus' }]
+      },
+      {
+        beforeBytes: 1000,
+        afterBytes: 100,
+        savedBytes: 900,
+        ruleHits: [{ name: 'ansi-strip' }, { name: 'failure-focus' }],
+        archivePath: '/tmp/arch/123.txt',
+        exitCode: 1,
+        durationMs: 10,
+        timedOut: false,
+        aborted: false
+      }
+    )
+    expect(text).toContain('<compressed>')
+    expect(text).toContain('[Token Saver]')
+    expect(text).toContain('-90%')
+    expect(text).toContain('ansi-strip, failure-focus')
+    expect(text).toContain('original: /tmp/arch/123.txt')
+  })
+
+  it('omits archive line when path is null', () => {
+    const text = formatToolResultText(
+      { text: 'x', beforeBytes: 100, afterBytes: 50, ruleHits: [{ name: 'ansi-strip' }] },
+      {
+        beforeBytes: 100,
+        afterBytes: 50,
+        savedBytes: 50,
+        ruleHits: [{ name: 'ansi-strip' }],
+        archivePath: null,
+        exitCode: 0,
+        durationMs: 0,
+        timedOut: false,
+        aborted: false
+      }
+    )
+    expect(text).not.toContain('original:')
+  })
+})
+
+describePosix('runBashWithCompression — happy paths', () => {
+  it('captures, archives, compresses', async () => {
+    const offload = new ContextOffloadStore({ rootDir: archiveRoot })
+    const r = await runBashWithCompression(
+      { command: 'echo hello' },
+      { sessionId: 'sess', defaultCwd: cwd, offloadStore: offload }
+    )
+    expect(r.runResult.exitCode).toBe(0)
+    expect(r.metadata.archivePath).toBeTruthy()
+    expect(r.metadata.beforeBytes).toBeGreaterThan(0)
+    // Echo output is small enough that no compression strategy fires.
+    expect(r.metadata.ruleHits).toHaveLength(0)
+    expect(r.text).toBe(r.runResult.combined)
+  })
+
+  it('compression footer fires when output is large + has compressible content', async () => {
+    const offload = new ContextOffloadStore({ rootDir: archiveRoot })
+    // Generate 50 identical lines (>4 same → progress-dedup), each 30 chars.
+    const r = await runBashWithCompression(
+      {
+        command: 'for i in $(seq 50); do echo same-line-content-here-padding; done'
+      },
+      { sessionId: 'sess', defaultCwd: cwd, offloadStore: offload }
+    )
+    expect(r.runResult.exitCode).toBe(0)
+    expect(r.metadata.ruleHits.length).toBeGreaterThan(0)
+    expect(r.text).toContain('[Token Saver]')
+    expect(r.text).toContain(r.metadata.archivePath ?? '')
+  })
+
+  it('honors abort signal', async () => {
+    const offload = new ContextOffloadStore({ rootDir: archiveRoot })
+    const ac = new AbortController()
+    setTimeout(() => ac.abort(), 80)
+    const r = await runBashWithCompression(
+      { command: 'sleep 5' },
+      { sessionId: 'sess', defaultCwd: cwd, offloadStore: offload },
+      ac.signal
+    )
+    expect(r.runResult.aborted).toBe(true)
+    expect(r.metadata.aborted).toBe(true)
+  })
+
+  it('archives even on non-zero exit', async () => {
+    const offload = new ContextOffloadStore({ rootDir: archiveRoot })
+    const r = await runBashWithCompression(
+      { command: 'echo failing-command; exit 7' },
+      { sessionId: 'sess', defaultCwd: cwd, offloadStore: offload }
+    )
+    expect(r.runResult.exitCode).toBe(7)
+    expect(r.metadata.archivePath).toBeTruthy()
+    const archived = await offload.read(r.metadata.archivePath as string)
+    expect(archived).toContain('failing-command')
+  })
+})
+
+describe('runBashWithCompression — failure isolation', () => {
+  it('returns synthetic result on spawn failure (does not throw)', async () => {
+    const offload = new ContextOffloadStore({ rootDir: archiveRoot })
+    const r = await runBashWithCompression(
+      { command: 'echo ok' },
+      // Pointing cwd at a path that does not exist forces spawn to fail.
+      {
+        sessionId: 'sess',
+        defaultCwd: '/this/path/should/not/exist/ever',
+        offloadStore: offload
+      }
+    )
+    expect(r.runResult.exitCode).toBe(-1)
+    expect(r.runResult.stderr).toContain('failed to spawn')
+  })
+
+  it('continues when archive write fails', async () => {
+    const failingStore = {
+      write: vi.fn().mockRejectedValue(new Error('disk-full'))
+    } as unknown as ContextOffloadStore
+    const warn = vi.fn()
+    const r = await runBashWithCompression(
+      { command: 'echo hi' },
+      {
+        sessionId: 's',
+        defaultCwd: cwd,
+        offloadStore: failingStore,
+        logger: { warn }
+      }
+    )
+    if (isPosix) {
+      expect(r.runResult.exitCode).toBe(0)
+      expect(r.metadata.archivePath).toBeNull()
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining('archive write failed'),
+        expect.any(Object)
+      )
+    }
+  })
+
+  it('falls back to raw output if pipeline crashes', async () => {
+    if (!isPosix) return
+    const offload = new ContextOffloadStore({ rootDir: archiveRoot })
+    const crashingStrategy: OutputStrategy = {
+      name: 'crashy',
+      apply: () => {
+        throw new Error('pipeline-crash')
+      }
+    }
+    // Pipeline isolates strategy throws — we need the pipeline ITSELF to
+    // crash, which only happens via a synthetic .run override.
+    const pipeline = new OutputCompressionPipeline([crashingStrategy])
+    const originalRun = pipeline.run.bind(pipeline)
+    pipeline.run = (() => {
+      throw new Error('pipeline-crash')
+    }) as typeof pipeline.run
+    void originalRun
+
+    const warn = vi.fn()
+    const r = await runBashWithCompression(
+      { command: 'echo hi' },
+      {
+        sessionId: 's',
+        defaultCwd: cwd,
+        offloadStore: offload,
+        pipeline,
+        logger: { warn }
+      }
+    )
+    expect(r.runResult.exitCode).toBe(0)
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('pipeline crashed'),
+      expect.any(Object)
+    )
+    expect(r.metadata.ruleHits).toEqual([])
+  })
+})

--- a/test/xuanpu-system-context.test.ts
+++ b/test/xuanpu-system-context.test.ts
@@ -1,0 +1,42 @@
+/**
+ * Test that the Xuanpu system context spells out the contract clearly enough
+ * that any future change reviewers can spot when the protective hint goes
+ * missing. This is essentially a contract-locking test — we don't try to
+ * verify the model behaves correctly (that needs an integration test), only
+ * that the agreed wording is present and stable.
+ */
+import { describe, it, expect } from 'vitest'
+import { XUANPU_SYSTEM_CONTEXT } from '../src/main/services/xuanpu-system-context'
+
+describe('XUANPU_SYSTEM_CONTEXT', () => {
+  it('explains the [Field Context] / [User Message] wrapper is informational', () => {
+    expect(XUANPU_SYSTEM_CONTEXT).toMatch(/\[Field Context.*\]/)
+    expect(XUANPU_SYSTEM_CONTEXT).toMatch(/\[User Message\]/)
+    expect(XUANPU_SYSTEM_CONTEXT.toLowerCase()).toMatch(/informational|not.*contract/)
+  })
+
+  it('forbids silent-exit on bare user messages', () => {
+    expect(XUANPU_SYSTEM_CONTEXT).toContain('Continue from where you left off.')
+    // Must explicitly tell the model "No response requested." is wrong.
+    expect(XUANPU_SYSTEM_CONTEXT).toMatch(/No response requested/)
+  })
+
+  it('asks the model to resume the prior task on bare resume markers', () => {
+    expect(XUANPU_SYSTEM_CONTEXT.toLowerCase()).toMatch(/resume.*(task|prior)/)
+  })
+
+  it('flags Field Context as observed data, not authoritative instructions', () => {
+    expect(XUANPU_SYSTEM_CONTEXT.toLowerCase()).toMatch(
+      /observed.*data|not.*authoritative/
+    )
+  })
+
+  it('is short enough to be cheap on every turn (< 1500 chars)', () => {
+    expect(XUANPU_SYSTEM_CONTEXT.length).toBeLessThan(1500)
+  })
+
+  it('is non-empty and contains no trailing whitespace', () => {
+    expect(XUANPU_SYSTEM_CONTEXT.length).toBeGreaterThan(100)
+    expect(XUANPU_SYSTEM_CONTEXT).toBe(XUANPU_SYSTEM_CONTEXT.trim())
+  })
+})


### PR DESCRIPTION
## Summary

本 PR 把"现场感增强"主线一次性合入：在 v1.4.5 基础上交付 v1.4.6 的字段内存能力，再叠加 v1.5.0 的 Token Saver MVP 横切能力，并顺手根治了一个 1.4.5 老用户也会遇到的 SDK resume 静默退出 bug。

## 三件事，按依赖顺序

### 1. v1.4.6 字段内存（commit \`34a9b2a\`）

合并 v1.4.1（Pinned Facts）+ v1.4.2（Memory 面板）+ v1.4.3（slash 命令）三份散文档为一份可执行 PRD 并交付：

- DB schema bump 到 21（新增 \`field_events\` / \`field_episodic_memory\` / \`field_session_checkpoints\`）
- repository + handlers + IPC + preload 全链路打通
- React UI：\`PinnedFactsCard\` / \`WorktreeContextEditor\` / \`MemoryPanel\`
- \`SessionView\` 加 \`/remember\` \`/forget\` \`/clear\` 三个 slash 命令
- Field Context 注入到 prompt 前缀
- README 中英两份 + i18n

### 2. v1.5.0 Token Saver MVP（commits \`5468c50\` → \`1bd34fd\`，stage 0–3）

把 RTK + 上下文卸载从"现场感子能力"重新定位为玄圃的横切基础能力。MVP 端到端打通：

\`\`\`
agent → mcp__xuanpu__bash → runBashCommand → ContextOffloadStore archive
       → defaultPipeline 压缩（5 类策略）→ formatToolResultText 拼 footer
       → SDK → Anthropic API（API 看到的是压缩文本）
       → 玄圃 UI 解析 footer → 节省徽章 + 展开原文 + 会话累计 banner
\`\`\`

| 阶段 | 内容 | commit |
|---|---|---|
| 0 | 统一 redact 模块 + 加固 + 单测 | \`5468c50\` |
| 1 | OutputCompressionPipeline + 5 策略（ANSI/Dedup/NDJSON/FailureFocus/StatsExtraction） | \`80a749b\` |
| 2a | ContextOffloadStore + BashCommandRunner（SDK 解耦基础设施） | \`501b1a0\` |
| 2b | 进程内 MCP server 接管 Bash + 「Token 节省器」开关（默认开） | \`269c01f\` |
| 3 | UI 感知层：节省徽章 + 展开原文 + 会话累计 banner | \`1bd34fd\` |

设计要点：
- **MVP 只接管 Bash**（其他工具二期再说）
- **开关默认开**，让用户立刻看到价值；可在 Settings → 隐私 → Token 节省器关闭
- **三层失败兜底**：spawn 失败 / archive 失败 / pipeline 崩溃，任一层挂了 agent 都不会卡死
- **路径白名单**：\`fileOps.readArchive\` 限定 \`~/.xuanpu/archive\`，50MB cap

### 3. SDK resume 静默退出根治（commits \`c4f5d4c\` + \`facf4d4\`）

abort 后 resume 时 SDK 会注入合成 user message \`Continue from where you left off.\`，模型常常因此回 \`No response requested.\` 直接退出，会话事实上"卡死"。

之前以为是注入本身的问题，深入查后发现根因是模型从玄圃 \`[Field Context]/[User Message]\` 包装结构推断出隐式协议——孤立 boilerplate 没穿这层壳，模型判定为非用户意图。

修复方式：
- \`c4f5d4c\`：玄圃侧过滤 SDK emit 的合成消息（不写 DB / 不展示 UI）
- \`facf4d4\`：通过 \`appendSystemPrompt\` 注入 \`XUANPU_SYSTEM_CONTEXT\`，明确告诉模型包装是信息性的、孤立 boilerplate 也要正常处理

**v1.4.5 用户合入后立刻收益**：abort 后 resume 不再卡死。

## 影响范围

| Agent | 改动 |
|---|---|
| Claude Code | 字段内存 + Token Saver + SDK resume fix |
| OpenCode | 仅字段内存（其他无影响） |
| Codex | 仅字段内存（其他无影响） |

## Test plan

- [x] \`pnpm vitest run\` 全部 token-saver 测试 95/95 ✅
- [x] \`pnpm vitest run test/field test/phase-21 test/phase-21-5 test/phase-22b\` 关联回归 71/71 ✅
- [x] \`pnpm lint\` 改动文件 0 errors ✅
- [ ] 手动验证：dev 跑一次 \`pnpm test\` 命令，看 Bash bubble 上节省徽章是否显示
- [ ] 手动验证：abort 一个 Claude 会话后 resume，确认不再 "No response requested"
- [ ] 手动验证：会话 header 累计 banner 在多次 Bash 调用后正确累加
- [ ] 手动验证：Settings → 隐私 → Token 节省器 toggle 关掉后回退到原生 Bash

## 不在本 PR 内（二期）

- Token Saver 扩展到 Read / Grep / WebFetch
- archive 检索（"上次那个 OOM 日志在哪"）
- 全局节省看板
- OpenCode / Codex 的 Token Saver 适配
- 把 archive 接入字段内存的 episodic 层（"压缩+召回"闭环）

## 文档

- 完整路线图：\`docs/plans/2026-05-04-token-saver-pipeline.md\`
- 系统提示原文：\`src/main/services/xuanpu-system-context.ts\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)