### PR TITLE
v1.4.7 PR 1: Hive upstream low-risk follow-ups

### DIFF
--- a/docs/plans/2026-05-09-hive-upstream-pr-followup.md
+++ b/docs/plans/2026-05-09-hive-upstream-pr-followup.md
@@ -1,0 +1,245 @@
+# Hive Upstream Recent PR Follow-up Plan
+
+## 背景
+
+本计划基于 2026-05-09 对 `morapelker/hive` 的上游扫描：
+
+- 扫描范围：最近 20 条 GitHub Release，重点覆盖 `v1.1.1` 到 `v1.0.111`。
+- 最新 Release：[`v1.1.1`](https://github.com/morapelker/hive/releases/tag/v1.1.1)。
+- 功能密度最高的近期 Release：[`v1.1.0`](https://github.com/morapelker/hive/releases/tag/v1.1.0)。
+- 当前开放 PR：[`#464 Add default allowlist patterns for read-only operations`](https://github.com/morapelker/hive/pull/464)。
+
+这轮不做整包追上游，也不把 Hive 的产品形态原样搬进 xuanpu。原则是：
+
+1. 小而确定的修复优先吸收。
+2. Codex 能力相关的上游改动只作为设计输入，按 xuanpu 当前架构重做。
+3. 与 Hive 品牌、Pet、Telegram、Jira、Ghostty 等强绑定的能力默认排除。
+
+## 最值得看
+
+### P0. 默认 allowlist 补齐只读操作
+
+参考 PR：[`#464`](https://github.com/morapelker/hive/pull/464)
+
+目标：
+
+- 在 command filter 默认配置里补充常见只读操作匹配。
+- 解决用户批准只读操作后，`grep` / `read` / `glob` 仍反复弹权限的问题。
+
+建议实现：
+
+- 在默认 `commandFilter.allowlist` 中加入：
+  - `read: **`
+  - `grep: * in *`
+  - `glob: *`
+- 保持现有 `edit: **`、`write: **` 默认项不变。
+- 不改变 blocklist、default behavior 和 security 开关语义。
+
+验收：
+
+- 新用户默认配置包含上述只读 pattern。
+- 旧 localStorage 设置 deep merge 后不会丢失新增默认字段。
+- command filter 单测覆盖 `read`、`grep: pattern in path`、`glob` 的自动批准路径。
+
+### P0. Run output URL 可点击
+
+参考 PR：[`#461`](https://github.com/morapelker/hive/pull/461)
+
+目标：
+
+- 在 Run output 中识别 HTTP/HTTPS URL。
+- 支持 Cmd/Ctrl hover 显示可点击状态。
+- 支持 Cmd/Ctrl click 用当前系统/Chrome 打开链接。
+- 普通点击、右键、无 modifier 点击不触发打开。
+
+建议实现：
+
+- 新增 URL 拆分工具，处理尾随标点、括号、ANSI 文本和普通文本混排。
+- 在 `RunOutputLine` 渲染正常输出时 linkify URL。
+- 搜索高亮优先级高于 URL linkify；有 search highlight 时保持现有高亮路径，避免两套 span 切分互相干扰。
+- 复用已有 `window.systemOps.openInChrome` 或当前项目已有打开链接能力，不新增主进程 IPC。
+
+验收：
+
+- `https://example.com` 渲染成可点击片段。
+- `https://example.com).` 只把真实 URL 部分识别为链接。
+- Cmd/Ctrl click 调用打开链接方法。
+- 普通 click 不调用打开链接方法。
+- ANSI 彩色输出在未搜索时仍能正常显示。
+
+### P0. follow-up 发送时刷新 last-message time
+
+参考 PR：[`#454`](https://github.com/morapelker/hive/pull/454)
+
+目标：
+
+- 用户发送 follow-up 时即时刷新 worktree / connection member 的 `last_message_at`。
+- 让 sidebar、recent list、pinned list 的活跃时间更贴近真实交互，而不是只依赖 session idle/completion。
+
+建议实现：
+
+- 抽一个轻量 helper，例如 `bumpWorktreeLastMessage`，集中处理：
+  - worktree-bound session
+  - connection-bound session 的成员 fan-out
+  - 缺少 worktree/connection 信息时 no-op
+- 在 session composer、kanban follow-up、auto-launch follow-up 等发送入口复用 helper。
+- 不改变现有 idle/completion 更新逻辑，只补发送时的及时更新。
+
+验收：
+
+- worktree session 发送 follow-up 后，该 worktree 的 `last_message_at` 更新。
+- connection session 发送 follow-up 后，connection 成员 worktree 的 `last_message_at` 更新。
+- 无 worktreeId / connectionId 的 board assistant 场景不报错。
+
+## 可关注
+
+### P1. Codex `/goal` 独立设计线
+
+参考 PR：
+
+- [`#456 Add Codex /goal feature support`](https://github.com/morapelker/hive/pull/456)
+- [`#462 Add goal mode support for ticket launches`](https://github.com/morapelker/hive/pull/462)
+- [`#463 Sync Codex goal state from global listener events`](https://github.com/morapelker/hive/pull/463)
+- [`#466 Add goal mode toggle for Codex handoffs`](https://github.com/morapelker/hive/pull/466)
+
+结论：
+
+- 这是近期上游最重要的 Codex 能力线。
+- `#456` 改动面很大，不适合 cherry-pick。
+- xuanpu 需要按当前 `SessionShell`、`AgentTimeline`、canonical agent event 和 Codex provider 链路重新设计。
+
+建议能力边界：
+
+- Codex 启动或 handoff 时可选择 `/goal`。
+- ticket launch 可携带 goal mode 和 success criteria。
+- Codex goal updated / cleared 事件进入 canonical event 流。
+- session timeline 能展示 goal 当前状态、目标、预算/耗时等关键信息。
+- goal 完成或清除后，UI 状态能回收，不残留过期目标。
+
+拆分建议：
+
+1. 事件与 provider 层：Codex schema / event mapper / implementer 支持 goal 事件。
+2. store 与 timeline 层：保存每个 session 的 goal state，并在 `AgentTimeline` 或对应卡片渲染。
+3. 入口层：handoff、ticket launch、session composer 的 goal mode toggle。
+
+### P2. Composer 输入性能优化
+
+参考 PR：[`#465 Reduce session composer re-renders on typing`](https://github.com/morapelker/hive/pull/465)
+
+结论：
+
+- 方向值得关注，但不能直接按 Hive 的旧 `SessionView` 结构搬。
+- xuanpu 当前已经有 `SessionShell` / `ComposerBar` 新结构，需先 profile 再改。
+
+建议：
+
+- 先用 React Profiler 或针对性 render count 测试确认输入时的主要 re-render 来源。
+- 只 memo 化稳定 leaf components，不把业务状态藏到难追踪的局部缓存里。
+- 保持 queue、steer、pending plan、attachment 等交互语义不变。
+
+### P2. Monaco hunk-focused diff view
+
+参考 PR：[`#451 Add hunk view for Monaco diffs`](https://github.com/morapelker/hive/pull/451)
+
+结论：
+
+- xuanpu 已有 Monaco diff、hunk action gutter、stage/unstage/revert hunk 能力。
+- 上游的价值主要在 hunk-focused view mode、隐藏上下文展开和评论区域保留。
+
+建议：
+
+- 不重复实现基础 hunk action。
+- 后续作为 diff review 体验升级：增加 split / inline / hunk 三态 view mode。
+- 与 PR comment gutter、file viewer tab state、diff prefs store 一起设计。
+
+### P2. PR notification 展示标题
+
+参考 PR：[`#457 Show PR title in notification widget`](https://github.com/morapelker/hive/pull/457)
+
+目标：
+
+- PR 创建或已有 PR 关联成功后，notification widget 除了状态外展示 PR title。
+
+建议：
+
+- 如果 xuanpu 当前 PR notification 信息不足，可作为小 polish 独立实现。
+- 字段命名保持简单，例如 `prTitle?: string`。
+- UI 中使用一行 muted/truncated 文案，避免挤占 notification 主信息。
+
+### P3. diff comments 与 copy plan
+
+参考 PR：
+
+- [`#437 Restore diff comments feature with full implementation`](https://github.com/morapelker/hive/pull/437)
+- [`#435 Add copy-to-clipboard functionality for plan markdown`](https://github.com/morapelker/hive/pull/435)
+
+结论：
+
+- 都有价值，但不进入近期默认实现。
+- diff comments 涉及 DB、IPC、diff anchor、side panel、session attachment，适合作为完整 review workflow 设计。
+- copy plan 是小功能，但要先确认 xuanpu 当前 plan FAB / ToolCall context menu 的产品语义。
+
+## 不建议投入
+
+以下上游改动本轮不建议进入 xuanpu backlog：
+
+- Hive Pet / first-pet hatch tip / pet drag 修复：
+  - [`#444`](https://github.com/morapelker/hive/pull/444)
+  - [`#446`](https://github.com/morapelker/hive/pull/446)
+  - [`#452`](https://github.com/morapelker/hive/pull/452)
+- Telegram plan forwarding：
+  - [`#467`](https://github.com/morapelker/hive/pull/467)
+  - 改动大、测试未跑，且不符合当前 xuanpu 近期方向。
+- Hive/Jira/Ghostty 专项 polish：
+  - 除非本地出现同类 bug，否则不主动吸收。
+
+## 实施顺序
+
+建议拆成三组 PR，不要混在一个大 PR：
+
+1. **PR A：低风险体验修复**
+   - 默认 allowlist 补只读操作。
+   - Run output URL linkify。
+   - follow-up 发送时刷新 `last_message_at`。
+
+2. **PR B：Codex `/goal` 设计与基础实现**
+   - 先补一份小设计或 PR 描述，锁定 canonical event shape。
+   - 实现 Codex goal event mapping、store 状态和 timeline 展示。
+
+3. **PR C：Codex `/goal` 入口补齐**
+   - handoff toggle。
+   - ticket launch goal mode。
+   - success criteria 输入与展示。
+
+P2/P3 项目不进入上述默认批次，等 PR A/B/C 完成后再回看。
+
+## 验证清单
+
+PR A 至少跑：
+
+```bash
+pnpm vitest run test/command-filter.test.ts test/run-pane-redesign/run-output-line.test.tsx
+```
+
+如果新增了 URL 工具或 last-message helper，需要补充并运行对应测试文件。
+
+Codex `/goal` PR 至少覆盖：
+
+- Codex event mapper: goal updated / cleared。
+- renderer store: session goal state set / clear。
+- timeline UI: active / paused / completed / cleared 状态渲染。
+- handoff / ticket launch: goal mode 只影响 Codex，不影响 Claude Code / OpenCode。
+
+最终合入前跑：
+
+```bash
+pnpm lint
+pnpm build
+```
+
+## 默认假设
+
+- 不直接 merge 或 cherry-pick 上游 Hive commit。
+- 不追更 20 条 release 之前的内容。
+- 不把 Hive 的 Pet、Telegram、品牌化 UI 作为 xuanpu 方向。
+- 当前已有 `package.json` 本地改动与本计划无关，后续实现时必须保持不动，除非对应 PR 明确需要依赖变更。

--- a/src/main/services/command-filter-service.ts
+++ b/src/main/services/command-filter-service.ts
@@ -40,7 +40,8 @@ export class CommandFilterService {
   /**
    * Split a bash command chain into individual sub-commands.
    * Properly handles quotes, heredocs, command substitutions, and escapes.
-   * Only splits on && at the top level (not inside strings or command substitutions).
+   * Only splits on top-level &&, ||, |, and ; operators (not inside strings or
+   * command substitutions).
    *
    * Handles:
    * - Single quotes ('...')
@@ -59,15 +60,14 @@ export class CommandFilterService {
     let inSingleQuote = false
     let inDoubleQuote = false
     let inBacktick = false
-    let commandSubDepth = 0  // Tracks $(...) nesting depth
+    let commandSubDepth = 0 // Tracks $(...) nesting depth
     let inHeredoc = false
     let heredocDelimiter = ''
-    let heredocIndented = false  // For <<- style heredocs
 
     // Stack to track quote state at each command substitution level
     // When we enter $(, we push current quote state and start fresh
     // When we exit ), we restore the previous quote state
-    const quoteStack: Array<{inSingleQuote: boolean; inDoubleQuote: boolean}> = []
+    const quoteStack: Array<{ inSingleQuote: boolean; inDoubleQuote: boolean }> = []
 
     while (i < command.length) {
       const char = command[i]
@@ -83,7 +83,6 @@ export class CommandFilterService {
 
           // Extract the delimiter
           let delimEnd = heredocStart
-          let quoted = false
 
           // Skip whitespace
           while (delimEnd < command.length && /\s/.test(command[delimEnd])) {
@@ -92,7 +91,6 @@ export class CommandFilterService {
 
           // Check if delimiter is quoted
           if (command[delimEnd] === "'" || command[delimEnd] === '"') {
-            quoted = true
             const quoteChar = command[delimEnd]
             delimEnd++
             const delimStart = delimEnd
@@ -106,8 +104,7 @@ export class CommandFilterService {
           } else {
             // Unquoted delimiter - ends at whitespace or special chars
             const delimStart = delimEnd
-            while (delimEnd < command.length &&
-                   !/[\s<>|;&()]/.test(command[delimEnd])) {
+            while (delimEnd < command.length && !/[\s<>|;&()]/.test(command[delimEnd])) {
               delimEnd++
             }
             heredocDelimiter = command.slice(delimStart, delimEnd)
@@ -115,7 +112,6 @@ export class CommandFilterService {
 
           if (heredocDelimiter) {
             inHeredoc = true
-            heredocIndented = isIndented
             // Add the heredoc start to current command
             current += command.slice(i, delimEnd)
             i = delimEnd
@@ -150,7 +146,6 @@ export class CommandFilterService {
               // Add only the delimiter to current (newline was already added in previous iteration)
               current += command.slice(i, delimiterEnd)
               heredocDelimiter = ''
-              heredocIndented = false
               i = delimiterEnd
               continue
             }
@@ -206,7 +201,7 @@ export class CommandFilterService {
       if (char === '$' && nextChar === '(' && !inSingleQuote) {
         commandSubDepth++
         // Push current quote state onto stack and reset quotes for the new context
-        quoteStack.push({inSingleQuote, inDoubleQuote})
+        quoteStack.push({ inSingleQuote, inDoubleQuote })
         inSingleQuote = false
         inDoubleQuote = false
         current += char
@@ -228,24 +223,32 @@ export class CommandFilterService {
         continue
       }
 
-      // Check for && operator (only when not in quotes/substitutions/heredocs)
-      if (char === '&' && nextChar === '&' &&
-          !inSingleQuote && !inDoubleQuote && !inBacktick &&
-          commandSubDepth === 0 && !inHeredoc) {
-        // Found a top-level &&
-        // Add current command if not empty
-        const trimmed = current.trim()
-        if (trimmed && trimmed !== '&&') { // Don't add standalone && as a command
-          result.push(trimmed)
+      // Check for top-level command separators.
+      if (!inSingleQuote && !inDoubleQuote && !inBacktick && commandSubDepth === 0 && !inHeredoc) {
+        const operatorLength =
+          char === '&' && nextChar === '&'
+            ? 2
+            : char === '|' && nextChar === '|'
+              ? 2
+              : char === '|' || char === ';'
+                ? 1
+                : 0
+
+        if (operatorLength > 0) {
+          // Add current command if not empty
+          const trimmed = current.trim()
+          if (trimmed) {
+            result.push(trimmed)
+          }
+          // Reset for next command
+          current = ''
+          // Skip the operator and any surrounding whitespace
+          i += operatorLength
+          while (i < command.length && /\s/.test(command[i])) {
+            i++
+          }
+          continue
         }
-        // Reset for next command
-        current = ''
-        // Skip the && and any surrounding whitespace
-        i += 2
-        while (i < command.length && /\s/.test(command[i])) {
-          i++
-        }
-        continue
       }
 
       // Add character to current command
@@ -255,7 +258,7 @@ export class CommandFilterService {
 
     // Add the last command if not empty
     const trimmed = current.trim()
-    if (trimmed && trimmed !== '&&') { // Don't add standalone && as a command
+    if (trimmed) {
       result.push(trimmed)
     }
 
@@ -377,10 +380,10 @@ export class CommandFilterService {
    */
   private matchPattern(command: string, pattern: string): boolean {
     try {
-      // For bash commands, * should match any character including /
-      // because command arguments regularly contain paths with slashes.
-      // The [^/]* behaviour is only useful for file-path patterns (edit:, read:, write:).
-      const isBashPattern = pattern.toLowerCase().startsWith('bash:')
+      // For direct file tools, * stays path-segment scoped. For command-like
+      // tools such as bash/grep/glob, arguments regularly contain paths with
+      // slashes, so * should match across /.
+      const isPathScopedPattern = /^(edit|read|write):/i.test(pattern)
 
       // Escape special regex characters except our wildcards
       const regexPattern = pattern
@@ -388,8 +391,8 @@ export class CommandFilterService {
         .replace(/\*\*/g, '__DOUBLESTAR__')
         // Escape other special regex chars
         .replace(/[.+?^${}()|[\]\\]/g, '\\$&')
-        // Convert * to regex — for bash patterns match everything, for file patterns exclude /
-        .replace(/\*/g, isBashPattern ? '.*' : '[^/]*')
+        // Convert * to regex — for file-path patterns exclude /, otherwise match everything
+        .replace(/\*/g, isPathScopedPattern ? '[^/]*' : '.*')
         // Convert ** back to regex (matches any sequence)
         .replace(/__DOUBLESTAR__/g, '.*')
 

--- a/src/renderer/src/components/layout/RunOutputLine.tsx
+++ b/src/renderer/src/components/layout/RunOutputLine.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import Ansi from 'ansi-to-react'
 import { parseAnsiSegments } from '@/lib/ansi-utils'
+import { hasHttpUrl, linkifyHttpUrls } from '@/lib/url-linkify'
 
 export interface SearchHighlight {
   /** Character offset where the match starts (in the stripped-ANSI plain text) */
@@ -66,6 +67,60 @@ function renderHighlightedLine(line: string, highlight: SearchHighlight): React.
   return <div className="whitespace-pre-wrap break-all">{parts}</div>
 }
 
+function RunOutputUrl({ text, url }: { text: string; url: string }): React.JSX.Element {
+  const [isModifierHover, setIsModifierHover] = React.useState(false)
+
+  const updateModifierHover = React.useCallback((event: React.MouseEvent<HTMLButtonElement>) => {
+    setIsModifierHover(event.metaKey || event.ctrlKey)
+  }, [])
+
+  const handleClick = React.useCallback(
+    (event: React.MouseEvent<HTMLButtonElement>) => {
+      if (!event.metaKey && !event.ctrlKey) return
+
+      event.preventDefault()
+      event.stopPropagation()
+      void window.systemOps.openInChrome(url)
+    },
+    [url]
+  )
+
+  return (
+    <button
+      type="button"
+      className={
+        isModifierHover
+          ? 'inline break-all cursor-pointer bg-transparent p-0 font-[inherit] text-primary underline'
+          : 'inline break-all cursor-text bg-transparent p-0 font-[inherit] text-inherit'
+      }
+      data-testid="run-output-url"
+      onClick={handleClick}
+      onContextMenu={(event) => event.stopPropagation()}
+      onMouseEnter={updateModifierHover}
+      onMouseLeave={() => setIsModifierHover(false)}
+      onMouseMove={updateModifierHover}
+    >
+      {text}
+    </button>
+  )
+}
+
+function renderLinkifiedLine(line: string): React.JSX.Element {
+  const parts = linkifyHttpUrls(line)
+
+  return (
+    <div className="whitespace-pre-wrap break-all [&_code]:all-unset">
+      {parts.map((part, index) => {
+        if (part.type === 'url') {
+          return <RunOutputUrl key={index} text={part.text} url={part.url} />
+        }
+
+        return <Ansi key={index}>{part.text}</Ansi>
+      })}
+    </div>
+  )
+}
+
 function RunOutputLineInner({ line, highlight }: RunOutputLineProps): React.JSX.Element {
   // Truncation marker
   if (line.startsWith('\x00TRUNC:')) {
@@ -89,6 +144,10 @@ function RunOutputLineInner({ line, highlight }: RunOutputLineProps): React.JSX.
   // Normal ANSI line — with or without highlight
   if (highlight) {
     return renderHighlightedLine(line, highlight)
+  }
+
+  if (hasHttpUrl(line)) {
+    return renderLinkifiedLine(line)
   }
 
   return (

--- a/src/renderer/src/components/session-hq/SessionShell.tsx
+++ b/src/renderer/src/components/session-hq/SessionShell.tsx
@@ -70,6 +70,7 @@ import {
 import { applySessionContextUsage } from '@/lib/context-usage'
 import { mapRawTranscriptToTimeline } from '@shared/lib/timeline-mappers'
 import { lastSendMode, messageSendTimes } from '@/lib/message-send-times'
+import { refreshSessionLastMessageAt } from '@/lib/session-last-message'
 import {
   getMessageDisplayContent,
   getUserMessageForkCutoff,
@@ -121,6 +122,9 @@ function useTimeline(
     agentSdk?: string | null
   }
 ) {
+  const worktreePath = options?.worktreePath
+  const opencodeSessionId = options?.opencodeSessionId
+  const agentSdk = options?.agentSdk
   // Restore optimistic messages from buffer on mount so they survive tab switches
   const initBuffer = getStreamingBuffer(sessionId)
   const [messages, setMessages] = useState<TimelineMessage[]>(
@@ -155,20 +159,21 @@ function useTimeline(
 
       const canFallbackToSdkMessages =
         Boolean(window.agentOps?.getMessages) &&
-        typeof options?.worktreePath === 'string' &&
-        options.worktreePath.length > 0 &&
-        typeof options?.opencodeSessionId === 'string' &&
-        options.opencodeSessionId.length > 0 &&
-        options.agentSdk !== 'codex' &&
-        options.agentSdk !== 'terminal'
+        typeof worktreePath === 'string' &&
+        worktreePath.length > 0 &&
+        typeof opencodeSessionId === 'string' &&
+        opencodeSessionId.length > 0 &&
+        agentSdk !== 'codex' &&
+        agentSdk !== 'terminal'
 
       if (!hasRenderableAssistant && canFallbackToSdkMessages) {
         try {
-          const transcript = await window.agentOps.getMessages(
-            options!.worktreePath!,
-            options!.opencodeSessionId!
-          )
-          if (transcript.success && Array.isArray(transcript.messages) && transcript.messages.length > 0) {
+          const transcript = await window.agentOps.getMessages(worktreePath!, opencodeSessionId!)
+          if (
+            transcript.success &&
+            Array.isArray(transcript.messages) &&
+            transcript.messages.length > 0
+          ) {
             const fallbackMessages = mapRawTranscriptToTimeline(transcript.messages)
             const fallbackHasAssistant = fallbackMessages.some(
               (msg) =>
@@ -225,7 +230,7 @@ function useTimeline(
     } finally {
       setLoading(false)
     }
-  }, [sessionId, options?.worktreePath, options?.opencodeSessionId, options?.agentSdk])
+  }, [sessionId, worktreePath, opencodeSessionId, agentSdk])
 
   useEffect(() => {
     setLoading(true)
@@ -519,7 +524,8 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
       sessionId,
       (current) => ({
         ...current,
-        optimisticMessages: optimisticRef.current.length > 0 ? [...optimisticRef.current] : undefined
+        optimisticMessages:
+          optimisticRef.current.length > 0 ? [...optimisticRef.current] : undefined
       }),
       { notify: 'immediate' }
     )
@@ -938,13 +944,27 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
                 async (wp, sid, message) => {
                   let messageParts: MessagePart[] | undefined
                   if (message.attachments.length > 0) {
-                    messageParts = await buildMessageParts(message.attachments as Attachment[], message.content)
+                    messageParts = await buildMessageParts(
+                      message.attachments as Attachment[],
+                      message.content
+                    )
                   }
-                  return window.agentOps.prompt(wp, sid, messageParts ?? message.content, requestModel, promptOptions)
+                  return window.agentOps.prompt(
+                    wp,
+                    sid,
+                    messageParts ?? message.content,
+                    requestModel,
+                    promptOptions
+                  )
                 },
                 worktreePath,
-                (sid, message) => useSessionRuntimeStore.getState().requeueMessageFront(sid, message)
-              ).catch((err) => console.error('[SessionShell] drainNextPending failed:', err))
+                (sid, message) =>
+                  useSessionRuntimeStore.getState().requeueMessageFront(sid, message)
+              )
+                .then((drained) => {
+                  if (drained) void refreshSessionLastMessageAt(sessionId)
+                })
+                .catch((err) => console.error('[SessionShell] drainNextPending failed:', err))
             }
           }
         }
@@ -1029,7 +1049,11 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
 
   // --- Composer action handler ---
   const handleComposerAction = useCallback(
-    async (action: ComposerAction, content: string, attachments: Attachment[]): Promise<boolean> => {
+    async (
+      action: ComposerAction,
+      content: string,
+      attachments: Attachment[]
+    ): Promise<boolean> => {
       if (!worktreePath || !droidSessionId) return false
       let optimisticMessageId: string | null = null
 
@@ -1113,12 +1137,17 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
         if (!consumed && (action === 'send' || action === 'stop_and_send')) {
           resetLiveOverlay(false)
         }
+        if (consumed) {
+          void refreshSessionLastMessageAt(sessionId)
+        }
 
         return consumed
       } catch (err) {
         console.error('[SessionShell] action failed:', err)
         if (optimisticMessageId) {
-          optimisticRef.current = optimisticRef.current.filter((msg) => msg.id !== optimisticMessageId)
+          optimisticRef.current = optimisticRef.current.filter(
+            (msg) => msg.id !== optimisticMessageId
+          )
           timelineMessagesRef.current = timelineMessagesRef.current.filter(
             (msg) => msg.id !== optimisticMessageId
           )
@@ -1146,11 +1175,11 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
 
   const canEditUserMessage = useCallback(
     (message: TimelineMessage) =>
-      message.role === 'user'
-      && message.id === lastUserMessageId
-      && !isStreaming
-      && lifecycle !== 'busy'
-      && lifecycle !== 'materializing',
+      message.role === 'user' &&
+      message.id === lastUserMessageId &&
+      !isStreaming &&
+      lifecycle !== 'busy' &&
+      lifecycle !== 'materializing',
     [lastUserMessageId, isStreaming, lifecycle]
   )
 
@@ -1178,8 +1207,8 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
 
       setMessages(trimmedMessages)
       timelineMessagesRef.current = trimmedMessages
-      optimisticRef.current = optimisticRef.current.filter(
-        (message) => trimmedMessages.some((candidate) => candidate.id === message.id)
+      optimisticRef.current = optimisticRef.current.filter((message) =>
+        trimmedMessages.some((candidate) => candidate.id === message.id)
       )
       syncOptimisticMessagesToMirror()
       setEditingMessageId(null)
@@ -1201,7 +1230,8 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
         const consumed = await executeSendAction('send', contentToSend, [], {
           worktreePath,
           sessionId: droidSessionId,
-          prompt: (wp, sid, content) => window.agentOps.prompt(wp, sid, content, requestModel, promptOptions),
+          prompt: (wp, sid, content) =>
+            window.agentOps.prompt(wp, sid, content, requestModel, promptOptions),
           abort: (wp, sid) => window.agentOps.abort(wp, sid),
           queueMessage: (sid, msg) => useSessionRuntimeStore.getState().queueMessage(sid, msg)
         })

--- a/src/renderer/src/hooks/useAgentEventBridge.ts
+++ b/src/renderer/src/hooks/useAgentEventBridge.ts
@@ -45,6 +45,7 @@ import {
 import { applySessionContextUsage } from '@/lib/context-usage'
 import { COMPLETION_WORDS } from '@/lib/format-utils'
 import { messageSendTimes } from '@/lib/message-send-times'
+import { refreshSessionLastMessageAt } from '@/lib/session-last-message'
 import { checkAutoApprove } from '@/lib/permissionUtils'
 import { toast } from 'sonner'
 import type { CanonicalAgentEvent } from '@shared/types/agent-protocol'
@@ -735,6 +736,7 @@ export function useAgentEventBridge(): void {
                 }
 
                 dispatchSucceeded = true
+                void refreshSessionLastMessageAt(sessionId)
               } catch {
                 useSessionStore.getState().requeueFollowUpMessageFront(sessionId, message)
                 markBackgroundSessionCompleted(sessionId)

--- a/src/renderer/src/lib/session-last-message.ts
+++ b/src/renderer/src/lib/session-last-message.ts
@@ -1,0 +1,72 @@
+import { useConnectionStore } from '@/stores/useConnectionStore'
+import { useSessionStore } from '@/stores/useSessionStore'
+import { useWorktreeStatusStore } from '@/stores/useWorktreeStatusStore'
+
+function refreshConnectionMembers(connectionId: string, timestamp: number): boolean {
+  const connection = useConnectionStore
+    .getState()
+    .connections.find((item) => item.id === connectionId)
+  if (!connection) return false
+
+  const statusStore = useWorktreeStatusStore.getState()
+  for (const member of connection.members) {
+    statusStore.setLastMessageTime(member.worktree_id, timestamp)
+  }
+  return true
+}
+
+function refreshFromStores(sessionId: string, timestamp: number): boolean {
+  const sessionState = useSessionStore.getState()
+  const statusStore = useWorktreeStatusStore.getState()
+
+  for (const [worktreeId, sessions] of sessionState.sessionsByWorktree) {
+    if (sessions.some((session) => session.id === sessionId)) {
+      statusStore.setLastMessageTime(worktreeId, timestamp)
+      return true
+    }
+  }
+
+  for (const [connectionId, sessions] of sessionState.sessionsByConnection) {
+    if (!sessions.some((session) => session.id === sessionId)) continue
+
+    return refreshConnectionMembers(connectionId, timestamp)
+  }
+
+  return false
+}
+
+async function refreshFromDatabase(sessionId: string, timestamp: number): Promise<void> {
+  if (typeof window === 'undefined' || !window.db?.session?.get) return
+
+  try {
+    const session = await window.db.session.get(sessionId)
+    if (!session) return
+
+    if (session.worktree_id) {
+      useWorktreeStatusStore.getState().setLastMessageTime(session.worktree_id, timestamp)
+      return
+    }
+
+    if (!session.connection_id) return
+
+    if (refreshConnectionMembers(session.connection_id, timestamp)) return
+
+    const result = await window.connectionOps?.get?.(session.connection_id)
+    if (!result?.success || !result.connection) return
+
+    const statusStore = useWorktreeStatusStore.getState()
+    for (const member of result.connection.members) {
+      statusStore.setLastMessageTime(member.worktree_id, timestamp)
+    }
+  } catch {
+    // Best-effort UI freshness helper; persistence failures should not break send paths.
+  }
+}
+
+export async function refreshSessionLastMessageAt(
+  sessionId: string,
+  timestamp = Date.now()
+): Promise<void> {
+  if (refreshFromStores(sessionId, timestamp)) return
+  await refreshFromDatabase(sessionId, timestamp)
+}

--- a/src/renderer/src/lib/url-linkify.ts
+++ b/src/renderer/src/lib/url-linkify.ts
@@ -1,0 +1,88 @@
+export type UrlLinkifyPart =
+  | { type: 'text'; text: string }
+  | { type: 'url'; text: string; url: string }
+
+// Stop before ANSI ESC as run output often colorizes URLs with SGR resets.
+// eslint-disable-next-line no-control-regex
+const URL_RE = /https?:\/\/[^\s<>"'\x1b]+/gi
+const TRAILING_PUNCTUATION = new Set(['.', ',', '!', '?', ';', ':'])
+const CLOSING_TO_OPENING: Record<string, string> = {
+  ')': '(',
+  ']': '[',
+  '}': '{'
+}
+
+function countChar(text: string, char: string): number {
+  let count = 0
+  for (const current of text) {
+    if (current === char) count++
+  }
+  return count
+}
+
+function splitTrailingUrlText(candidate: string): { url: string; trailing: string } {
+  let url = candidate
+  let trailing = ''
+
+  while (url.length > 0) {
+    const last = url.at(-1)
+    if (!last) break
+
+    if (TRAILING_PUNCTUATION.has(last)) {
+      trailing = last + trailing
+      url = url.slice(0, -1)
+      continue
+    }
+
+    const opening = CLOSING_TO_OPENING[last]
+    if (opening && countChar(url, last) > countChar(url, opening)) {
+      trailing = last + trailing
+      url = url.slice(0, -1)
+      continue
+    }
+
+    break
+  }
+
+  return { url, trailing }
+}
+
+export function linkifyHttpUrls(text: string): UrlLinkifyPart[] {
+  URL_RE.lastIndex = 0
+
+  const parts: UrlLinkifyPart[] = []
+  let lastIndex = 0
+  let match: RegExpExecArray | null
+
+  while ((match = URL_RE.exec(text)) !== null) {
+    if (match.index > lastIndex) {
+      parts.push({ type: 'text', text: text.slice(lastIndex, match.index) })
+    }
+
+    const candidate = match[0]
+    const { url, trailing } = splitTrailingUrlText(candidate)
+
+    if (url.length > 0) {
+      parts.push({ type: 'url', text: url, url })
+    } else {
+      parts.push({ type: 'text', text: candidate })
+    }
+
+    if (trailing.length > 0) {
+      parts.push({ type: 'text', text: trailing })
+    }
+
+    lastIndex = match.index + candidate.length
+  }
+
+  if (lastIndex < text.length) {
+    parts.push({ type: 'text', text: text.slice(lastIndex) })
+  }
+
+  return parts
+}
+
+export function hasHttpUrl(text: string): boolean {
+  URL_RE.lastIndex = 0
+  return URL_RE.test(text)
+}

--- a/src/renderer/src/stores/useSettingsStore.ts
+++ b/src/renderer/src/stores/useSettingsStore.ts
@@ -164,6 +164,8 @@ const DEFAULT_COMMAND_FILTER_ALLOWLIST = [
   'glob: *'
 ]
 
+const LEGACY_COMMAND_FILTER_ALLOWLIST = ['edit: **', 'write: **']
+
 const DEFAULT_SETTINGS: AppSettings = {
   locale: DEFAULT_LOCALE,
   autoStartSession: true,
@@ -220,14 +222,25 @@ const DEFAULT_SETTINGS: AppSettings = {
   sessionUiV2Enabled: true
 }
 
-function mergePatternList(defaultPatterns: string[], persistedPatterns?: string[]): string[] {
-  const merged = [...defaultPatterns]
-  for (const pattern of persistedPatterns ?? []) {
-    if (!merged.includes(pattern)) {
-      merged.push(pattern)
-    }
+function samePatternSet(left: string[], right: string[]): boolean {
+  if (left.length !== right.length) return false
+  const rightSet = new Set(right)
+  return left.every((pattern) => rightSet.has(pattern))
+}
+
+function resolveCommandFilterAllowlist(persistedPatterns?: string[]): string[] {
+  if (!persistedPatterns) {
+    return [...DEFAULT_SETTINGS.commandFilter.allowlist]
   }
-  return merged
+
+  if (
+    samePatternSet(persistedPatterns, LEGACY_COMMAND_FILTER_ALLOWLIST) ||
+    samePatternSet(persistedPatterns, DEFAULT_SETTINGS.commandFilter.allowlist)
+  ) {
+    return [...DEFAULT_SETTINGS.commandFilter.allowlist]
+  }
+
+  return [...persistedPatterns]
 }
 
 export function mergeCommandFilterSettings(
@@ -236,7 +249,7 @@ export function mergeCommandFilterSettings(
   return {
     ...DEFAULT_SETTINGS.commandFilter,
     ...(persisted || {}),
-    allowlist: mergePatternList(DEFAULT_SETTINGS.commandFilter.allowlist, persisted?.allowlist),
+    allowlist: resolveCommandFilterAllowlist(persisted?.allowlist),
     blocklist: persisted?.blocklist ?? DEFAULT_SETTINGS.commandFilter.blocklist
   }
 }

--- a/src/renderer/src/stores/useSettingsStore.ts
+++ b/src/renderer/src/stores/useSettingsStore.ts
@@ -156,6 +156,14 @@ export interface AppSettings {
   sessionUiV2Enabled: boolean
 }
 
+const DEFAULT_COMMAND_FILTER_ALLOWLIST = [
+  'edit: **',
+  'write: **',
+  'read: **',
+  'grep: * in *',
+  'glob: *'
+]
+
 const DEFAULT_SETTINGS: AppSettings = {
   locale: DEFAULT_LOCALE,
   autoStartSession: true,
@@ -188,7 +196,7 @@ const DEFAULT_SETTINGS: AppSettings = {
   skippedUpdateVersion: null,
   initialSetupComplete: false,
   commandFilter: {
-    allowlist: ['edit: **', 'write: **'],
+    allowlist: DEFAULT_COMMAND_FILTER_ALLOWLIST,
     blocklist: [
       'bash: rm -rf *',
       'bash: sudo rm *',
@@ -210,6 +218,27 @@ const DEFAULT_SETTINGS: AppSettings = {
   uiZoomLevel: 0,
   uiFontScale: 1,
   sessionUiV2Enabled: true
+}
+
+function mergePatternList(defaultPatterns: string[], persistedPatterns?: string[]): string[] {
+  const merged = [...defaultPatterns]
+  for (const pattern of persistedPatterns ?? []) {
+    if (!merged.includes(pattern)) {
+      merged.push(pattern)
+    }
+  }
+  return merged
+}
+
+export function mergeCommandFilterSettings(
+  persisted?: Partial<CommandFilterSettings> | null
+): CommandFilterSettings {
+  return {
+    ...DEFAULT_SETTINGS.commandFilter,
+    ...(persisted || {}),
+    allowlist: mergePatternList(DEFAULT_SETTINGS.commandFilter.allowlist, persisted?.allowlist),
+    blocklist: persisted?.blocklist ?? DEFAULT_SETTINGS.commandFilter.blocklist
+  }
 }
 
 interface SettingsState extends AppSettings {
@@ -266,12 +295,9 @@ async function loadSettingsFromDatabase(): Promise<AppSettings | null> {
         return {
           ...DEFAULT_SETTINGS,
           ...parsed,
-          // Deep-merge commandFilter so new fields (e.g. `enabled`) always have defaults
-          // even for users whose saved settings pre-date those fields being added.
-          commandFilter: {
-            ...DEFAULT_SETTINGS.commandFilter,
-            ...(parsed.commandFilter || {})
-          }
+          // Deep-merge commandFilter so new fields and new default allowlist
+          // patterns are present for users whose saved settings pre-date them.
+          commandFilter: mergeCommandFilterSettings(parsed.commandFilter)
         }
       }
     }
@@ -540,7 +566,15 @@ export const useSettingsStore = create<SettingsState>()(
         uiZoomLevel: state.uiZoomLevel,
         uiFontScale: state.uiFontScale,
         sessionUiV2Enabled: state.sessionUiV2Enabled
-      })
+      }),
+      merge: (persistedState, currentState) => {
+        const persisted = persistedState as Partial<SettingsState> | undefined
+        return {
+          ...currentState,
+          ...(persisted || {}),
+          commandFilter: mergeCommandFilterSettings(persisted?.commandFilter)
+        }
+      }
     }
   )
 )

--- a/test/command-filter.test.ts
+++ b/test/command-filter.test.ts
@@ -1,15 +1,14 @@
-import { describe, expect, test } from 'vitest'
+import { describe, expect, test, vi } from 'vitest'
 
 // Mock logger
-const mockLogger = {
+const mockLogger = vi.hoisted(() => ({
   info: () => {},
   warn: () => {},
   error: () => {},
   debug: () => {}
-}
+}))
 
 // Import and mock the logger before importing the service
-import { vi } from 'vitest'
 vi.mock('../src/main/services/logger', () => ({
   createLogger: () => mockLogger
 }))
@@ -65,19 +64,11 @@ describe('CommandFilterService', () => {
       }
 
       // Single command that matches
-      const result1 = service.evaluateToolUse(
-        'Bash',
-        { command: 'git commit -m "test"' },
-        settings
-      )
+      const result1 = service.evaluateToolUse('Bash', { command: 'git commit -m "test"' }, settings)
       expect(result1).toBe('allow')
 
       // Single command that doesn't match
-      const result2 = service.evaluateToolUse(
-        'Bash',
-        { command: 'git add .' },
-        settings
-      )
+      const result2 = service.evaluateToolUse('Bash', { command: 'git add .' }, settings)
       expect(result2).toBe('ask')
 
       // Chain where only one matches (should ask)
@@ -122,6 +113,32 @@ describe('CommandFilterService', () => {
     })
   })
 
+  describe('default read-only allowlist patterns', () => {
+    const settings = {
+      allowlist: ['edit: **', 'write: **', 'read: **', 'grep: * in *', 'glob: *'],
+      blocklist: [],
+      defaultBehavior: 'ask' as const,
+      enabled: true
+    }
+
+    test('allows read tools by default pattern', () => {
+      expect(service.evaluateToolUse('Read', { file_path: 'src/main.ts' }, settings)).toBe('allow')
+      expect(service.evaluateToolUse('Read', { path: '/tmp/project/README.md' }, settings)).toBe(
+        'allow'
+      )
+    })
+
+    test('allows grep tools by default pattern', () => {
+      expect(service.evaluateToolUse('Grep', { pattern: 'TODO', path: 'src/main' }, settings)).toBe(
+        'allow'
+      )
+    })
+
+    test('allows glob tools by default pattern', () => {
+      expect(service.evaluateToolUse('Glob', { pattern: '**/*.ts' }, settings)).toBe('allow')
+    })
+  })
+
   describe('splitBashChain', () => {
     test('splits on && || | and ;', () => {
       expect(service.splitBashChain('cmd1 && cmd2')).toEqual(['cmd1', 'cmd2'])
@@ -132,7 +149,8 @@ describe('CommandFilterService', () => {
     })
 
     test('handles complex git commit command', () => {
-      const cmd = 'git commit -m "Fix: Build Docker image for Linux/amd64 platform GKE requires Linux/amd64 images. Building on Apple Silicon without --platform flag creates arm64 images, causing \'no match for platform in manifest\' errors. Add --platform linux/amd64 to ensure the image works on GKE."'
+      const cmd =
+        'git commit -m "Fix: Build Docker image for Linux/amd64 platform GKE requires Linux/amd64 images. Building on Apple Silicon without --platform flag creates arm64 images, causing \'no match for platform in manifest\' errors. Add --platform linux/amd64 to ensure the image works on GKE."'
       expect(service.splitBashChain(cmd)).toEqual([cmd])
     })
 

--- a/test/phase-22/session-10/settings-runtime-migration.test.ts
+++ b/test/phase-22/session-10/settings-runtime-migration.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest'
-import { migrateSettingsShape } from '../../../src/renderer/src/stores/useSettingsStore'
+import {
+  mergeCommandFilterSettings,
+  migrateSettingsShape
+} from '../../../src/renderer/src/stores/useSettingsStore'
 
 describe('settings runtime migration', () => {
   it('migrates legacy defaultAgentSdk to defaultRuntimeId', () => {
@@ -20,5 +23,26 @@ describe('settings runtime migration', () => {
     })
 
     expect(migrated.defaultRuntimeId).toBe('claude-code')
+  })
+
+  it('adds new default read-only command filter patterns to existing allowlists', () => {
+    const merged = mergeCommandFilterSettings({
+      allowlist: ['bash: git status *'],
+      blocklist: ['bash: rm -rf *'],
+      defaultBehavior: 'ask',
+      enabled: true
+    })
+
+    expect(merged.allowlist).toEqual([
+      'edit: **',
+      'write: **',
+      'read: **',
+      'grep: * in *',
+      'glob: *',
+      'bash: git status *'
+    ])
+    expect(merged.blocklist).toEqual(['bash: rm -rf *'])
+    expect(merged.defaultBehavior).toBe('ask')
+    expect(merged.enabled).toBe(true)
   })
 })

--- a/test/phase-22/session-10/settings-runtime-migration.test.ts
+++ b/test/phase-22/session-10/settings-runtime-migration.test.ts
@@ -25,9 +25,9 @@ describe('settings runtime migration', () => {
     expect(migrated.defaultRuntimeId).toBe('claude-code')
   })
 
-  it('adds new default read-only command filter patterns to existing allowlists', () => {
+  it('upgrades the legacy default command filter allowlist', () => {
     const merged = mergeCommandFilterSettings({
-      allowlist: ['bash: git status *'],
+      allowlist: ['edit: **', 'write: **'],
       blocklist: ['bash: rm -rf *'],
       defaultBehavior: 'ask',
       enabled: true
@@ -38,9 +38,22 @@ describe('settings runtime migration', () => {
       'write: **',
       'read: **',
       'grep: * in *',
-      'glob: *',
-      'bash: git status *'
+      'glob: *'
     ])
+    expect(merged.blocklist).toEqual(['bash: rm -rf *'])
+    expect(merged.defaultBehavior).toBe('ask')
+    expect(merged.enabled).toBe(true)
+  })
+
+  it('preserves customized command filter allowlists', () => {
+    const merged = mergeCommandFilterSettings({
+      allowlist: ['bash: git status *'],
+      blocklist: ['bash: rm -rf *'],
+      defaultBehavior: 'ask',
+      enabled: true
+    })
+
+    expect(merged.allowlist).toEqual(['bash: git status *'])
     expect(merged.blocklist).toEqual(['bash: rm -rf *'])
     expect(merged.defaultBehavior).toBe('ask')
     expect(merged.enabled).toBe(true)

--- a/test/run-pane-redesign/run-output-line.test.tsx
+++ b/test/run-pane-redesign/run-output-line.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, test, vi } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
 import React from 'react'
 import {
   RunOutputLine,
@@ -14,9 +14,7 @@ vi.mock('ansi-to-react', () => ({
 describe('RunOutputLine', () => {
   describe('marker lines', () => {
     test('renders truncation marker with \x00TRUNC: prefix', () => {
-      const { container } = render(
-        <RunOutputLine line={'\x00TRUNC:[older output truncated]'} />
-      )
+      const { container } = render(<RunOutputLine line={'\x00TRUNC:[older output truncated]'} />)
       const div = container.firstChild as HTMLElement
       expect(div.textContent).toBe('[older output truncated]')
       expect(div.className).toContain('text-center')
@@ -25,16 +23,12 @@ describe('RunOutputLine', () => {
     })
 
     test('renders custom truncation message', () => {
-      const { container } = render(
-        <RunOutputLine line={'\x00TRUNC:500 lines omitted'} />
-      )
+      const { container } = render(<RunOutputLine line={'\x00TRUNC:500 lines omitted'} />)
       expect(container.textContent).toBe('500 lines omitted')
     })
 
     test('renders CMD marker with $ prefix', () => {
-      const { container } = render(
-        <RunOutputLine line={'\x00CMD:npm run dev'} />
-      )
+      const { container } = render(<RunOutputLine line={'\x00CMD:npm run dev'} />)
       const div = container.firstChild as HTMLElement
       expect(div.textContent).toBe('$ npm run dev')
       expect(div.className).toContain('font-semibold')
@@ -72,6 +66,98 @@ describe('RunOutputLine', () => {
       const ansi = screen.getByTestId('ansi')
       expect(ansi.textContent).toBe(ansiLine)
     })
+
+    test('does not include ANSI reset codes in URL target', () => {
+      const openInChrome = vi.mocked(window.systemOps.openInChrome)
+      openInChrome.mockClear()
+
+      render(<RunOutputLine line={'\x1b[36mhttps://example.com\x1b[0m'} />)
+      const url = screen.getByTestId('run-output-url')
+      fireEvent.click(url, { metaKey: true })
+
+      expect(url.textContent).toBe('https://example.com')
+      expect(openInChrome).toHaveBeenCalledWith('https://example.com')
+    })
+
+    test('linkifies HTTP and HTTPS URLs', () => {
+      const { container } = render(
+        <RunOutputLine line="open https://example.com and http://localhost:3000/path" />
+      )
+
+      const urls = screen.getAllByTestId('run-output-url')
+      expect(urls).toHaveLength(2)
+      expect(urls[0].textContent).toBe('https://example.com')
+      expect(urls[1].textContent).toBe('http://localhost:3000/path')
+      expect(container.textContent).toBe('open https://example.com and http://localhost:3000/path')
+    })
+
+    test('excludes trailing punctuation and unmatched closing brackets from URL target', () => {
+      render(<RunOutputLine line="preview (https://example.com/path)." />)
+
+      const url = screen.getByTestId('run-output-url')
+      expect(url.textContent).toBe('https://example.com/path')
+      expect(document.body.textContent).toBe('preview (https://example.com/path).')
+    })
+
+    test('keeps balanced closing brackets inside URL target', () => {
+      render(<RunOutputLine line="docs https://example.com/path(foo)" />)
+
+      const url = screen.getByTestId('run-output-url')
+      expect(url.textContent).toBe('https://example.com/path(foo)')
+    })
+
+    test('Cmd click opens URL in Chrome', () => {
+      const openInChrome = vi.mocked(window.systemOps.openInChrome)
+      openInChrome.mockClear()
+
+      render(<RunOutputLine line="visit https://example.com" />)
+      fireEvent.click(screen.getByTestId('run-output-url'), { metaKey: true })
+
+      expect(openInChrome).toHaveBeenCalledTimes(1)
+      expect(openInChrome).toHaveBeenCalledWith('https://example.com')
+    })
+
+    test('Ctrl click opens URL in Chrome', () => {
+      const openInChrome = vi.mocked(window.systemOps.openInChrome)
+      openInChrome.mockClear()
+
+      render(<RunOutputLine line="visit https://example.com" />)
+      fireEvent.click(screen.getByTestId('run-output-url'), { ctrlKey: true })
+
+      expect(openInChrome).toHaveBeenCalledTimes(1)
+      expect(openInChrome).toHaveBeenCalledWith('https://example.com')
+    })
+
+    test('plain click and right click do not open URL', () => {
+      const openInChrome = vi.mocked(window.systemOps.openInChrome)
+      openInChrome.mockClear()
+
+      render(<RunOutputLine line="visit https://example.com" />)
+      const url = screen.getByTestId('run-output-url')
+
+      fireEvent.click(url)
+      fireEvent.contextMenu(url)
+
+      expect(openInChrome).not.toHaveBeenCalled()
+    })
+
+    test('modifier hover is the only visibly openable URL state', () => {
+      render(<RunOutputLine line="visit https://example.com" />)
+      const url = screen.getByTestId('run-output-url')
+
+      expect(url.className).toContain('cursor-text')
+      expect(url.className).not.toContain('underline')
+
+      fireEvent.mouseEnter(url, { metaKey: true })
+
+      expect(url.className).toContain('cursor-pointer')
+      expect(url.className).toContain('underline')
+
+      fireEvent.mouseLeave(url)
+
+      expect(url.className).toContain('cursor-text')
+      expect(url.className).not.toContain('underline')
+    })
   })
 
   describe('highlighted lines', () => {
@@ -81,9 +167,7 @@ describe('RunOutputLine', () => {
         matchEnd: 11,
         isCurrent: false
       }
-      const { container } = render(
-        <RunOutputLine line="hello world foo" highlight={highlight} />
-      )
+      const { container } = render(<RunOutputLine line="hello world foo" highlight={highlight} />)
       const marks = container.querySelectorAll('mark')
       expect(marks).toHaveLength(1)
       expect(marks[0].textContent).toBe('world')
@@ -95,9 +179,7 @@ describe('RunOutputLine', () => {
         matchEnd: 5,
         isCurrent: true
       }
-      const { container } = render(
-        <RunOutputLine line="hello world" highlight={highlight} />
-      )
+      const { container } = render(<RunOutputLine line="hello world" highlight={highlight} />)
       const mark = container.querySelector('mark')!
       expect(mark.className).toContain('bg-yellow-400/80')
     })
@@ -108,9 +190,7 @@ describe('RunOutputLine', () => {
         matchEnd: 5,
         isCurrent: false
       }
-      const { container } = render(
-        <RunOutputLine line="hello world" highlight={highlight} />
-      )
+      const { container } = render(<RunOutputLine line="hello world" highlight={highlight} />)
       const mark = container.querySelector('mark')!
       expect(mark.className).toContain('bg-yellow-400/40')
     })
@@ -121,9 +201,7 @@ describe('RunOutputLine', () => {
         matchEnd: 11,
         isCurrent: false
       }
-      const { container } = render(
-        <RunOutputLine line="hello world" highlight={highlight} />
-      )
+      const { container } = render(<RunOutputLine line="hello world" highlight={highlight} />)
       const mark = container.querySelector('mark')!
       expect(mark.textContent).toBe('hello world')
       // No text outside the mark
@@ -137,9 +215,7 @@ describe('RunOutputLine', () => {
         matchEnd: 5,
         isCurrent: false
       }
-      const { container } = render(
-        <RunOutputLine line="hello world" highlight={highlight} />
-      )
+      const { container } = render(<RunOutputLine line="hello world" highlight={highlight} />)
       const mark = container.querySelector('mark')!
       expect(mark.textContent).toBe('hello')
       // The rest should be in a span
@@ -154,9 +230,7 @@ describe('RunOutputLine', () => {
         matchEnd: 11,
         isCurrent: false
       }
-      const { container } = render(
-        <RunOutputLine line="hello world" highlight={highlight} />
-      )
+      const { container } = render(<RunOutputLine line="hello world" highlight={highlight} />)
       const mark = container.querySelector('mark')!
       expect(mark.textContent).toBe('world')
       const spans = container.querySelectorAll('span')
@@ -172,9 +246,7 @@ describe('RunOutputLine', () => {
         matchEnd: 3,
         isCurrent: false
       }
-      const { container } = render(
-        <RunOutputLine line={line} highlight={highlight} />
-      )
+      const { container } = render(<RunOutputLine line={line} highlight={highlight} />)
       const mark = container.querySelector('mark')!
       expect(mark.textContent).toBe('red')
       // "red" is highlighted, " text" is not
@@ -188,10 +260,21 @@ describe('RunOutputLine', () => {
         matchEnd: 5,
         isCurrent: false
       }
-      render(
-        <RunOutputLine line="hello world" highlight={highlight} />
-      )
+      render(<RunOutputLine line="hello world" highlight={highlight} />)
       expect(screen.queryByTestId('ansi')).toBeNull()
+    })
+
+    test('highlighted line does not linkify URLs', () => {
+      const highlight: SearchHighlight = {
+        matchStart: 6,
+        matchEnd: 25,
+        isCurrent: false
+      }
+
+      render(<RunOutputLine line="visit https://example.com" highlight={highlight} />)
+
+      expect(screen.queryByTestId('run-output-url')).toBeNull()
+      expect(screen.getByText('https://example.com')).toBeInTheDocument()
     })
   })
 
@@ -209,9 +292,7 @@ describe('RunOutputLine', () => {
     })
 
     test('re-renders when line changes', () => {
-      const { container, rerender } = render(
-        <RunOutputLine line="first" />
-      )
+      const { container, rerender } = render(<RunOutputLine line="first" />)
       expect(container.textContent).toBe('first')
 
       rerender(<RunOutputLine line="second" />)
@@ -230,9 +311,7 @@ describe('RunOutputLine', () => {
         isCurrent: true
       }
 
-      const { container, rerender } = render(
-        <RunOutputLine line="hello" highlight={hl1} />
-      )
+      const { container, rerender } = render(<RunOutputLine line="hello" highlight={hl1} />)
       const mark1 = container.querySelector('mark')!
       expect(mark1.className).toContain('bg-yellow-400/40')
 

--- a/test/session-last-message/session-last-message.test.ts
+++ b/test/session-last-message/session-last-message.test.ts
@@ -1,0 +1,140 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { refreshSessionLastMessageAt } from '@/lib/session-last-message'
+
+const mocks = vi.hoisted(() => ({
+  sessionsByWorktree: new Map<string, Array<{ id: string }>>(),
+  sessionsByConnection: new Map<string, Array<{ id: string }>>(),
+  connections: [] as Array<{
+    id: string
+    members: Array<{ worktree_id: string }>
+  }>,
+  setLastMessageTime: vi.fn(),
+  dbSessionGet: vi.fn(),
+  connectionGet: vi.fn()
+}))
+
+vi.mock('@/stores/useSessionStore', () => ({
+  useSessionStore: {
+    getState: () => ({
+      sessionsByWorktree: mocks.sessionsByWorktree,
+      sessionsByConnection: mocks.sessionsByConnection
+    })
+  }
+}))
+
+vi.mock('@/stores/useConnectionStore', () => ({
+  useConnectionStore: {
+    getState: () => ({
+      connections: mocks.connections
+    })
+  }
+}))
+
+vi.mock('@/stores/useWorktreeStatusStore', () => ({
+  useWorktreeStatusStore: {
+    getState: () => ({
+      setLastMessageTime: mocks.setLastMessageTime
+    })
+  }
+}))
+
+describe('refreshSessionLastMessageAt', () => {
+  beforeEach(() => {
+    mocks.sessionsByWorktree.clear()
+    mocks.sessionsByConnection.clear()
+    mocks.connections.length = 0
+    mocks.setLastMessageTime.mockClear()
+    mocks.dbSessionGet.mockReset()
+    mocks.dbSessionGet.mockResolvedValue(null)
+    mocks.connectionGet.mockReset()
+    mocks.connectionGet.mockResolvedValue({ success: false })
+
+    Object.defineProperty(window, 'db', {
+      configurable: true,
+      writable: true,
+      value: {
+        session: {
+          get: mocks.dbSessionGet
+        }
+      }
+    })
+
+    Object.defineProperty(window, 'connectionOps', {
+      configurable: true,
+      writable: true,
+      value: {
+        get: mocks.connectionGet
+      }
+    })
+  })
+
+  test('updates a worktree-bound session worktree', async () => {
+    mocks.sessionsByWorktree.set('wt-1', [{ id: 'session-1' }])
+
+    await refreshSessionLastMessageAt('session-1', 1234)
+
+    expect(mocks.setLastMessageTime).toHaveBeenCalledTimes(1)
+    expect(mocks.setLastMessageTime).toHaveBeenCalledWith('wt-1', 1234)
+    expect(mocks.dbSessionGet).not.toHaveBeenCalled()
+  })
+
+  test('fans out a connection-bound session to all connection members', async () => {
+    mocks.sessionsByConnection.set('conn-1', [{ id: 'session-2' }])
+    mocks.connections.push({
+      id: 'conn-1',
+      members: [{ worktree_id: 'wt-1' }, { worktree_id: 'wt-2' }]
+    })
+
+    await refreshSessionLastMessageAt('session-2', 5678)
+
+    expect(mocks.setLastMessageTime).toHaveBeenCalledTimes(2)
+    expect(mocks.setLastMessageTime).toHaveBeenNthCalledWith(1, 'wt-1', 5678)
+    expect(mocks.setLastMessageTime).toHaveBeenNthCalledWith(2, 'wt-2', 5678)
+    expect(mocks.dbSessionGet).not.toHaveBeenCalled()
+  })
+
+  test('falls back to the database for an unloaded worktree-bound session', async () => {
+    mocks.dbSessionGet.mockResolvedValue({
+      id: 'session-db',
+      worktree_id: 'wt-db',
+      connection_id: null
+    })
+
+    await refreshSessionLastMessageAt('session-db', 4321)
+
+    expect(mocks.dbSessionGet).toHaveBeenCalledWith('session-db')
+    expect(mocks.setLastMessageTime).toHaveBeenCalledTimes(1)
+    expect(mocks.setLastMessageTime).toHaveBeenCalledWith('wt-db', 4321)
+  })
+
+  test('falls back to connectionOps for an unloaded connection-bound session', async () => {
+    mocks.dbSessionGet.mockResolvedValue({
+      id: 'session-db-conn',
+      worktree_id: null,
+      connection_id: 'conn-db'
+    })
+    mocks.connectionGet.mockResolvedValue({
+      success: true,
+      connection: {
+        id: 'conn-db',
+        members: [{ worktree_id: 'wt-a' }, { worktree_id: 'wt-b' }]
+      }
+    })
+
+    await refreshSessionLastMessageAt('session-db-conn', 8765)
+
+    expect(mocks.connectionGet).toHaveBeenCalledWith('conn-db')
+    expect(mocks.setLastMessageTime).toHaveBeenCalledTimes(2)
+    expect(mocks.setLastMessageTime).toHaveBeenNthCalledWith(1, 'wt-a', 8765)
+    expect(mocks.setLastMessageTime).toHaveBeenNthCalledWith(2, 'wt-b', 8765)
+  })
+
+  test('no-ops when binding information is missing', async () => {
+    mocks.sessionsByConnection.set('conn-missing', [{ id: 'session-3' }])
+
+    await refreshSessionLastMessageAt('session-3', 9999)
+    await refreshSessionLastMessageAt('unknown-session', 9999)
+
+    expect(mocks.setLastMessageTime).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary

This is PR 1 for the shared v1.4.7 Hive-upstream follow-up batch. It intentionally does not bump `package.json`.

- Add default read-only command filter allowlist patterns for `read`, `grep`, and `glob`, including migration-safe merging for existing persisted settings.
- Linkify HTTP/HTTPS URLs in Run output with Cmd/Ctrl hover and Cmd/Ctrl click opening through `systemOps.openInChrome`; normal clicks and right-clicks remain inert.
- Refresh worktree activity time when follow-up messages are sent, queued, drained, steered, or background-dispatched, including connection member fan-out and DB fallback.

## Verification

- `pnpm vitest run test/command-filter.test.ts test/phase-22/session-10/settings-runtime-migration.test.ts test/run-pane-redesign/run-output-line.test.tsx test/session-last-message/session-last-message.test.ts test/phase-15/session-7/last-message-time-store.test.ts`
- `pnpm lint` — passes with existing repository warnings only.
- `pnpm build`

## Versioning

All PRs in this batch are intended for v1.4.7. Version bump/release notes should happen once the stacked batch is complete.
