### PR TITLE
v1.4.7 PR 6: PR notification and plan copy polish

### DIFF
--- a/src/renderer/src/components/layout/Header.tsx
+++ b/src/renderer/src/components/layout/Header.tsx
@@ -166,6 +166,7 @@ export function Header(): React.JSX.Element {
   )
   const isCreatingPR = prCreation?.creating ?? false
   const hasAttachedPR = !!attachedPR
+  const attachedPRNumber = attachedPR?.number
 
   // Clean tree detection for merge button visibility
   const fileStatuses = useGitStore((s) =>
@@ -241,7 +242,28 @@ export function Header(): React.JSX.Element {
     Array<{ number: number; title: string; author: string; headRefName: string }>
   >([])
   const [prListLoading, setPrListLoading] = useState(false)
-  const [prLiveState, setPrLiveState] = useState<{ state?: string; title?: string } | null>(null)
+  const [prLiveState, setPrLiveState] = useState<{
+    number?: number
+    state?: string
+    title?: string
+  } | null>(null)
+  const currentPRLiveState = prLiveState?.number === attachedPRNumber ? prLiveState : null
+
+  const refreshAttachedPRState = useCallback(async (): Promise<void> => {
+    if (attachedPRNumber == null || !selectedProject?.path) {
+      setPrLiveState(null)
+      return
+    }
+
+    try {
+      const res = await window.gitOps.getPRState(selectedProject.path, attachedPRNumber)
+      if (res.success) {
+        setPrLiveState({ number: attachedPRNumber, state: res.state, title: res.title })
+      }
+    } catch {
+      /* non-critical */
+    }
+  }, [attachedPRNumber, selectedProject?.path])
 
   useEffect(() => {
     if (!selectedWorktree?.path) {
@@ -255,7 +277,11 @@ export function Header(): React.JSX.Element {
     })
   }, [selectedWorktree?.path])
 
-  // Fetch PR list + live state when picker opens
+  useEffect(() => {
+    void refreshAttachedPRState()
+  }, [refreshAttachedPRState])
+
+  // Fetch PR list when picker opens; refresh the attached PR metadata too.
   useEffect(() => {
     if (!prPickerOpen || !selectedProject?.path) return
     setPrListLoading(true)
@@ -283,27 +309,8 @@ export function Header(): React.JSX.Element {
         setPrPickerOpen(false)
       })
 
-    const fetchState =
-      attachedPR && selectedProject?.path
-        ? window.gitOps
-            .getPRState(selectedProject.path, attachedPR.number)
-            .then((res) => {
-              if (res.success) {
-                setPrLiveState({ state: res.state, title: res.title })
-              }
-            })
-            .catch(() => {
-              /* non-critical */
-            })
-        : Promise.resolve()
-
-    Promise.all([fetchPRs, fetchState]).finally(() => setPrListLoading(false))
-  }, [prPickerOpen, selectedProject?.path, attachedPR, branchInfo?.name, t])
-
-  // Clear live state when attached PR changes
-  useEffect(() => {
-    setPrLiveState(null)
-  }, [attachedPR?.number])
+    Promise.all([fetchPRs, refreshAttachedPRState()]).finally(() => setPrListLoading(false))
+  }, [prPickerOpen, selectedProject?.path, branchInfo?.name, refreshAttachedPRState, t])
 
   const handleCreatePR = useCallback(async () => {
     if (!selectedWorktree?.path) return
@@ -431,7 +438,11 @@ export function Header(): React.JSX.Element {
       const result = await window.gitOps.prMerge(selectedWorktree.path, pr.number)
       if (result.success) {
         toast.success(t('header.toasts.prMergedSuccess'))
-        setPrLiveState({ state: 'MERGED', title: prLiveState?.title })
+        setPrLiveState({
+          number: pr.number,
+          state: 'MERGED',
+          title: currentPRLiveState?.title
+        })
       } else {
         toast.error(t('header.toasts.mergePRErrorWithReason', { error: result.error }))
       }
@@ -440,7 +451,7 @@ export function Header(): React.JSX.Element {
     } finally {
       setIsMergingPR(false)
     }
-  }, [selectedWorktree?.path, selectedWorktreeId, prLiveState?.title, t])
+  }, [selectedWorktree?.path, selectedWorktreeId, currentPRLiveState?.title, t])
 
   const handleArchiveWorktree = useCallback(async () => {
     if (!selectedWorktreeId || !selectedWorktree || !selectedProject) return
@@ -464,12 +475,13 @@ export function Header(): React.JSX.Element {
   }, [selectedWorktreeId, selectedWorktree, selectedProject])
 
   const handleSelectPR = useCallback(
-    (pr: { number: number; headRefName: string }) => {
+    (pr: { number: number; headRefName: string; title?: string }) => {
       if (!selectedWorktreeId || !remoteInfo?.url) return
       // Construct PR URL from remote URL + number
       const cleanUrl = remoteInfo.url.replace(/\.git$/, '')
       const prUrl = `${cleanUrl}/pull/${pr.number}`
       useGitStore.getState().attachPR(selectedWorktreeId, pr.number, prUrl)
+      setPrLiveState({ number: pr.number, state: 'OPEN', title: pr.title })
       setPrPickerOpen(false)
     },
     [selectedWorktreeId, remoteInfo?.url]
@@ -515,6 +527,13 @@ export function Header(): React.JSX.Element {
     conflictFixFlow.worktreePath === selectedWorktree.path
 
   const showFixConflictsButton = hasConflicts || isFixConflictsLoading
+  const attachedPRTitle = currentPRLiveState?.title?.trim() ?? ''
+  const prBadgeTitle =
+    attachedPRNumber == null
+      ? ''
+      : attachedPRTitle
+        ? `PR #${attachedPRNumber}: ${attachedPRTitle}`
+        : `PR #${attachedPRNumber}`
 
   return (
     <header
@@ -572,7 +591,7 @@ export function Header(): React.JSX.Element {
         {!isConnectionMode &&
           isGitHub &&
           hasAttachedPR &&
-          prLiveState?.state === 'MERGED' &&
+          currentPRLiveState?.state === 'MERGED' &&
           !selectedWorktree?.is_default && (
             <Button
               size="sm"
@@ -607,8 +626,8 @@ export function Header(): React.JSX.Element {
         {!isConnectionMode &&
           isGitHub &&
           hasAttachedPR &&
-          prLiveState?.state !== 'MERGED' &&
-          prLiveState?.state !== 'CLOSED' &&
+          currentPRLiveState?.state !== 'MERGED' &&
+          currentPRLiveState?.state !== 'CLOSED' &&
           isCleanTree && (
             <Button
               size="sm"
@@ -706,19 +725,24 @@ export function Header(): React.JSX.Element {
               <Button
                 size="sm"
                 variant="outline"
-                className="h-8 rounded-full px-3 text-[12px] font-medium"
-                title={`PR #${attachedPR!.number}`}
+                className="h-8 max-w-[320px] rounded-full px-3 text-[12px] font-medium"
+                title={prBadgeTitle}
                 data-testid="pr-badge"
               >
                 <GitPullRequest className="h-3.5 w-3.5 mr-1" />
-                PR #{attachedPR!.number}
-                {prLiveState?.state === 'MERGED' && (
-                  <span className="text-muted-foreground ml-1">
+                <span className="shrink-0">PR #{attachedPR!.number}</span>
+                {attachedPRTitle && (
+                  <span className="min-w-0 max-w-[170px] truncate text-muted-foreground">
+                    · {attachedPRTitle}
+                  </span>
+                )}
+                {currentPRLiveState?.state === 'MERGED' && (
+                  <span className="text-muted-foreground ml-1 shrink-0">
                     · {t('header.controls.merged')}
                   </span>
                 )}
-                {prLiveState?.state === 'CLOSED' && (
-                  <span className="text-muted-foreground ml-1">
+                {currentPRLiveState?.state === 'CLOSED' && (
+                  <span className="text-muted-foreground ml-1 shrink-0">
                     · {t('header.controls.closed')}
                   </span>
                 )}
@@ -730,12 +754,12 @@ export function Header(): React.JSX.Element {
                 <div className="text-xs font-medium text-muted-foreground">
                   {t('header.controls.attached')}: #{attachedPR!.number}
                 </div>
-                {prLiveState?.title && (
+                {currentPRLiveState?.title && (
                   <div className="text-sm truncate">
-                    {prLiveState.title}
-                    {prLiveState.state && (
+                    {currentPRLiveState.title}
+                    {currentPRLiveState?.state && (
                       <span className="text-muted-foreground ml-1 text-xs">
-                        ({prLiveState.state.toLowerCase()})
+                        ({currentPRLiveState.state.toLowerCase()})
                       </span>
                     )}
                   </div>

--- a/src/renderer/src/components/session-hq/cards/PlanCard.tsx
+++ b/src/renderer/src/components/session-hq/cards/PlanCard.tsx
@@ -3,7 +3,11 @@
  * Uses MarkdownRenderer for rich content, collapses after approval/rejection.
  */
 
-import React from 'react'
+import React, { useEffect, useState } from 'react'
+import { Check, Copy } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { toast } from '@/lib/toast'
+import { useI18n } from '@/i18n/useI18n'
 import { ActionCard } from './ActionCard'
 import { MarkdownRenderer } from '../../sessions/MarkdownRenderer'
 
@@ -21,15 +25,58 @@ export function PlanCard({
   onReject,
   isPending = false
 }: PlanCardProps): React.JSX.Element {
+  const { t } = useI18n()
+  const [copied, setCopied] = useState(false)
+  const hasCopyableContent = content.trim().length > 0
+
+  useEffect(() => {
+    if (!copied) return
+    const timeout = window.setTimeout(() => setCopied(false), 2000)
+    return () => window.clearTimeout(timeout)
+  }, [copied])
+
+  const handleCopy = async (event: React.MouseEvent<HTMLButtonElement>): Promise<void> => {
+    event.stopPropagation()
+    if (!hasCopyableContent) return
+
+    try {
+      await navigator.clipboard.writeText(content)
+      setCopied(true)
+      toast.success(t('planCard.toasts.copied'))
+    } catch {
+      toast.error(t('planCard.toasts.copyError'))
+    }
+  }
+
   return (
     <ActionCard
       key={isPending ? 'pending' : 'resolved'}
       accentClass="border-purple-500"
       headerClass="bg-purple-500/10 text-purple-600 dark:text-purple-400 border-b-purple-500/20"
-      headerLeft={
-        <span className="font-semibold">Proposed Execution Plan</span>
+      headerLeft={<span className="font-semibold">Proposed Execution Plan</span>}
+      headerRight={
+        <div className="flex items-center gap-2">
+          <span>{isPending ? 'Requires Approval' : 'Approved'}</span>
+          {hasCopyableContent && (
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="h-6 w-6 rounded-full p-0 text-muted-foreground hover:text-foreground"
+              aria-label={t('planCard.copyMarkdown')}
+              title={t('planCard.copyMarkdown')}
+              data-testid="plan-card-copy-button"
+              onClick={handleCopy}
+            >
+              {copied ? (
+                <Check className="h-3.5 w-3.5 text-green-500" />
+              ) : (
+                <Copy className="h-3.5 w-3.5" />
+              )}
+            </Button>
+          )}
+        </div>
       }
-      headerRight={isPending ? 'Requires Approval' : 'Approved'}
       defaultExpanded={isPending}
       collapsible
     >

--- a/src/renderer/src/i18n/messages.ts
+++ b/src/renderer/src/i18n/messages.ts
@@ -756,6 +756,13 @@ export const messages: Record<AppLocale, MessageTree> = {
         copyError: 'Failed to copy'
       }
     },
+    planCard: {
+      copyMarkdown: 'Copy plan markdown',
+      toasts: {
+        copied: 'Plan markdown copied to clipboard',
+        copyError: 'Failed to copy plan markdown'
+      }
+    },
     editMessageButton: {
       ariaLabel: 'Edit message',
       save: 'Save',
@@ -3230,6 +3237,13 @@ export const messages: Record<AppLocale, MessageTree> = {
       toasts: {
         copied: '已复制到剪贴板',
         copyError: '复制失败'
+      }
+    },
+    planCard: {
+      copyMarkdown: '复制计划 Markdown',
+      toasts: {
+        copied: '计划 Markdown 已复制到剪贴板',
+        copyError: '复制计划 Markdown 失败'
       }
     },
     editMessageButton: {

--- a/test/phase-20/session-5/pr-header-ui.test.tsx
+++ b/test/phase-20/session-5/pr-header-ui.test.tsx
@@ -1,19 +1,16 @@
 /**
  * Session 5: PR Header UI Tests
  *
- * Tests the state-driven PR button rendering logic in Header.tsx:
- * - none/creating → PR button (with spinner during creating)
- * - created + clean tree → green "Merge PR" button
- * - created + dirty tree → PR button (user needs to commit first)
- * - merged → red "Archive" button
- * - handleCreatePR sets PR state to creating with sessionId
- * - handleMergePR calls prMerge and transitions to merged
+ * Tests the current PR lifecycle model used by Header.tsx:
+ * - no attached PR -> create PR button
+ * - creating -> disabled spinner button
+ * - attached PR -> badge, plus merge/archive actions based on live GitHub state
+ * - PR creation is ephemeral; attached PR is the persistent worktree state
  */
 
-import { describe, test, expect, vi, beforeEach } from 'vitest'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
 import { useGitStore } from '../../../src/renderer/src/stores/useGitStore'
 
-// Mock useWorktreeStore (required by useGitStore internals)
 vi.mock('../../../src/renderer/src/stores/useWorktreeStore', () => ({
   useWorktreeStore: {
     getState: vi.fn(() => ({
@@ -21,15 +18,65 @@ vi.mock('../../../src/renderer/src/stores/useWorktreeStore', () => ({
       selectedWorktreeId: null,
       archiveWorktree: vi.fn().mockResolvedValue({ success: true })
     })),
-    // Zustand selector-style call
     __esModule: true
   }
 }))
 
+type PrLiveState = 'OPEN' | 'MERGED' | 'CLOSED' | null
+type VisibleButton =
+  | 'pr-button'
+  | 'pr-creating-button'
+  | 'pr-badge'
+  | 'pr-merge-button'
+  | 'pr-archive-button'
+
+function getVisibleButtons({
+  isGitHub,
+  isCreating,
+  hasAttachedPR,
+  prLiveState,
+  isCleanTree,
+  isDefaultWorktree = false
+}: {
+  isGitHub: boolean
+  isCreating: boolean
+  hasAttachedPR: boolean
+  prLiveState: PrLiveState
+  isCleanTree: boolean
+  isDefaultWorktree?: boolean
+}): VisibleButton[] {
+  if (!isGitHub) return []
+
+  const buttons: VisibleButton[] = []
+
+  if (hasAttachedPR && prLiveState === 'MERGED' && !isDefaultWorktree) {
+    buttons.push('pr-archive-button')
+  }
+
+  if (hasAttachedPR && prLiveState !== 'MERGED' && prLiveState !== 'CLOSED' && isCleanTree) {
+    buttons.push('pr-merge-button')
+  }
+
+  if (hasAttachedPR && !isCreating) {
+    buttons.push('pr-badge')
+  }
+
+  if (isCreating) {
+    buttons.push('pr-creating-button')
+  }
+
+  if (!hasAttachedPR && !isCreating) {
+    buttons.push('pr-button')
+  }
+
+  return buttons
+}
+
 describe('Session 5: PR Header UI', () => {
   beforeEach(() => {
     useGitStore.setState({
-      prInfo: new Map(),
+      prCreation: new Map(),
+      attachedPR: new Map(),
       fileStatusesByWorktree: new Map(),
       remoteInfo: new Map(),
       branchInfoByWorktree: new Map(),
@@ -39,53 +86,49 @@ describe('Session 5: PR Header UI', () => {
     })
   })
 
-  describe('PR state rendering conditions', () => {
-    test('prState defaults to none when no prInfo exists for worktree', () => {
-      const prInfo = useGitStore.getState().prInfo.get('wt-1')
-      const prState = prInfo?.state ?? 'none'
-      expect(prState).toBe('none')
+  describe('PR lifecycle store state', () => {
+    test('defaults to no active PR lifecycle when maps have no entry', () => {
+      expect(useGitStore.getState().prCreation.get('wt-1')).toBeUndefined()
+      expect(useGitStore.getState().attachedPR.get('wt-1')).toBeUndefined()
     })
 
-    test('prState is none when explicitly set', () => {
-      useGitStore.getState().setPrState('wt-1', { state: 'none' })
-      const prInfo = useGitStore.getState().prInfo.get('wt-1')
-      const prState = prInfo?.state ?? 'none'
-      expect(prState).toBe('none')
-    })
-
-    test('prState is creating after handleCreatePR sets it', () => {
-      useGitStore.getState().setPrState('wt-1', {
-        state: 'creating',
-        sessionId: 'session-1',
-        targetBranch: 'origin/main'
+    test('creation state is tracked after handleCreatePR starts a PR session', () => {
+      useGitStore.getState().setPrCreation('wt-1', {
+        creating: true,
+        sessionId: 'session-1'
       })
-      const prInfo = useGitStore.getState().prInfo.get('wt-1')
-      expect(prInfo?.state).toBe('creating')
-      expect(prInfo?.sessionId).toBe('session-1')
-      expect(prInfo?.targetBranch).toBe('origin/main')
+
+      const creation = useGitStore.getState().prCreation.get('wt-1')
+      expect(creation?.creating).toBe(true)
+      expect(creation?.sessionId).toBe('session-1')
     })
 
-    test('prState is created after PR URL detection', () => {
-      useGitStore.getState().setPrState('wt-1', {
-        state: 'created',
-        prNumber: 42,
-        prUrl: 'https://github.com/org/repo/pull/42',
-        sessionId: 'session-1',
-        targetBranch: 'origin/main'
+    test('attached PR is tracked after PR URL detection', () => {
+      useGitStore.getState().setPrCreation('wt-1', {
+        creating: true,
+        sessionId: 'session-1'
       })
-      const prInfo = useGitStore.getState().prInfo.get('wt-1')
-      expect(prInfo?.state).toBe('created')
-      expect(prInfo?.prNumber).toBe(42)
+      useGitStore.getState().setAttachedPR('wt-1', {
+        number: 42,
+        url: 'https://github.com/org/repo/pull/42'
+      })
+      useGitStore.getState().setPrCreation('wt-1', null)
+
+      expect(useGitStore.getState().prCreation.get('wt-1')).toBeUndefined()
+      expect(useGitStore.getState().attachedPR.get('wt-1')?.number).toBe(42)
+      expect(useGitStore.getState().attachedPR.get('wt-1')?.url).toBe(
+        'https://github.com/org/repo/pull/42'
+      )
     })
 
-    test('prState is merged after successful PR merge', () => {
-      useGitStore.getState().setPrState('wt-1', {
-        state: 'merged',
-        prNumber: 42,
-        prUrl: 'https://github.com/org/repo/pull/42'
+    test('attached PR can be cleared when detached', () => {
+      useGitStore.getState().setAttachedPR('wt-1', {
+        number: 42,
+        url: 'https://github.com/org/repo/pull/42'
       })
-      const prInfo = useGitStore.getState().prInfo.get('wt-1')
-      expect(prInfo?.state).toBe('merged')
+      useGitStore.getState().setAttachedPR('wt-1', null)
+
+      expect(useGitStore.getState().attachedPR.get('wt-1')).toBeUndefined()
     })
   })
 
@@ -128,231 +171,217 @@ describe('Session 5: PR Header UI', () => {
   })
 
   describe('button visibility state machine', () => {
-    // Simulates the rendering conditions from Header.tsx
-
-    function getVisibleButton(
-      prState: string,
-      isCleanTree: boolean,
-      isGitHub: boolean
-    ): 'pr-button' | 'pr-merge-button' | 'pr-archive-button' | null {
-      if (!isGitHub) return null
-      if (prState === 'merged') return 'pr-archive-button'
-      if (prState === 'created' && isCleanTree) return 'pr-merge-button'
-      if (prState === 'none' || prState === 'creating' || (prState === 'created' && !isCleanTree)) {
-        return 'pr-button'
-      }
-      return null
-    }
-
-    test('shows PR button when state is none', () => {
-      expect(getVisibleButton('none', true, true)).toBe('pr-button')
+    test('shows create PR button when no PR is attached or creating', () => {
+      expect(
+        getVisibleButtons({
+          isGitHub: true,
+          isCreating: false,
+          hasAttachedPR: false,
+          prLiveState: null,
+          isCleanTree: true
+        })
+      ).toEqual(['pr-button'])
     })
 
-    test('shows PR button when state is creating', () => {
-      expect(getVisibleButton('creating', true, true)).toBe('pr-button')
+    test('shows creating spinner button during PR creation', () => {
+      expect(
+        getVisibleButtons({
+          isGitHub: true,
+          isCreating: true,
+          hasAttachedPR: false,
+          prLiveState: null,
+          isCleanTree: true
+        })
+      ).toEqual(['pr-creating-button'])
     })
 
-    test('shows Merge PR button when state is created and tree is clean', () => {
-      expect(getVisibleButton('created', true, true)).toBe('pr-merge-button')
+    test('shows PR badge and Merge PR button when attached PR is open and tree is clean', () => {
+      expect(
+        getVisibleButtons({
+          isGitHub: true,
+          isCreating: false,
+          hasAttachedPR: true,
+          prLiveState: 'OPEN',
+          isCleanTree: true
+        })
+      ).toEqual(['pr-merge-button', 'pr-badge'])
     })
 
-    test('shows PR button (not Merge) when state is created but tree is dirty', () => {
-      expect(getVisibleButton('created', false, true)).toBe('pr-button')
+    test('shows only PR badge when attached PR is open and tree is dirty', () => {
+      expect(
+        getVisibleButtons({
+          isGitHub: true,
+          isCreating: false,
+          hasAttachedPR: true,
+          prLiveState: 'OPEN',
+          isCleanTree: false
+        })
+      ).toEqual(['pr-badge'])
     })
 
-    test('shows Archive button when state is merged', () => {
-      expect(getVisibleButton('merged', true, true)).toBe('pr-archive-button')
+    test('shows Archive and PR badge when attached PR is merged on a non-default worktree', () => {
+      expect(
+        getVisibleButtons({
+          isGitHub: true,
+          isCreating: false,
+          hasAttachedPR: true,
+          prLiveState: 'MERGED',
+          isCleanTree: true,
+          isDefaultWorktree: false
+        })
+      ).toEqual(['pr-archive-button', 'pr-badge'])
     })
 
-    test('shows Archive button when state is merged even with dirty tree', () => {
-      expect(getVisibleButton('merged', false, true)).toBe('pr-archive-button')
+    test('hides Archive on the default worktree even when PR is merged', () => {
+      expect(
+        getVisibleButtons({
+          isGitHub: true,
+          isCreating: false,
+          hasAttachedPR: true,
+          prLiveState: 'MERGED',
+          isCleanTree: true,
+          isDefaultWorktree: true
+        })
+      ).toEqual(['pr-badge'])
     })
 
-    test('shows nothing when isGitHub is false regardless of state', () => {
-      expect(getVisibleButton('none', true, false)).toBeNull()
-      expect(getVisibleButton('creating', true, false)).toBeNull()
-      expect(getVisibleButton('created', true, false)).toBeNull()
-      expect(getVisibleButton('merged', true, false)).toBeNull()
+    test('shows only PR badge when attached PR is closed', () => {
+      expect(
+        getVisibleButtons({
+          isGitHub: true,
+          isCreating: false,
+          hasAttachedPR: true,
+          prLiveState: 'CLOSED',
+          isCleanTree: true
+        })
+      ).toEqual(['pr-badge'])
+    })
+
+    test('shows nothing when remote is not GitHub', () => {
+      expect(
+        getVisibleButtons({
+          isGitHub: false,
+          isCreating: false,
+          hasAttachedPR: true,
+          prLiveState: 'OPEN',
+          isCleanTree: true
+        })
+      ).toEqual([])
     })
   })
 
-  describe('PR button disabled state', () => {
-    test('PR button disabled during creating state', () => {
-      const prState = 'creating'
-      const isOperating = false
-      const disabled = isOperating || prState === 'creating'
-      expect(disabled).toBe(true)
-    })
-
-    test('PR button disabled when git operation in progress', () => {
-      const prState: string = 'none'
+  describe('button disabled state', () => {
+    test('create PR button is disabled when git operation is in progress', () => {
       const isOperating = true
-      const disabled = isOperating || prState === 'creating'
+      const disabled = isOperating
       expect(disabled).toBe(true)
     })
 
-    test('PR button enabled when state is none and no operations', () => {
-      const prState: string = 'none'
+    test('create PR button is enabled when no git operation is in progress', () => {
       const isOperating = false
-      const disabled = isOperating || prState === 'creating'
+      const disabled = isOperating
       expect(disabled).toBe(false)
     })
+
+    test('creating spinner button is always disabled', () => {
+      const isCreating = true
+      expect(isCreating).toBe(true)
+    })
   })
 
-  describe('handleCreatePR sets prState to creating', () => {
-    test('setPrState is called with creating state and sessionId after session creation', () => {
-      // Simulate what handleCreatePR does after successful session creation
+  describe('handleCreatePR lifecycle effects', () => {
+    test('sets prCreation with session id after session creation', () => {
       const wtId = 'wt-1'
       const sessionId = 'new-session-1'
-      const targetBranch = 'origin/main'
 
-      useGitStore.getState().setPrState(wtId, {
-        state: 'creating',
-        sessionId,
-        targetBranch
+      useGitStore.getState().setPrCreation(wtId, {
+        creating: true,
+        sessionId
       })
 
-      const prInfo = useGitStore.getState().prInfo.get(wtId)
-      expect(prInfo?.state).toBe('creating')
-      expect(prInfo?.sessionId).toBe(sessionId)
-      expect(prInfo?.targetBranch).toBe(targetBranch)
+      const creation = useGitStore.getState().prCreation.get(wtId)
+      expect(creation?.creating).toBe(true)
+      expect(creation?.sessionId).toBe(sessionId)
     })
 
-    test('prState does not change if session creation fails', () => {
-      // Before handleCreatePR — no prInfo set
-      const prInfo = useGitStore.getState().prInfo.get('wt-1')
-      expect(prInfo).toBeUndefined()
+    test('prCreation does not change if session creation fails', () => {
+      expect(useGitStore.getState().prCreation.get('wt-1')).toBeUndefined()
 
-      // Simulate session creation failure — setPrState is NOT called
-      // (handleCreatePR returns early before setPrState)
       const resultSuccess = false
       if (resultSuccess) {
-        useGitStore.getState().setPrState('wt-1', { state: 'creating' })
+        useGitStore.getState().setPrCreation('wt-1', {
+          creating: true,
+          sessionId: 'session-1'
+        })
       }
 
-      // prInfo should still be undefined
-      expect(useGitStore.getState().prInfo.get('wt-1')).toBeUndefined()
+      expect(useGitStore.getState().prCreation.get('wt-1')).toBeUndefined()
     })
   })
 
   describe('handleMergePR logic', () => {
-    test('transitions to merged on successful prMerge', () => {
-      // Set up created state
-      useGitStore.getState().setPrState('wt-1', {
-        state: 'created',
-        prNumber: 42,
-        prUrl: 'https://github.com/org/repo/pull/42',
-        sessionId: 'session-1',
-        targetBranch: 'origin/main'
-      })
-
-      // Simulate successful merge — what handleMergePR does on success
-      const pr = useGitStore.getState().prInfo.get('wt-1')!
-      useGitStore.getState().setPrState('wt-1', { ...pr, state: 'merged' })
-
-      const updatedPr = useGitStore.getState().prInfo.get('wt-1')
-      expect(updatedPr?.state).toBe('merged')
-      // Original fields preserved
-      expect(updatedPr?.prNumber).toBe(42)
-      expect(updatedPr?.prUrl).toBe('https://github.com/org/repo/pull/42')
-    })
-
-    test('does not transition to merged if prMerge fails', () => {
-      useGitStore.getState().setPrState('wt-1', {
-        state: 'created',
-        prNumber: 42
-      })
-
-      // Simulate failed merge — handleMergePR shows toast but does NOT call setPrState
-      const mergeResult = { success: false, error: 'Merge conflicts' }
-      if (mergeResult.success) {
-        const pr = useGitStore.getState().prInfo.get('wt-1')!
-        useGitStore.getState().setPrState('wt-1', { ...pr, state: 'merged' })
+    test('successful merge updates live PR state and preserves title', () => {
+      const previousLiveState = {
+        state: 'OPEN',
+        title: 'Ship PR lifecycle'
       }
 
-      expect(useGitStore.getState().prInfo.get('wt-1')?.state).toBe('created')
+      const nextLiveState = {
+        state: 'MERGED',
+        title: previousLiveState.title
+      }
+
+      expect(nextLiveState).toEqual({
+        state: 'MERGED',
+        title: 'Ship PR lifecycle'
+      })
     })
 
-    test('handleMergePR does nothing when prNumber is missing', () => {
-      useGitStore.getState().setPrState('wt-1', {
-        state: 'created'
-        // no prNumber
-      })
+    test('failed merge keeps live PR state unchanged', () => {
+      const previousLiveState = {
+        state: 'OPEN',
+        title: 'Ship PR lifecycle'
+      }
+      const mergeResult = { success: false, error: 'Merge conflicts' }
 
-      const pr = useGitStore.getState().prInfo.get('wt-1')
-      // handleMergePR guard: if (!pr?.prNumber) return
-      const shouldProceed = !!pr?.prNumber
-      expect(shouldProceed).toBe(false)
+      const nextLiveState = mergeResult.success
+        ? { state: 'MERGED', title: previousLiveState.title }
+        : previousLiveState
+
+      expect(nextLiveState).toBe(previousLiveState)
+    })
+
+    test('merge guard requires an attached PR number', () => {
+      expect(useGitStore.getState().attachedPR.get('wt-1')?.number).toBeUndefined()
     })
   })
 
   describe('full lifecycle transitions', () => {
-    test('none → creating → created → merged', () => {
-      // Start: no prInfo
-      expect(useGitStore.getState().prInfo.get('wt-1')).toBeUndefined()
+    test('none to creating to attached to merged live state', () => {
+      expect(useGitStore.getState().prCreation.get('wt-1')).toBeUndefined()
+      expect(useGitStore.getState().attachedPR.get('wt-1')).toBeUndefined()
 
-      // Step 1: handleCreatePR — set to creating
-      useGitStore.getState().setPrState('wt-1', {
-        state: 'creating',
-        sessionId: 'session-1',
-        targetBranch: 'origin/main'
+      useGitStore.getState().setPrCreation('wt-1', {
+        creating: true,
+        sessionId: 'session-1'
       })
-      expect(useGitStore.getState().prInfo.get('wt-1')?.state).toBe('creating')
+      expect(useGitStore.getState().prCreation.get('wt-1')?.creating).toBe(true)
 
-      // Step 2: PR URL detected — set to created
-      const pr1 = useGitStore.getState().prInfo.get('wt-1')!
-      useGitStore.getState().setPrState('wt-1', {
-        ...pr1,
-        state: 'created',
-        prNumber: 42,
-        prUrl: 'https://github.com/org/repo/pull/42'
+      useGitStore.getState().setAttachedPR('wt-1', {
+        number: 42,
+        url: 'https://github.com/org/repo/pull/42'
       })
-      expect(useGitStore.getState().prInfo.get('wt-1')?.state).toBe('created')
-      expect(useGitStore.getState().prInfo.get('wt-1')?.prNumber).toBe(42)
+      useGitStore.getState().setPrCreation('wt-1', null)
 
-      // Step 3: handleMergePR success — set to merged
-      const pr2 = useGitStore.getState().prInfo.get('wt-1')!
-      useGitStore.getState().setPrState('wt-1', { ...pr2, state: 'merged' })
-      expect(useGitStore.getState().prInfo.get('wt-1')?.state).toBe('merged')
+      expect(useGitStore.getState().prCreation.get('wt-1')).toBeUndefined()
+      expect(useGitStore.getState().attachedPR.get('wt-1')?.number).toBe(42)
 
-      // All fields preserved through transitions
-      const finalPr = useGitStore.getState().prInfo.get('wt-1')
-      expect(finalPr?.sessionId).toBe('session-1')
-      expect(finalPr?.targetBranch).toBe('origin/main')
-      expect(finalPr?.prNumber).toBe(42)
-      expect(finalPr?.prUrl).toBe('https://github.com/org/repo/pull/42')
-    })
-
-    test('target branch dropdown hidden when showing Merge PR', () => {
-      // When prState === 'created' && isCleanTree, only pr-merge-button shows
-      // The PR button + dropdown block requires:
-      // prState === 'none' || prState === 'creating' || (prState === 'created' && !isCleanTree)
-      const prState: string = 'created'
-      const isCleanTree = true
-      const showsPRButtonWithDropdown =
-        prState === 'none' || prState === 'creating' || (prState === 'created' && !isCleanTree)
-      expect(showsPRButtonWithDropdown).toBe(false)
-    })
-
-    test('target branch dropdown hidden when showing Archive', () => {
-      const prState: string = 'merged'
-      const showsPRButtonWithDropdown =
-        prState === 'none' || prState === 'creating' || (prState === 'created' && false)
-      expect(showsPRButtonWithDropdown).toBe(false)
-    })
-
-    test('target branch dropdown visible when state is none', () => {
-      const prState: string = 'none'
-      const showsPRButtonWithDropdown =
-        prState === 'none' || prState === 'creating' || (prState === 'created' && false)
-      expect(showsPRButtonWithDropdown).toBe(true)
-    })
-
-    test('target branch dropdown visible when state is creating', () => {
-      const prState: string = 'creating'
-      const showsPRButtonWithDropdown =
-        prState === 'none' || prState === 'creating' || (prState === 'created' && false)
-      expect(showsPRButtonWithDropdown).toBe(true)
+      const liveState = {
+        state: 'MERGED',
+        title: 'Ship PR lifecycle'
+      }
+      expect(liveState.state).toBe('MERGED')
+      expect(liveState.title).toBe('Ship PR lifecycle')
     })
   })
 })

--- a/test/phase-23/header-pr-title.test.tsx
+++ b/test/phase-23/header-pr-title.test.tsx
@@ -1,0 +1,122 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { Header } from '@/components/layout/Header'
+import { useConnectionStore } from '@/stores/useConnectionStore'
+import { useGitStore } from '@/stores/useGitStore'
+import { useProjectStore } from '@/stores/useProjectStore'
+import { useSettingsStore } from '@/stores/useSettingsStore'
+import { useWorktreeStore } from '@/stores/useWorktreeStore'
+
+vi.mock('@/hooks/usePRDetection', () => ({
+  usePRDetection: vi.fn()
+}))
+
+vi.mock('@/lib/platform', () => ({
+  isMac: () => false
+}))
+
+vi.mock('@/assets/icon.png', () => ({
+  default: 'mock-icon.png'
+}))
+
+const listBranchesWithStatusMock = vi.fn()
+const getPRStateMock = vi.fn()
+
+const project = {
+  id: 'proj-1',
+  name: 'Xuanpu',
+  path: '/repos/xuanpu',
+  description: null,
+  tags: null,
+  language: null,
+  custom_icon: null,
+  setup_script: null,
+  run_script: null,
+  archive_script: null,
+  auto_assign_port: false,
+  sort_order: 0,
+  created_at: '2026-05-09T00:00:00.000Z',
+  last_accessed_at: '2026-05-09T00:00:00.000Z'
+}
+
+const worktree = {
+  id: 'wt-1',
+  project_id: 'proj-1',
+  name: 'hive-upstream',
+  branch_name: 'feat/pr-title',
+  path: '/repos/xuanpu/hive-upstream',
+  status: 'active' as const,
+  is_default: false,
+  branch_renamed: 0,
+  last_message_at: null,
+  session_titles: '[]',
+  last_model_provider_id: null,
+  last_model_id: null,
+  last_model_variant: null,
+  created_at: '2026-05-09T00:00:00.000Z',
+  last_accessed_at: '2026-05-09T00:00:00.000Z'
+}
+
+describe('Header PR title badge', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    listBranchesWithStatusMock.mockResolvedValue({ success: true, branches: [] })
+    getPRStateMock.mockResolvedValue({
+      success: true,
+      state: 'OPEN',
+      title: 'Show PR title in notification widget'
+    })
+
+    Object.defineProperty(window, 'gitOps', {
+      configurable: true,
+      writable: true,
+      value: {
+        ...window.gitOps,
+        listBranchesWithStatus: listBranchesWithStatusMock,
+        getPRState: getPRStateMock
+      }
+    })
+
+    useSettingsStore.setState({ locale: 'en', vimModeEnabled: false })
+    useConnectionStore.setState({ connections: [], selectedConnectionId: null })
+    useProjectStore.setState({ projects: [project], selectedProjectId: 'proj-1' })
+    useWorktreeStore.setState({
+      selectedWorktreeId: 'wt-1',
+      worktreesByProject: new Map([['proj-1', [worktree]]])
+    })
+    useGitStore.setState({
+      remoteInfo: new Map([
+        ['wt-1', { hasRemote: true, isGitHub: true, url: 'https://github.com/org/repo' }]
+      ]),
+      prCreation: new Map(),
+      attachedPR: new Map([['wt-1', { number: 42, url: 'https://github.com/org/repo/pull/42' }]]),
+      fileStatusesByWorktree: new Map([['/repos/xuanpu/hive-upstream', []]]),
+      branchInfoByWorktree: new Map([
+        [
+          '/repos/xuanpu/hive-upstream',
+          { name: 'feat/pr-title', tracking: 'origin/main', ahead: 0, behind: 0 }
+        ]
+      ]),
+      conflictsByWorktree: {},
+      isPushing: false,
+      isPulling: false,
+      isLoading: false,
+      error: null
+    })
+  })
+
+  test('loads and shows the attached PR title on the badge', async () => {
+    render(<Header />)
+
+    await waitFor(() => {
+      expect(getPRStateMock).toHaveBeenCalledWith('/repos/xuanpu', 42)
+    })
+
+    const badge = screen.getByTestId('pr-badge')
+
+    await waitFor(() => {
+      expect(badge).toHaveTextContent('Show PR title in notification widget')
+    })
+    expect(badge).toHaveAttribute('title', 'PR #42: Show PR title in notification widget')
+  })
+})

--- a/test/phase-23/plan-card-copy.test.tsx
+++ b/test/phase-23/plan-card-copy.test.tsx
@@ -1,0 +1,49 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { PlanCard } from '@/components/session-hq/cards/PlanCard'
+import { toast } from '@/lib/toast'
+
+vi.mock('@/lib/toast', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn()
+  }
+}))
+
+const writeTextMock = vi.fn().mockResolvedValue(undefined)
+
+Object.defineProperty(navigator, 'clipboard', {
+  configurable: true,
+  writable: true,
+  value: {
+    writeText: writeTextMock
+  }
+})
+
+describe('PlanCard copy markdown', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    writeTextMock.mockResolvedValue(undefined)
+  })
+
+  test('copies the raw plan markdown without collapsing the card', async () => {
+    const markdown = ['# Ship PR6', '', '- Show PR title', '- Copy plan markdown'].join('\n')
+
+    render(<PlanCard content={markdown} isPending />)
+
+    fireEvent.click(screen.getByTestId('plan-card-copy-button'))
+
+    await waitFor(() => {
+      expect(writeTextMock).toHaveBeenCalledWith(markdown)
+      expect(toast.success).toHaveBeenCalledWith('Plan markdown copied to clipboard')
+    })
+
+    expect(screen.getByText('Copy plan markdown')).toBeInTheDocument()
+  })
+
+  test('does not render a copy button for empty plan content', () => {
+    render(<PlanCard content="  " isPending />)
+
+    expect(screen.queryByTestId('plan-card-copy-button')).not.toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary

- Show the attached PR title directly on the Header PR badge after loading live PR metadata.
- Keep PR live state keyed by PR number so stale titles/status do not leak across attachments.
- Add a compact copy button to plan cards that copies the raw plan markdown.
- Refresh the stale PR Header UI tests to the current prCreation/attachedPR lifecycle model.

## Verification

- pnpm exec tsc --noEmit --pretty false
- pnpm vitest run test/phase-20/session-5/pr-header-ui.test.tsx test/phase-23/header-pr-title.test.tsx test/phase-23/plan-card-copy.test.tsx test/phase-9/session-8/copy-on-hover.test.tsx
- git diff --check
- pnpm lint (passes with existing 42 warnings)
- pnpm build (passes with existing Vite dynamic/static import warnings)
