### PR TITLE
v1.4.7 PR 4: Codex goal entry completion

### DIFF
--- a/src/renderer/src/components/session-hq/SessionShell.tsx
+++ b/src/renderer/src/components/session-hq/SessionShell.tsx
@@ -36,7 +36,7 @@ import { ForkFromMessageConfirmDialog } from './ForkFromMessageConfirmDialog'
 import { PlanReadyImplementFab } from '../sessions/PlanReadyImplementFab'
 import { ScrollToBottomFab } from '../sessions/ScrollToBottomFab'
 import { useSessionRuntimeStore } from '@/stores/useSessionRuntimeStore'
-import { useSessionStore } from '@/stores/useSessionStore'
+import { useSessionStore, type PendingPromptOptions } from '@/stores/useSessionStore'
 import { useWorktreeStore } from '@/stores'
 import { useContextStore } from '@/stores/useContextStore'
 import { useWorktreeStatusStore } from '@/stores/useWorktreeStatusStore'
@@ -513,6 +513,23 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
     }
     return undefined
   }, [agentSdk, goalMode, mode, successCriteria])
+  const buildPendingPromptOptions = useCallback(
+    (options?: PendingPromptOptions): RendererPromptOptions | undefined => {
+      if (agentSdk === 'codex') {
+        return {
+          goalMode: options?.goalMode ?? promptOptions?.goalMode ?? false,
+          successCriteria: options?.successCriteria ?? promptOptions?.successCriteria ?? ''
+        }
+      }
+
+      if (agentSdk === 'opencode') {
+        return { mode: options?.mode ?? mode }
+      }
+
+      return undefined
+    },
+    [agentSdk, mode, promptOptions]
+  )
   const currentModelId = resolvedModel?.modelID ?? ''
   const currentProviderId = resolvedModel?.providerID ?? ''
   const skipForkFromMessageConfirm = useSettingsStore((s) => s.skipForkFromMessageConfirm)
@@ -777,6 +794,90 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
       cancelled = true
     }
   }, [sessionId, worktreePath, opcSessionId, agentSdk])
+
+  useEffect(() => {
+    if (!worktreePath || !droidSessionId) return
+
+    const pending = useSessionStore.getState().dequeuePendingMessageWithOptions(sessionId)
+    if (!pending) return
+
+    let cancelled = false
+    const effectivePromptOptions = buildPendingPromptOptions(pending.options)
+    const pendingMode = pending.options?.mode ?? mode
+    const optimisticMessageId = `optimistic-${Date.now()}`
+
+    ;(async () => {
+      try {
+        resetLiveOverlay(true)
+        useSessionStore.getState().markSessionFirstMessage(sessionId)
+        messageSendTimes.set(sessionId, Date.now())
+        lastSendMode.set(sessionId, pendingMode)
+        useWorktreeStatusStore
+          .getState()
+          .setSessionStatus(sessionId, pendingMode === 'plan' ? 'planning' : 'working')
+
+        const optimisticMsg: TimelineMessage = {
+          id: optimisticMessageId,
+          role: 'user',
+          content: pending.message,
+          timestamp: new Date().toISOString()
+        }
+        appendOptimistic(optimisticMsg)
+        timelineMessagesRef.current = [...timelineMessagesRef.current, optimisticMsg]
+        syncOptimisticMessagesToMirror()
+
+        const result = await window.agentOps.prompt(
+          worktreePath,
+          droidSessionId,
+          pending.message,
+          requestModel,
+          effectivePromptOptions
+        )
+
+        if (cancelled) return
+
+        if (!result.success) {
+          throw new Error(result.error || 'Failed to send pending message')
+        }
+
+        void refreshSessionLastMessageAt(sessionId)
+      } catch (err) {
+        console.error('[SessionShell] pending message send failed:', err)
+        useSessionStore
+          .getState()
+          .requeuePendingMessage(sessionId, pending.message, pending.options)
+        optimisticRef.current = optimisticRef.current.filter(
+          (msg) => msg.id !== optimisticMessageId
+        )
+        timelineMessagesRef.current = timelineMessagesRef.current.filter(
+          (msg) => msg.id !== optimisticMessageId
+        )
+        setMessages((prev) => prev.filter((msg) => msg.id !== optimisticMessageId))
+        syncOptimisticMessagesToMirror()
+        useWorktreeStatusStore.getState().clearSessionStatus(sessionId)
+        resetLiveOverlay(false)
+        if (!cancelled) {
+          toast.error(err instanceof Error ? err.message : 'Failed to send pending message')
+        }
+      }
+    })()
+
+    return () => {
+      cancelled = true
+    }
+  }, [
+    sessionId,
+    worktreePath,
+    droidSessionId,
+    buildPendingPromptOptions,
+    mode,
+    requestModel,
+    appendOptimistic,
+    syncOptimisticMessagesToMirror,
+    optimisticRef,
+    resetLiveOverlay,
+    setMessages
+  ])
 
   useEffect(() => {
     if (!worktreePath || !droidSessionId || !window.agentOps?.getMessages) return
@@ -1464,10 +1565,88 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
     promptOptions
   ])
 
-  const handlePlanHandoff = useCallback(() => {
-    // Just clear the pending plan — user will handle it elsewhere
-    useSessionStore.getState().clearPendingPlan(sessionId)
-  }, [sessionId])
+  const handlePlanHandoff = useCallback(async () => {
+    if (!pendingPlan) return
+
+    const planContent = pendingPlan.planContent.trim()
+    if (!planContent) {
+      toast.error(t('sessionView.toasts.noAssistantPlanToHandoff'))
+      return
+    }
+
+    const sourceAgentSdk = sessionRecord?.agent_sdk
+    const handoffPrompt = `Implement the following plan\n${planContent}`
+    const pendingOptions: PendingPromptOptions | undefined =
+      sourceAgentSdk === 'codex' && goalMode
+        ? {
+            goalMode: true,
+            ...(successCriteria.trim() ? { successCriteria: successCriteria.trim() } : {})
+          }
+        : undefined
+
+    const sessionStore = useSessionStore.getState()
+
+    try {
+      let result:
+        | Awaited<ReturnType<typeof sessionStore.createConnectionSession>>
+        | Awaited<ReturnType<typeof sessionStore.createSession>>
+
+      if (connectionId) {
+        result = await sessionStore.createConnectionSession(
+          connectionId,
+          sourceAgentSdk ?? undefined,
+          'build'
+        )
+      } else {
+        const currentWorktreeId = worktreeId
+        const currentProjectId = sessionRecord?.project_id
+        if (!currentWorktreeId || !currentProjectId) {
+          toast.error(t('sessionView.toasts.startHandoffSessionError'))
+          return
+        }
+
+        result = await sessionStore.createSession(
+          currentWorktreeId,
+          currentProjectId,
+          sourceAgentSdk ?? undefined,
+          'build'
+        )
+      }
+
+      if (!result.success || !result.session) {
+        toast.error(result.error ?? t('sessionView.toasts.createHandoffSessionError'))
+        return
+      }
+
+      await sessionStore.setSessionMode(result.session.id, 'build')
+      sessionStore.setPendingMessage(result.session.id, handoffPrompt, pendingOptions)
+
+      if (connectionId) {
+        sessionStore.setActiveConnectionSession(result.session.id)
+      } else {
+        sessionStore.setActiveSession(result.session.id)
+      }
+
+      useSessionStore.getState().clearPendingPlan(sessionId)
+      useSessionRuntimeStore.getState().removeInterrupt(sessionId, pendingPlan.requestId)
+      useWorktreeStatusStore.getState().clearSessionStatus(sessionId)
+    } catch (err) {
+      console.error('[SessionShell] plan handoff failed:', err)
+      toast.error(
+        err instanceof Error ? err.message : t('sessionView.toasts.startHandoffSessionError')
+      )
+    }
+  }, [
+    pendingPlan,
+    sessionRecord?.agent_sdk,
+    sessionRecord?.project_id,
+    goalMode,
+    successCriteria,
+    connectionId,
+    worktreeId,
+    sessionId,
+    t
+  ])
 
   const handlePlanReject = useCallback(async () => {
     if (!pendingPlan) return

--- a/src/renderer/src/stores/useSessionStore.ts
+++ b/src/renderer/src/stores/useSessionStore.ts
@@ -23,6 +23,17 @@ export interface PendingPlan {
   toolUseID: string
 }
 
+export interface PendingPromptOptions {
+  mode?: SessionMode
+  goalMode?: boolean
+  successCriteria?: string
+}
+
+export interface PendingInitialMessage {
+  message: string
+  options?: PendingPromptOptions
+}
+
 // Session type matching the database schema
 interface Session {
   id: string
@@ -60,6 +71,7 @@ interface SessionState {
   modeBySession: Map<string, SessionMode>
   // Pending initial messages - keyed by session ID (e.g., code review prompts)
   pendingMessages: Map<string, string>
+  pendingMessageOptions: Map<string, PendingPromptOptions>
   // Pending plan approvals - keyed by session ID (from ExitPlanMode blocking tool)
   pendingPlans: Map<string, PendingPlan>
   // Pending follow-up messages - keyed by session ID, ordered queue of messages to auto-send
@@ -132,9 +144,14 @@ interface SessionState {
    * via createSessionMessage / upsertSessionActivity).
    */
   markSessionFirstMessage: (sessionId: string) => void
-  setPendingMessage: (sessionId: string, message: string) => void
+  setPendingMessage: (sessionId: string, message: string, options?: PendingPromptOptions) => void
   dequeuePendingMessage: (sessionId: string) => string | null
-  requeuePendingMessage: (sessionId: string, message: string) => void
+  dequeuePendingMessageWithOptions: (sessionId: string) => PendingInitialMessage | null
+  requeuePendingMessage: (
+    sessionId: string,
+    message: string,
+    options?: PendingPromptOptions
+  ) => void
   consumePendingMessage: (sessionId: string) => string | null
   setPendingFollowUpMessages: (sessionId: string, messages: string[]) => void
   dequeueFollowUpMessage: (sessionId: string) => string | null
@@ -195,6 +212,7 @@ export const useSessionStore = create<SessionState>()(
       tabOrderByWorktree: new Map(),
       modeBySession: new Map(),
       pendingMessages: new Map(),
+      pendingMessageOptions: new Map(),
       pendingPlans: new Map(),
       pendingFollowUpMessages: new Map(),
       isLoading: false,
@@ -1280,11 +1298,17 @@ export const useSessionStore = create<SessionState>()(
       },
 
       // Set a pending initial message for a session (e.g., code review prompt)
-      setPendingMessage: (sessionId: string, message: string) => {
+      setPendingMessage: (sessionId: string, message: string, options?: PendingPromptOptions) => {
         set((state) => {
           const newMap = new Map(state.pendingMessages)
+          const newOptionsMap = new Map(state.pendingMessageOptions)
           newMap.set(sessionId, message)
-          return { pendingMessages: newMap }
+          if (options) {
+            newOptionsMap.set(sessionId, options)
+          } else {
+            newOptionsMap.delete(sessionId)
+          }
+          return { pendingMessages: newMap, pendingMessageOptions: newOptionsMap }
         })
       },
 
@@ -1294,19 +1318,48 @@ export const useSessionStore = create<SessionState>()(
         if (message) {
           set((state) => {
             const newMap = new Map(state.pendingMessages)
+            const newOptionsMap = new Map(state.pendingMessageOptions)
             newMap.delete(sessionId)
-            return { pendingMessages: newMap }
+            newOptionsMap.delete(sessionId)
+            return { pendingMessages: newMap, pendingMessageOptions: newOptionsMap }
           })
         }
         return message
       },
 
-      // Restore a pending message for a session (used when auto-send fails)
-      requeuePendingMessage: (sessionId: string, message: string) => {
+      // Dequeue the pending initial message together with launch-specific prompt options.
+      dequeuePendingMessageWithOptions: (sessionId: string): PendingInitialMessage | null => {
+        const message = get().pendingMessages.get(sessionId) || null
+        if (!message) return null
+
+        const options = get().pendingMessageOptions.get(sessionId)
         set((state) => {
           const newMap = new Map(state.pendingMessages)
+          const newOptionsMap = new Map(state.pendingMessageOptions)
+          newMap.delete(sessionId)
+          newOptionsMap.delete(sessionId)
+          return { pendingMessages: newMap, pendingMessageOptions: newOptionsMap }
+        })
+
+        return options ? { message, options } : { message }
+      },
+
+      // Restore a pending message for a session (used when auto-send fails)
+      requeuePendingMessage: (
+        sessionId: string,
+        message: string,
+        options?: PendingPromptOptions
+      ) => {
+        set((state) => {
+          const newMap = new Map(state.pendingMessages)
+          const newOptionsMap = new Map(state.pendingMessageOptions)
           newMap.set(sessionId, message)
-          return { pendingMessages: newMap }
+          if (options) {
+            newOptionsMap.set(sessionId, options)
+          } else {
+            newOptionsMap.delete(sessionId)
+          }
+          return { pendingMessages: newMap, pendingMessageOptions: newOptionsMap }
         })
       },
 

--- a/test/phase-23/session-pending-message-options.test.ts
+++ b/test/phase-23/session-pending-message-options.test.ts
@@ -1,0 +1,43 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { useSessionStore } from '../../src/renderer/src/stores/useSessionStore'
+
+describe('session pending initial message options', () => {
+  beforeEach(() => {
+    useSessionStore.setState({
+      pendingMessages: new Map(),
+      pendingMessageOptions: new Map()
+    })
+  })
+
+  it('dequeues a pending initial message together with goal launch options', () => {
+    useSessionStore.getState().setPendingMessage('sess-1', 'Implement the following plan', {
+      goalMode: true,
+      successCriteria: 'Focused tests pass'
+    })
+
+    expect(useSessionStore.getState().dequeuePendingMessageWithOptions('sess-1')).toEqual({
+      message: 'Implement the following plan',
+      options: {
+        goalMode: true,
+        successCriteria: 'Focused tests pass'
+      }
+    })
+    expect(useSessionStore.getState().dequeuePendingMessageWithOptions('sess-1')).toBeNull()
+    expect(useSessionStore.getState().pendingMessageOptions.has('sess-1')).toBe(false)
+  })
+
+  it('keeps legacy string dequeue semantics and clears stale launch options', () => {
+    useSessionStore
+      .getState()
+      .setPendingMessage('sess-1', 'Create a pull request', { goalMode: true })
+
+    expect(useSessionStore.getState().dequeuePendingMessage('sess-1')).toBe('Create a pull request')
+    expect(useSessionStore.getState().pendingMessageOptions.has('sess-1')).toBe(false)
+
+    useSessionStore.getState().setPendingMessage('sess-1', 'Fix merge conflicts')
+
+    expect(useSessionStore.getState().dequeuePendingMessageWithOptions('sess-1')).toEqual({
+      message: 'Fix merge conflicts'
+    })
+  })
+})

--- a/test/phase-23/session-shell-plan-implement-source.test.ts
+++ b/test/phase-23/session-shell-plan-implement-source.test.ts
@@ -39,7 +39,44 @@ describe('SessionShell plan implement flow (source verification)', () => {
     )
 
     expect(source).toContain('const requestModel = useMemo(() => {')
-    expect(source).toContain('window.agentOps.prompt(wp, sid, messageParts ?? c, requestModel)')
-    expect(source).toContain('window.agentOps.prompt(wp, sid, c, requestModel)')
+    expect(source).toContain(
+      'window.agentOps.prompt(wp, sid, messageParts ?? c, requestModel, promptOptions)'
+    )
+    expect(source).toContain('window.agentOps.prompt(wp, sid, c, requestModel, promptOptions)')
+  })
+
+  test('new UI auto-sends pending initial messages with launch-specific options', async () => {
+    const fs = await import('fs')
+    const path = await import('path')
+    const source = fs.readFileSync(
+      path.resolve(__dirname, '../../src/renderer/src/components/session-hq/SessionShell.tsx'),
+      'utf-8'
+    )
+
+    expect(source).toContain('dequeuePendingMessageWithOptions(sessionId)')
+    expect(source).toContain('buildPendingPromptOptions(pending.options)')
+    expect(source).toContain('window.agentOps.prompt(')
+    expect(source).toContain('effectivePromptOptions')
+    expect(source).toContain('requeuePendingMessage(sessionId, pending.message, pending.options)')
+  })
+
+  test('new UI handoff creates a build session and carries Codex goal options', async () => {
+    const fs = await import('fs')
+    const path = await import('path')
+    const source = fs.readFileSync(
+      path.resolve(__dirname, '../../src/renderer/src/components/session-hq/SessionShell.tsx'),
+      'utf-8'
+    )
+
+    expect(source).toContain('const handlePlanHandoff = useCallback(async () => {')
+    expect(source).toContain(
+      'const handoffPrompt = `Implement the following plan\\n${planContent}`'
+    )
+    expect(source).toContain("sourceAgentSdk === 'codex' && goalMode")
+    expect(source).toContain('goalMode: true')
+    expect(source).toContain(
+      'sessionStore.setPendingMessage(result.session.id, handoffPrompt, pendingOptions)'
+    )
+    expect(source).toContain("sessionStore.setSessionMode(result.session.id, 'build')")
   })
 })


### PR DESCRIPTION
## Scope

- Completes SessionShell plan handoff instead of only clearing the pending plan.
- Creates a new build-mode session for handoff, preserving the source runtime.
- Carries Codex-only goal launch options through pending initial messages so handoff can set a real app-server goal before the first turn.
- Adds typed pending-message option storage while keeping legacy string dequeue behavior for PR/review/conflict launch flows.

## Notes

- This remains part of the v1.4.7 Hive upstream follow-up stack.
- No standalone ticket-launch product surface exists in the current xuanpu UI; the reusable pending-launch options path is in place for any future ticket launch entry without faking `/goal` text.

## Verification

- `pnpm vitest run test/phase-23/session-shell-plan-implement-source.test.ts test/phase-23/session-pending-message-options.test.ts test/phase-23/session-send-actions.test.ts`
- `pnpm exec tsc --noEmit --pretty false`
- `pnpm vitest run test/phase-22/session-5/codex-app-server-manager.test.ts test/phase-22/session-5/codex-prompt-streaming.test.ts test/phase-23/composer-bar.test.tsx test/phase-23/session-shell-plan-implement-source.test.ts test/phase-23/session-pending-message-options.test.ts`
- `git diff --check`
- `pnpm lint` (passes with 42 existing warnings)
- `pnpm build` (passes with existing Vite dynamic/static import warnings)
