### PR TITLE
v1.4.7 PR 3: Codex goal launch entries

### DIFF
--- a/src/main/ipc/agent-handlers.ts
+++ b/src/main/ipc/agent-handlers.ts
@@ -82,6 +82,46 @@ function prependToMessage<T extends MessageOrParts>(m: T, prefix: string): T {
   return copy as unknown as T
 }
 
+function parsePromptOptions(
+  rawOptions: Record<string, unknown> | undefined
+): PromptOptions | undefined {
+  if (!rawOptions) return undefined
+
+  const options: PromptOptions = {}
+  if (typeof rawOptions.codexFastMode === 'boolean') {
+    options.codexFastMode = rawOptions.codexFastMode
+  }
+  if (rawOptions.mode === 'build' || rawOptions.mode === 'plan') {
+    options.mode = rawOptions.mode
+  }
+  if (typeof rawOptions.goalMode === 'boolean') {
+    options.goalMode = rawOptions.goalMode
+  }
+  if (typeof rawOptions.successCriteria === 'string') {
+    const successCriteria = rawOptions.successCriteria.trim()
+    if (successCriteria) {
+      options.successCriteria = successCriteria
+    }
+  }
+
+  return Object.keys(options).length > 0 ? options : undefined
+}
+
+function buildGoalObjective(promptText: string, successCriteria?: string): string {
+  const objective = promptText.trim()
+  const criteria = successCriteria?.trim() ?? ''
+
+  if (!objective) {
+    return criteria ? `Success criteria:\n${criteria}` : ''
+  }
+
+  if (!criteria) {
+    return objective
+  }
+
+  return `${objective}\n\nSuccess criteria:\n${criteria}`
+}
+
 // Dedupe concurrent agent:connect calls per hive session. React StrictMode
 // double-invokes the renderer effect in dev, and stray callers may also retry —
 // without dedupe each call spins up a fresh runtime session (e.g. an extra
@@ -226,16 +266,7 @@ export function registerAgentHandlers(
               variant: typeof rawModel.variant === 'string' ? rawModel.variant : undefined
             }
           }
-          const rawOptions = obj.options as Record<string, unknown> | undefined
-          if (rawOptions) {
-            options = {}
-            if (typeof rawOptions.codexFastMode === 'boolean') {
-              options.codexFastMode = rawOptions.codexFastMode
-            }
-            if (rawOptions.mode === 'build' || rawOptions.mode === 'plan') {
-              options.mode = rawOptions.mode
-            }
-          }
+          options = parsePromptOptions(obj.options as Record<string, unknown> | undefined)
         } else {
           // Legacy positional args: (worktreePath, sessionId, message)
           worktreePath = args[0] as string
@@ -253,16 +284,7 @@ export function registerAgentHandlers(
               variant: typeof rawModel.variant === 'string' ? rawModel.variant : undefined
             }
           }
-          const rawOptions = args[4] as Record<string, unknown> | undefined
-          if (rawOptions) {
-            options = {}
-            if (typeof rawOptions.codexFastMode === 'boolean') {
-              options.codexFastMode = rawOptions.codexFastMode
-            }
-            if (rawOptions.mode === 'build' || rawOptions.mode === 'plan') {
-              options.mode = rawOptions.mode
-            }
-          }
+          options = parsePromptOptions(args[4] as Record<string, unknown> | undefined)
         }
 
         // Phase 22A: inject Field Context (working memory snapshot) as a prefix
@@ -278,6 +300,16 @@ export function registerAgentHandlers(
         //   3. Slash commands (/using-superpowers, /compact, /init, ...) are
         //      SDK internals. Prefixing them breaks SDK command detection.
         const originalMessage = messageOrParts
+
+        if (options?.goalMode) {
+          const goalObjective = buildGoalObjective(
+            getFirstText(originalMessage) ?? '',
+            options.successCriteria
+          )
+          if (goalObjective) {
+            options = { ...options, goalObjective }
+          }
+        }
 
         const firstTextRaw = getFirstText(messageOrParts)?.trimStart()
         const isSlashCommand = firstTextRaw?.startsWith('/') ?? false

--- a/src/main/services/agent-runtime-types.ts
+++ b/src/main/services/agent-runtime-types.ts
@@ -18,6 +18,12 @@ export interface PromptOptions {
   codexFastMode?: boolean
   /** Session mode — used by OpenCode to select the agent (e.g. 'plan' → agent:'plan') */
   mode?: 'build' | 'plan'
+  /** Codex-only: set an app-server thread goal before starting the next turn. */
+  goalMode?: boolean
+  /** Codex-only: optional success criteria appended to the goal objective. */
+  successCriteria?: string
+  /** Main-process internal objective derived before Field Context injection. */
+  goalObjective?: string
 }
 
 export interface AgentRuntimeAdapter {

--- a/src/main/services/codex-app-server-manager.ts
+++ b/src/main/services/codex-app-server-manager.ts
@@ -121,6 +121,18 @@ export interface CodexTurnStartResult {
   resumeCursor?: string
 }
 
+// ── Thread goal input ─────────────────────────────────────────────
+
+export interface CodexThreadGoalSetInput {
+  objective: string
+  status?: string
+  tokenBudget?: number | null
+}
+
+export interface CodexThreadGoalSetResponse {
+  goal?: unknown
+}
+
 // ── Event types ───────────────────────────────────────────────────
 
 export interface CodexManagerEvent {
@@ -625,6 +637,27 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
       threadId: context.session.threadId,
       ...(resumeCursor ? { resumeCursor } : {})
     }
+  }
+
+  async setThreadGoal(
+    threadId: string,
+    input: CodexThreadGoalSetInput
+  ): Promise<CodexThreadGoalSetResponse> {
+    const context = this.sessions.get(threadId)
+    if (!context) {
+      throw new Error(`setThreadGoal: no session found for threadId=${threadId}`)
+    }
+
+    if (!context.session.threadId) {
+      throw new Error('setThreadGoal: session has no threadId')
+    }
+
+    return this.sendRequest<CodexThreadGoalSetResponse>(context, 'thread/goal/set', {
+      threadId: context.session.threadId,
+      objective: input.objective,
+      status: input.status ?? 'active',
+      tokenBudget: input.tokenBudget ?? null
+    })
   }
 
   async steerTurn(threadId: string, input: CodexTurnInput, turnId?: string): Promise<void> {

--- a/src/main/services/codex-implementer.ts
+++ b/src/main/services/codex-implementer.ts
@@ -113,6 +113,21 @@ function extractProposedPlanMarkdown(text: string): string | null {
   return match ? (match[1]?.trim() ?? null) : null
 }
 
+function buildCodexGoalObjective(promptText: string, successCriteria?: string): string {
+  const objective = promptText.trim()
+  const criteria = successCriteria?.trim() ?? ''
+
+  if (!objective) {
+    return criteria ? `Success criteria:\n${criteria}` : ''
+  }
+
+  if (!criteria) {
+    return objective
+  }
+
+  return `${objective}\n\nSuccess criteria:\n${criteria}`
+}
+
 // ── Immediate title helpers ────────────────────────────────────────────────
 
 const IMMEDIATE_TITLE_LENGTH = 50
@@ -899,6 +914,20 @@ export class CodexImplementer implements AgentSdkImplementer, AgentRuntimeAdapte
         } catch {
           // Fall through to default mode
         }
+      }
+
+      if (options?.goalMode) {
+        const objective =
+          options.goalObjective?.trim() || buildCodexGoalObjective(text, options.successCriteria)
+        if (!objective) {
+          throw new Error('Codex goal mode requires a non-empty objective')
+        }
+
+        await this.manager.setThreadGoal(session.threadId, {
+          objective,
+          status: 'active',
+          tokenBudget: null
+        })
       }
 
       await this.manager.sendTurn(session.threadId, {

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -586,7 +586,12 @@ declare global {
         sessionId: string,
         messageOrParts: string | MessagePart[],
         model?: { providerID: string; modelID: string; variant?: string },
-        options?: { codexFastMode?: boolean; mode?: 'build' | 'plan' }
+        options?: {
+          codexFastMode?: boolean
+          mode?: 'build' | 'plan'
+          goalMode?: boolean
+          successCriteria?: string
+        }
       ) => Promise<import('../shared/types/agent-ipc').AgentIpcResult>
       // Abort a streaming session
       abort: (

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1206,7 +1206,12 @@ const agentOps = {
           | { type: 'file'; mime: string; url: string; filename?: string }
         >,
     model?: { providerID: string; modelID: string; variant?: string },
-    options?: { codexFastMode?: boolean; mode?: 'build' | 'plan' }
+    options?: {
+      codexFastMode?: boolean
+      mode?: 'build' | 'plan'
+      goalMode?: boolean
+      successCriteria?: string
+    }
   ): Promise<{ success: boolean; error?: string }> => {
     const parts =
       typeof messageOrParts === 'string'

--- a/src/renderer/src/components/session-hq/ComposerBar.tsx
+++ b/src/renderer/src/components/session-hq/ComposerBar.tsx
@@ -56,6 +56,12 @@ export interface ComposerBarProps {
   onToggleMode?: () => void
   /** Pending plan (truthy means plan is ready for review) */
   pendingPlan?: unknown | null
+  /** Codex-only goal launch controls */
+  supportsGoalMode?: boolean
+  goalMode?: boolean
+  onToggleGoalMode?: () => void
+  successCriteria?: string
+  onSuccessCriteriaChange?: (value: string) => void
   /** Worktree path for slash command fetching */
   worktreePath?: string | null
   /** Bumped when session.commands_available fires — triggers re-fetch of SDK commands */
@@ -111,6 +117,11 @@ export function ComposerBar({
   mode = 'build',
   onToggleMode,
   pendingPlan,
+  supportsGoalMode = false,
+  goalMode = false,
+  onToggleGoalMode,
+  successCriteria = '',
+  onSuccessCriteriaChange,
   worktreePath,
   commandsVersion = 0,
   containerRef
@@ -330,6 +341,8 @@ export function ComposerBar({
   const alternativesEnabled =
     availableAlternatives.length > 0 &&
     (canSend || availableAlternatives.includes('stop_and_send'))
+  const showGoalControls = supportsGoalMode && !pendingPlan && onToggleGoalMode
+  const showSuccessCriteria = showGoalControls && goalMode
 
   return (
     <div
@@ -389,6 +402,26 @@ export function ComposerBar({
         />
       </div>
 
+      {showSuccessCriteria && (
+        <div className="px-4 pb-1">
+          <textarea
+            value={successCriteria}
+            onChange={(e) => onSuccessCriteriaChange?.(e.target.value)}
+            placeholder="Success criteria..."
+            disabled={isDisabled}
+            className={cn(
+              'w-full resize-none rounded-md border border-border/60 bg-background/45 px-2.5 py-1.5',
+              'text-xs placeholder:text-muted-foreground',
+              'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring/45',
+              'disabled:cursor-not-allowed disabled:opacity-50',
+              'min-h-[32px] max-h-[88px]'
+            )}
+            rows={1}
+            data-testid="composer-success-criteria"
+          />
+        </div>
+      )}
+
       {/* Bottom row: attach + plan + spacer + send */}
       <div className="flex items-center gap-2 px-3 pb-3 pt-1">
         <AttachmentButton
@@ -416,6 +449,26 @@ export function ComposerBar({
             title="Toggle Plan Mode (Tab)"
           >
             Plan
+          </Button>
+        ) : null}
+
+        {showGoalControls ? (
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className={cn(
+              'h-7 rounded-full border px-2.5 text-xs font-medium transition-[color,background-color,border-color,box-shadow]',
+              goalMode
+                ? 'border-emerald-300/80 bg-emerald-500/10 text-emerald-700 shadow-[0_0_0_1px_rgba(110,231,183,0.22),0_0_12px_rgba(16,185,129,0.16)] hover:bg-emerald-500/14 hover:text-emerald-800 dark:border-emerald-400/45 dark:bg-emerald-500/12 dark:text-emerald-200 dark:shadow-[0_0_0_1px_rgba(52,211,153,0.2),0_0_14px_rgba(5,150,105,0.16)]'
+                : 'border-border/70 bg-background/65 text-muted-foreground shadow-none hover:border-border hover:bg-background/85 hover:text-foreground'
+            )}
+            onClick={onToggleGoalMode}
+            aria-pressed={goalMode}
+            title="Toggle Goal Mode"
+            data-testid="composer-goal-toggle"
+          >
+            Goal
           </Button>
         ) : null}
 

--- a/src/renderer/src/components/session-hq/SessionShell.tsx
+++ b/src/renderer/src/components/session-hq/SessionShell.tsx
@@ -284,6 +284,12 @@ export interface SessionShellProps {
   sessionId: string
 }
 
+type RendererPromptOptions = {
+  mode?: 'build' | 'plan'
+  goalMode?: boolean
+  successCriteria?: string
+}
+
 export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Element {
   const { t } = useI18n()
   // --- Data sources ---
@@ -373,6 +379,8 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
   // --- Plan mode ---
   const mode = useSessionStore((s) => s.modeBySession?.get(sessionId) ?? 'build')
   const pendingPlan = useSessionStore((s) => s.pendingPlans?.get(sessionId) ?? null)
+  const [goalMode, setGoalMode] = useState(false)
+  const [successCriteria, setSuccessCriteria] = useState('')
   // Claude Code's ExitPlanMode tool_use.input.plan is usually empty — the SDK
   // writes the plan to disk and we read it during canUseTool, then ship it via
   // plan.ready. Expose it by tool_use id so PlanCard can render the real text.
@@ -385,6 +393,14 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
   }, [pendingPlan?.toolUseID, pendingPlan?.planContent])
   const toggleMode = useCallback(() => {
     useSessionStore.getState().toggleSessionMode(sessionId)
+  }, [sessionId])
+  const toggleGoalMode = useCallback(() => {
+    setGoalMode((current) => !current)
+  }, [])
+
+  useEffect(() => {
+    setGoalMode(false)
+    setSuccessCriteria('')
   }, [sessionId])
 
   // --- Cost / tokens ---
@@ -486,15 +502,17 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
 
     return resolvedModel ?? undefined
   }, [resolvedModel, sessionRecord?.model_provider_id, sessionRecord?.model_id])
-  // Phase 1.4.8: OpenCode's plan agent only activates when the prompt body
-  // carries `agent: 'plan'`, which opencode-service.prompt() derives from
-  // PromptOptions.mode. Build the options object here so every send path
-  // (first prompt / queued drain / follow-up / proposed-plan implement)
-  // consistently passes the live session mode.
-  const promptOptions = useMemo(
-    () => (agentSdk === 'opencode' ? { mode } : undefined),
-    [agentSdk, mode]
-  )
+  // Build prompt options once so every send path (first prompt / queued drain /
+  // follow-up / proposed-plan implement) sees the same runtime-specific flags.
+  const promptOptions = useMemo<RendererPromptOptions | undefined>(() => {
+    if (agentSdk === 'codex') {
+      return { goalMode, successCriteria }
+    }
+    if (agentSdk === 'opencode') {
+      return { mode }
+    }
+    return undefined
+  }, [agentSdk, goalMode, mode, successCriteria])
   const currentModelId = resolvedModel?.modelID ?? ''
   const currentProviderId = resolvedModel?.providerID ?? ''
   const skipForkFromMessageConfirm = useSettingsStore((s) => s.skipForkFromMessageConfirm)
@@ -1611,6 +1629,11 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
           mode={mode}
           onToggleMode={toggleMode}
           pendingPlan={pendingPlan}
+          supportsGoalMode={agentSdk === 'codex'}
+          goalMode={goalMode}
+          onToggleGoalMode={toggleGoalMode}
+          successCriteria={successCriteria}
+          onSuccessCriteriaChange={setSuccessCriteria}
           worktreePath={worktreePath}
           commandsVersion={commandsVersion}
         />

--- a/test/phase-22/session-5/codex-app-server-manager.test.ts
+++ b/test/phase-22/session-5/codex-app-server-manager.test.ts
@@ -301,9 +301,7 @@ describe('CodexAppServerManager — collaborationMode in sendTurn', () => {
     ])
     expect(params.settings.reasoningEffort).toBe('low')
     expect(params.collaborationMode.mode).toBe('default')
-    expect(params.collaborationMode.settings.developer_instructions).toBe(
-      'Title only instructions'
-    )
+    expect(params.collaborationMode.settings.developer_instructions).toBe('Title only instructions')
     expect(params.collaborationMode.settings.reasoning_effort).toBe('low')
   })
 })
@@ -347,10 +345,7 @@ describe('CodexAppServerManager.steerTurn', () => {
       input: [{ type: 'text', text: 'course correct' }]
     })
 
-    manager.handleStdoutLine(
-      context,
-      JSON.stringify({ id: steerMsg.id, result: { ok: true } })
-    )
+    manager.handleStdoutLine(context, JSON.stringify({ id: steerMsg.id, result: { ok: true } }))
 
     await steerPromise
   })
@@ -369,11 +364,64 @@ describe('CodexAppServerManager.steerTurn', () => {
     const steerMsg = messages.find((message: any) => message.method === 'turn/steer')
     expect(steerMsg?.params.turnId).toBe('turn-override-9')
 
-    manager.handleStdoutLine(
-      context,
-      JSON.stringify({ id: steerMsg.id, result: { ok: true } })
-    )
+    manager.handleStdoutLine(context, JSON.stringify({ id: steerMsg.id, result: { ok: true } }))
 
     await steerPromise
+  })
+})
+
+describe('CodexAppServerManager.setThreadGoal', () => {
+  let manager: CodexAppServerManager
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    manager = new CodexAppServerManager()
+  })
+
+  afterEach(() => {
+    manager.stopAll()
+    manager.removeAllListeners()
+  })
+
+  function seedSession(context: CodexSessionContext): void {
+    const sessionsMap = (manager as any).sessions as Map<string, CodexSessionContext>
+    sessionsMap.set(context.session.threadId!, context)
+  }
+
+  function getWrittenMessages(stdin: { write: ReturnType<typeof vi.fn> }): any[] {
+    return stdin.write.mock.calls.map((call: any[]) => JSON.parse((call[0] as string).trim()))
+  }
+
+  it('sends thread/goal/set with an active goal objective', async () => {
+    const { context, stdin } = createTestContext()
+    seedSession(context)
+
+    const goalPromise = manager.setThreadGoal('thread-123', {
+      objective: 'Finish migration',
+      status: 'active',
+      tokenBudget: null
+    })
+
+    const messages = getWrittenMessages(stdin)
+    const goalMsg = messages.find((message: any) => message.method === 'thread/goal/set')
+    expect(goalMsg).toBeDefined()
+    expect(goalMsg.params).toEqual({
+      threadId: 'thread-123',
+      objective: 'Finish migration',
+      status: 'active',
+      tokenBudget: null
+    })
+
+    manager.handleStdoutLine(
+      context,
+      JSON.stringify({
+        id: goalMsg.id,
+        result: { goal: { objective: 'Finish migration', status: 'active' } }
+      })
+    )
+
+    await expect(goalPromise).resolves.toEqual({
+      goal: { objective: 'Finish migration', status: 'active' }
+    })
   })
 })

--- a/test/phase-22/session-5/codex-prompt-streaming.test.ts
+++ b/test/phase-22/session-5/codex-prompt-streaming.test.ts
@@ -1,6 +1,24 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
+vi.mock('electron', () => ({
+  BrowserWindow: vi.fn(),
+  Notification: vi.fn().mockImplementation(() => ({
+    show: vi.fn(),
+    on: vi.fn()
+  })),
+  app: {
+    getName: vi.fn(() => 'Xuanpu'),
+    getPath: vi.fn(() => '/tmp')
+  },
+  nativeImage: {
+    createFromPath: vi.fn(() => ({
+      isEmpty: vi.fn(() => false),
+      resize: vi.fn()
+    }))
+  }
+}))
+
 // Mock logger
 vi.mock('../../../src/main/services/logger', () => ({
   createLogger: () => ({
@@ -32,6 +50,7 @@ vi.mock('../../../src/main/services/codex-app-server-manager', () => {
     hasSession: vi.fn().mockReturnValue(false),
     getSession: vi.fn(),
     listSessions: vi.fn().mockReturnValue([]),
+    setThreadGoal: vi.fn(),
     sendTurn: vi.fn(),
     on: vi.fn().mockImplementation((_event: string, handler: any) => {
       eventListeners.push(handler)
@@ -705,6 +724,119 @@ describe('CodexImplementer.prompt()', () => {
       serviceTier: 'fast',
       interactionMode: 'default'
     })
+  })
+
+  // ── goal mode ─────────────────────────────────────────────────
+
+  it('sets a Codex thread goal before sending the turn when goal mode is enabled', async () => {
+    seedSession()
+
+    simulateManagerEvents([
+      {
+        id: 'e1',
+        kind: 'notification',
+        provider: 'codex',
+        threadId: 'thread-1',
+        createdAt: new Date().toISOString(),
+        method: 'turn/completed',
+        payload: { turn: { status: 'completed' } }
+      }
+    ])
+
+    await impl.prompt('/test/project', 'thread-1', 'Ship the migration', undefined, {
+      goalMode: true,
+      successCriteria: 'Focused tests pass'
+    })
+
+    expect(mockManager.setThreadGoal).toHaveBeenCalledWith('thread-1', {
+      objective: 'Ship the migration\n\nSuccess criteria:\nFocused tests pass',
+      status: 'active',
+      tokenBudget: null
+    })
+    expect(mockManager.sendTurn).toHaveBeenCalledWith('thread-1', {
+      text: 'Ship the migration',
+      model: 'gpt-5.4',
+      interactionMode: 'default'
+    })
+    expect(mockManager.setThreadGoal.mock.invocationCallOrder[0]).toBeLessThan(
+      mockManager.sendTurn.mock.invocationCallOrder[0]
+    )
+  })
+
+  it('uses the pre-injection goal objective when provided by IPC', async () => {
+    seedSession()
+
+    simulateManagerEvents([
+      {
+        id: 'e1',
+        kind: 'notification',
+        provider: 'codex',
+        threadId: 'thread-1',
+        createdAt: new Date().toISOString(),
+        method: 'turn/completed',
+        payload: { turn: { status: 'completed' } }
+      }
+    ])
+
+    await impl.prompt(
+      '/test/project',
+      'thread-1',
+      '[Field Context]\nCurrent file: src/a.ts\n\n[User Message]\nShip the migration',
+      undefined,
+      {
+        goalMode: true,
+        successCriteria: 'Focused tests pass',
+        goalObjective: 'Ship the migration\n\nSuccess criteria:\nFocused tests pass'
+      }
+    )
+
+    expect(mockManager.setThreadGoal).toHaveBeenCalledWith('thread-1', {
+      objective: 'Ship the migration\n\nSuccess criteria:\nFocused tests pass',
+      status: 'active',
+      tokenBudget: null
+    })
+  })
+
+  it('does not set a thread goal when goal mode is disabled', async () => {
+    seedSession()
+
+    simulateManagerEvents([
+      {
+        id: 'e1',
+        kind: 'notification',
+        provider: 'codex',
+        threadId: 'thread-1',
+        createdAt: new Date().toISOString(),
+        method: 'turn/completed',
+        payload: { turn: { status: 'completed' } }
+      }
+    ])
+
+    await impl.prompt('/test/project', 'thread-1', 'Regular prompt', undefined, {
+      successCriteria: 'Ignored without goal mode'
+    })
+
+    expect(mockManager.setThreadGoal).not.toHaveBeenCalled()
+    expect(mockManager.sendTurn).toHaveBeenCalled()
+  })
+
+  it('fails the prompt before sendTurn when explicit goal setup fails', async () => {
+    const session = seedSession()
+    mockManager.setThreadGoal.mockRejectedValue(new Error('goal RPC failed'))
+
+    await impl.prompt('/test/project', 'thread-1', 'Ship the migration', undefined, {
+      goalMode: true
+    })
+
+    expect(mockManager.sendTurn).not.toHaveBeenCalled()
+    expect(session.status).toBe('error')
+
+    const errorEvents = mockWindow.webContents.send.mock.calls
+      .filter((c: any[]) => c[0] === 'agent:stream')
+      .map((c: any[]) => c[1])
+      .filter((e: any) => e.type === 'session.error')
+    expect(errorEvents).toHaveLength(1)
+    expect(errorEvents[0].data.error).toBe('goal RPC failed')
   })
 
   // ── plan mode interactionMode ───────────────────────────────

--- a/test/phase-23/composer-bar.test.tsx
+++ b/test/phase-23/composer-bar.test.tsx
@@ -3,8 +3,9 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { act, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { ComposerBar } from '../../src/renderer/src/components/session-hq/ComposerBar'
-
-;(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+;(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true
 
 beforeEach(() => {
   Object.defineProperty(window, 'db', {
@@ -46,11 +47,7 @@ describe('ComposerBar', () => {
     await user.type(screen.getByRole('textbox'), 'Follow up after this run')
     await user.click(screen.getByTestId('composer-primary-action'))
 
-    expect(onAction).toHaveBeenCalledWith(
-      'queue',
-      'Follow up after this run',
-      expect.any(Array)
-    )
+    expect(onAction).toHaveBeenCalledWith('queue', 'Follow up after this run', expect.any(Array))
   })
 
   it('shows steer and stop actions in the busy-state action menu', async () => {
@@ -64,6 +61,7 @@ describe('ComposerBar', () => {
         firstInterrupt={null}
         onAction={vi.fn()}
         isConnected={true}
+        supportsSteer={true}
       />
     )
 
@@ -88,6 +86,7 @@ describe('ComposerBar', () => {
         firstInterrupt={null}
         onAction={onAction}
         isConnected={true}
+        supportsSteer={true}
       />
     )
 
@@ -104,5 +103,89 @@ describe('ComposerBar', () => {
       'Switch to investigating the failing test',
       expect.any(Array)
     )
+  })
+
+  it('renders and toggles the Codex goal control', async () => {
+    const user = userEvent.setup()
+    const onToggleGoalMode = vi.fn()
+
+    render(
+      <ComposerBar
+        sessionId="sess-1"
+        lifecycle="idle"
+        pendingCount={0}
+        firstInterrupt={null}
+        onAction={vi.fn()}
+        isConnected={true}
+        supportsGoalMode={true}
+        goalMode={false}
+        onToggleGoalMode={onToggleGoalMode}
+      />
+    )
+
+    const goalToggle = screen.getByTestId('composer-goal-toggle')
+    expect(goalToggle).toHaveTextContent('Goal')
+    expect(goalToggle).toHaveAttribute('aria-pressed', 'false')
+
+    await user.click(goalToggle)
+
+    expect(onToggleGoalMode).toHaveBeenCalledTimes(1)
+  })
+
+  it('shows success criteria input only while goal mode is enabled', async () => {
+    const user = userEvent.setup()
+
+    function GoalComposer(): React.JSX.Element {
+      const [goalMode, setGoalMode] = React.useState(false)
+      const [successCriteria, setSuccessCriteria] = React.useState('')
+
+      return (
+        <ComposerBar
+          sessionId="sess-1"
+          lifecycle="idle"
+          pendingCount={0}
+          firstInterrupt={null}
+          onAction={vi.fn()}
+          isConnected={true}
+          supportsGoalMode={true}
+          goalMode={goalMode}
+          onToggleGoalMode={() => setGoalMode((current) => !current)}
+          successCriteria={successCriteria}
+          onSuccessCriteriaChange={setSuccessCriteria}
+        />
+      )
+    }
+
+    render(<GoalComposer />)
+
+    expect(screen.queryByTestId('composer-success-criteria')).not.toBeInTheDocument()
+
+    await user.click(screen.getByTestId('composer-goal-toggle'))
+    const criteriaInput = screen.getByTestId('composer-success-criteria')
+    expect(criteriaInput).toBeInTheDocument()
+    expect(criteriaInput).toHaveAttribute('placeholder', 'Success criteria...')
+
+    await user.type(criteriaInput, 'All tests pass and the UI is stable')
+
+    expect(criteriaInput).toHaveValue('All tests pass and the UI is stable')
+  })
+
+  it('does not render goal controls when goal mode is unsupported', () => {
+    render(
+      <ComposerBar
+        sessionId="sess-1"
+        lifecycle="idle"
+        pendingCount={0}
+        firstInterrupt={null}
+        onAction={vi.fn()}
+        isConnected={true}
+        supportsGoalMode={false}
+        goalMode={true}
+        onToggleGoalMode={vi.fn()}
+      />
+    )
+
+    expect(screen.queryByTestId('composer-goal-toggle')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('composer-success-criteria')).not.toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## Summary

- Add Codex app-server `thread/goal/set` support and set the active thread goal before starting a goal-mode turn.
- Extend prompt options through IPC/preload so Xuanpu can pass Codex `goalMode` and `successCriteria` without faking a slash command.
- Add Codex-only Goal controls to the Session HQ composer and reuse the same options for normal sends, queued drains, edits, and plan implementation.
- Add regression coverage for the goal RPC, Codex prompt goal setup, and composer goal controls.

## Stack / Version

- This is v1.4.7 PR 3 in the stacked batch.
- Base: `feat_20260509_codex_goal_foundation` (PR #51).
- No `package.json` version bump in this PR; version/release metadata stays for the final release step.

## Verification

- `pnpm vitest run test/phase-22/session-5/codex-app-server-manager.test.ts test/phase-22/session-5/codex-prompt-streaming.test.ts test/phase-23/composer-bar.test.tsx`
- `git diff --check`
- `pnpm lint` (passes with existing warnings)
- `pnpm build` (passes with existing Vite dynamic/static import warnings)
