### PR TITLE
Improve Session HQ Chinese localization coverage

### DIFF
--- a/src/renderer/src/components/session-hq/AgentRail.tsx
+++ b/src/renderer/src/components/session-hq/AgentRail.tsx
@@ -9,6 +9,7 @@ import React from 'react'
 import { cn } from '@/lib/utils'
 import type { SessionRuntimeState, InterruptItem } from '@/stores/useSessionRuntimeStore'
 import { Wrench, AlertCircle, MessageCircle, CheckCircle } from 'lucide-react'
+import { useI18n } from '@/i18n/useI18n'
 
 // ---------------------------------------------------------------------------
 // Props
@@ -29,6 +30,7 @@ export interface AgentRailProps {
 // ---------------------------------------------------------------------------
 
 function InterruptQueueItem({ item }: { item: InterruptItem }): React.JSX.Element {
+  const { t } = useI18n()
   const iconMap = {
     question: <MessageCircle className="h-3.5 w-3.5 text-blue-400" />,
     permission: <AlertCircle className="h-3.5 w-3.5 text-yellow-400" />,
@@ -37,10 +39,10 @@ function InterruptQueueItem({ item }: { item: InterruptItem }): React.JSX.Elemen
   }
 
   const labelMap = {
-    question: 'Question pending',
-    permission: 'Permission needed',
-    command_approval: 'Command approval',
-    plan: 'Plan approval'
+    question: t('sessionHq.agentRail.interrupts.question'),
+    permission: t('sessionHq.agentRail.interrupts.permission'),
+    command_approval: t('sessionHq.agentRail.interrupts.commandApproval'),
+    plan: t('sessionHq.agentRail.interrupts.plan')
   }
 
   return (
@@ -61,12 +63,11 @@ export function AgentRail({
   unreadCount,
   collapsed = false
 }: AgentRailProps): React.JSX.Element | null {
+  const { t } = useI18n()
+
   // Don't render the rail when there's nothing to show
   const hasContent =
-    interruptQueue.length > 0 ||
-    unreadCount > 0 ||
-    lifecycle === 'busy' ||
-    lifecycle === 'retry'
+    interruptQueue.length > 0 || unreadCount > 0 || lifecycle === 'busy' || lifecycle === 'retry'
 
   if (collapsed || !hasContent) return null
 
@@ -82,7 +83,11 @@ export function AgentRail({
         <div className="px-3 py-3 border-b border-border">
           <div className="flex items-center gap-2 text-xs text-muted-foreground">
             <Wrench className="h-3.5 w-3.5 animate-spin" />
-            <span>{lifecycle === 'busy' ? 'Working...' : 'Retrying...'}</span>
+            <span>
+              {lifecycle === 'busy'
+                ? t('sessionHq.agentRail.status.working')
+                : t('sessionHq.agentRail.status.retrying')}
+            </span>
           </div>
         </div>
       )}
@@ -91,7 +96,7 @@ export function AgentRail({
       {interruptQueue.length > 0 && (
         <div className="px-3 py-3 space-y-2">
           <div className="text-[11px] font-medium text-muted-foreground uppercase tracking-wider">
-            Pending ({interruptQueue.length})
+            {t('sessionHq.agentRail.pending', { count: interruptQueue.length })}
           </div>
           {interruptQueue.map((item) => (
             <InterruptQueueItem key={item.id} item={item} />
@@ -102,7 +107,13 @@ export function AgentRail({
       {/* Unread count */}
       {unreadCount > 0 && (
         <div className="px-3 py-2 text-xs text-muted-foreground">
-          {unreadCount} unread {unreadCount === 1 ? 'message' : 'messages'}
+          {t('sessionHq.agentRail.unread', {
+            count: unreadCount,
+            label:
+              unreadCount === 1
+                ? t('sessionHq.agentRail.messageSingular')
+                : t('sessionHq.agentRail.messagePlural')
+          })}
         </div>
       )}
     </div>

--- a/src/renderer/src/components/session-hq/AgentTimeline.tsx
+++ b/src/renderer/src/components/session-hq/AgentTimeline.tsx
@@ -427,7 +427,7 @@ function TimelineNodeView({
             {node.message.steered === true && (
               <div className="mb-2">
                 <span className="inline-flex items-center rounded-md bg-sky-500/15 px-2 py-0.5 text-[10px] font-semibold text-sky-500">
-                  STEERED
+                  {t('sessionHq.timeline.steered')}
                 </span>
               </div>
             )}
@@ -582,8 +582,12 @@ function TimelineNodeView({
               id: node.toolUse.id,
               sessionID: '',
               prompt: (node.toolUse.input?.prompt as string) ?? '',
-              description: (node.toolUse.input?.description as string) ?? 'Delegated task',
-              agent: (node.toolUse.input?.subagent_type as string) ?? 'Agent',
+              description:
+                (node.toolUse.input?.description as string) ??
+                t('sessionHq.cards.subAgent.defaultDescription'),
+              agent:
+                (node.toolUse.input?.subagent_type as string) ??
+                t('sessionHq.cards.subAgent.agentFallback'),
               parts: [],
               status: (node.toolUse.status === 'success'
                 ? 'completed'
@@ -652,11 +656,11 @@ function TimelineNodeView({
             <span className="font-medium text-foreground">{label}</span>
             <span className="text-xs text-muted-foreground">
               {isRunning
-                ? 'Running...'
+                ? t('sessionHq.timeline.genericToolStatus.running')
                 : isError
-                  ? 'Error'
+                  ? t('sessionHq.timeline.genericToolStatus.error')
                   : isSuccess
-                    ? 'Done'
+                    ? t('sessionHq.timeline.genericToolStatus.done')
                     : node.toolUse.status}
             </span>
           </div>
@@ -778,6 +782,8 @@ export function AgentTimeline({
   onPointerCancel,
   bottomFloatingHeight = 0
 }: AgentTimelineProps): React.JSX.Element {
+  const { t } = useI18n()
+
   // Flatten messages into timeline nodes
   const nodes = useMemo(() => {
     // Compute a numeric cutoff for the active run. Assistant messages whose
@@ -1232,7 +1238,9 @@ export function AgentTimeline({
             >
               <Loader2 className="h-3 w-3 animate-spin" />
             </div>
-            <div className="text-sm text-muted-foreground italic">Thinking…</div>
+            <div className="text-sm text-muted-foreground italic">
+              {t('sessionHq.timeline.thinking')}
+            </div>
           </div>
         )}
 
@@ -1244,8 +1252,8 @@ export function AgentTimeline({
         {nodes.length === 0 && ephemeralStatusRows.length === 0 && !isStreaming && !sessionGoal && (
           <div className="flex flex-col items-center justify-center py-20 text-muted-foreground">
             <MessageSquare className="h-10 w-10 mb-3 opacity-30" />
-            <div className="text-sm font-medium">No messages yet</div>
-            <div className="text-xs mt-1">Send a message to start the conversation</div>
+            <div className="text-sm font-medium">{t('sessionHq.timeline.emptyTitle')}</div>
+            <div className="text-xs mt-1">{t('sessionHq.timeline.emptySubtitle')}</div>
           </div>
         )}
       </div>

--- a/src/renderer/src/components/session-hq/MissionControl.tsx
+++ b/src/renderer/src/components/session-hq/MissionControl.tsx
@@ -20,6 +20,7 @@ import {
   Loader2,
   User
 } from 'lucide-react'
+import { useI18n } from '@/i18n/useI18n'
 
 // ---------------------------------------------------------------------------
 // Types
@@ -67,6 +68,7 @@ export function MissionControl({
   allComplete,
   isStreaming
 }: MissionControlProps): React.JSX.Element | null {
+  const { t } = useI18n()
   const [expanded, setExpanded] = useState(false)
   const [leaving, setLeaving] = useState(false)
 
@@ -86,13 +88,8 @@ export function MissionControl({
     [tasks]
   )
   const totalCount = tasks.length
-  const progressPercent = totalCount > 0
-    ? Math.round((completedCount / totalCount) * 100)
-    : 0
-  const activeTask = useMemo(
-    () => tasks.find((t) => t.status === 'in_progress'),
-    [tasks]
-  )
+  const progressPercent = totalCount > 0 ? Math.round((completedCount / totalCount) * 100) : 0
+  const activeTask = useMemo(() => tasks.find((t) => t.status === 'in_progress'), [tasks])
 
   // Don't render when not visible and not animating out
   if (!visible && !leaving) return null
@@ -146,10 +143,13 @@ export function MissionControl({
         {/* Current task / summary */}
         <span className="text-sm font-medium text-foreground truncate flex-1">
           {allComplete
-            ? 'All tasks completed'
+            ? t('sessionHq.missionControl.allTasksCompleted')
             : activeTask
               ? activeTask.content
-              : `${completedCount}/${totalCount} tasks`}
+              : t('sessionHq.missionControl.taskCount', {
+                  completed: completedCount,
+                  total: totalCount
+                })}
         </span>
 
         {/* Progress track */}

--- a/src/renderer/src/components/session-hq/SessionHeader.tsx
+++ b/src/renderer/src/components/session-hq/SessionHeader.tsx
@@ -6,7 +6,15 @@
  */
 
 import { useMemo, useState } from 'react'
-import { DollarSign, Clock3, Layers3, TriangleAlert, Lock, TerminalSquare, Check } from 'lucide-react'
+import {
+  DollarSign,
+  Clock3,
+  Layers3,
+  TriangleAlert,
+  Lock,
+  TerminalSquare,
+  Check
+} from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { ModelSelector } from '../sessions/ModelSelector'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
@@ -32,16 +40,38 @@ type AgentSdk = 'opencode' | 'claude-code' | 'codex' | 'terminal'
 const PROVIDER_LABELS: Record<string, string> = {
   'claude-code': 'Claude',
   opencode: 'OpenCode',
-  codex: 'Codex',
-  terminal: 'Terminal'
+  codex: 'Codex'
 }
 
-const LIFECYCLE_META: Record<SessionLifecycle, { label: string; dotClass: string }> = {
-  idle: { label: 'Idle', dotClass: 'bg-muted-foreground/50' },
-  busy: { label: 'Working', dotClass: 'bg-celadon animate-pulse' },
-  retry: { label: 'Retrying', dotClass: 'bg-yellow-500 animate-pulse' },
-  error: { label: 'Error', dotClass: 'bg-red-500' },
-  materializing: { label: 'Starting', dotClass: 'bg-blue-500 animate-pulse' }
+function getProviderLabel(sdk: string, t: ReturnType<typeof useI18n>['t']): string {
+  if (sdk === 'terminal') return t('bottomPanel.tabs.terminal')
+  return PROVIDER_LABELS[sdk] ?? sdk
+}
+
+function getLifecycleLabel(
+  lifecycle: SessionLifecycle,
+  t: ReturnType<typeof useI18n>['t']
+): string {
+  switch (lifecycle) {
+    case 'idle':
+      return t('sessionHq.header.lifecycle.idle')
+    case 'busy':
+      return t('sessionHq.header.lifecycle.busy')
+    case 'retry':
+      return t('sessionHq.header.lifecycle.retry')
+    case 'error':
+      return t('sessionHq.header.lifecycle.error')
+    case 'materializing':
+      return t('sessionHq.header.lifecycle.materializing')
+  }
+}
+
+const LIFECYCLE_META: Record<SessionLifecycle, { dotClass: string }> = {
+  idle: { dotClass: 'bg-muted-foreground/50' },
+  busy: { dotClass: 'bg-celadon animate-pulse' },
+  retry: { dotClass: 'bg-yellow-500 animate-pulse' },
+  error: { dotClass: 'bg-red-500' },
+  materializing: { dotClass: 'bg-blue-500 animate-pulse' }
 }
 
 function formatNumber(n: number): string {
@@ -86,7 +116,8 @@ function ProviderCapsule({
   locked: boolean
 }): React.JSX.Element {
   const { t } = useI18n()
-  const label = PROVIDER_LABELS[sdk] ?? sdk
+  const label = getProviderLabel(sdk, t)
+  const lifecycleLabel = getLifecycleLabel(lifecycle, t)
   const meta = LIFECYCLE_META[lifecycle] ?? LIFECYCLE_META.idle
   const availableAgentSdks = useSettingsStore((s) => s.availableAgentSdks)
   const [open, setOpen] = useState(false)
@@ -107,6 +138,7 @@ function ProviderCapsule({
           <span
             className="inline-flex items-center gap-1.5 border border-border/40 rounded-md px-2 py-1 text-[11px] font-medium text-muted-foreground cursor-default"
             data-testid="provider-capsule-locked"
+            title={lifecycleLabel}
           >
             <span className={cn('h-1.5 w-1.5 rounded-full', meta.dotClass)} />
             {label}
@@ -130,7 +162,7 @@ function ProviderCapsule({
       agentSdk: next
     })
     if (!result.success) {
-      toast.error(result.error || 'Failed to update provider')
+      toast.error(result.error || t('sessionHq.header.providerUpdateError'))
     }
   }
 
@@ -141,6 +173,7 @@ function ProviderCapsule({
           type="button"
           className="inline-flex items-center gap-1.5 border border-border/40 rounded-md px-2 py-1 text-[11px] font-medium text-muted-foreground hover:bg-muted/40 hover:text-foreground transition-colors cursor-pointer"
           data-testid="provider-capsule"
+          title={lifecycleLabel}
         >
           <span className={cn('h-1.5 w-1.5 rounded-full', meta.dotClass)} />
           {label}
@@ -158,14 +191,12 @@ function ProviderCapsule({
               }}
               className={cn(
                 'flex w-full items-center justify-between gap-2 rounded-md px-2 py-1.5 text-xs transition-colors',
-                active
-                  ? 'bg-primary/10 text-primary'
-                  : 'text-foreground hover:bg-muted/60'
+                active ? 'bg-primary/10 text-primary' : 'text-foreground hover:bg-muted/60'
               )}
             >
               <span className="flex items-center gap-1.5">
                 {s === 'terminal' && <TerminalSquare className="h-3.5 w-3.5 text-emerald-500" />}
-                {PROVIDER_LABELS[s] ?? s}
+                {getProviderLabel(s, t)}
               </span>
               {active && <Check className="h-3.5 w-3.5" />}
             </button>
@@ -185,6 +216,8 @@ function ContextCapsule({
   modelId: string
   providerId: string
 }): React.JSX.Element | null {
+  const { t } = useI18n()
+
   // useShallow + field picking is required: getContextUsage() returns a fresh
   // object each call, and some fields (model, cost, rawMaxTokens) can also be
   // freshly-allocated — a naive selector would loop useSyncExternalStore.
@@ -228,10 +261,10 @@ function ContextCapsule({
       </TooltipTrigger>
       <TooltipContent side="bottom" sideOffset={8} className="max-w-[260px]">
         <div className="space-y-1.5">
-          <div className="font-medium">Context Window</div>
+          <div className="font-medium">{t('contextIndicator.title')}</div>
           <div>
             {formatNumber(used)}
-            {limit ? ` / ${formatNumber(limit)}` : ''} tokens
+            {limit ? ` / ${formatNumber(limit)}` : ''} {t('sessionHq.header.tokens')}
           </div>
           {categories && categories.length > 0 ? (
             <div className="border-t border-background/20 pt-1.5 space-y-0.5 text-[10px] opacity-80">
@@ -244,22 +277,36 @@ function ContextCapsule({
             </div>
           ) : (
             <div className="border-t border-background/20 pt-1.5 space-y-0.5 text-[10px] opacity-80">
-              <div className="text-[10px] opacity-100">Latest turn API usage</div>
-              <div>Input: {formatNumber(tokens.input)}</div>
-              <div>Cache read: {formatNumber(tokens.cacheRead)}</div>
-              <div>Cache write: {formatNumber(tokens.cacheWrite)}</div>
+              <div className="text-[10px] opacity-100">{t('contextIndicator.latestTurn')}</div>
+              <div>
+                {t('contextIndicator.labels.input')}: {formatNumber(tokens.input)}
+              </div>
+              <div>
+                {t('contextIndicator.labels.cacheRead')}: {formatNumber(tokens.cacheRead)}
+              </div>
+              <div>
+                {t('contextIndicator.labels.cacheWrite')}: {formatNumber(tokens.cacheWrite)}
+              </div>
             </div>
           )}
           {(tokens.output > 0 || tokens.reasoning > 0) && (
             <div className="border-t border-background/20 pt-1.5 space-y-0.5 text-[10px] opacity-60">
-              <div className="text-[10px]">Generated</div>
-              {tokens.output > 0 && <div>Output: {formatNumber(tokens.output)}</div>}
-              {tokens.reasoning > 0 && <div>Reasoning: {formatNumber(tokens.reasoning)}</div>}
+              <div className="text-[10px]">{t('contextIndicator.generated.title')}</div>
+              {tokens.output > 0 && (
+                <div>
+                  {t('contextIndicator.generated.output')}: {formatNumber(tokens.output)}
+                </div>
+              )}
+              {tokens.reasoning > 0 && (
+                <div>
+                  {t('contextIndicator.generated.reasoning')}: {formatNumber(tokens.reasoning)}
+                </div>
+              )}
             </div>
           )}
           {isRefreshing && (
             <div className="border-t border-background/20 pt-1.5 text-[10px] opacity-70">
-              Compressing context...
+              {t('sessionHq.header.compressingContext')}
             </div>
           )}
         </div>
@@ -277,6 +324,7 @@ function CostCapsule({
   fallbackCost: number
   fallbackTokens: { input: number; output: number; cacheRead: number; cacheWrite: number } | null
 }): React.JSX.Element | null {
+  const { t } = useI18n()
   const totalCost = Math.max(summary?.total_cost ?? 0, fallbackCost ?? 0)
   const hasSummaryTokens = (summary?.total_tokens ?? 0) > 0
   const totalTokens = summary?.total_tokens ?? 0
@@ -300,33 +348,37 @@ function CostCapsule({
         <PopoverHeader className="gap-2">
           <PopoverTitle className="flex items-center gap-2 text-sm">
             <DollarSign className="h-4 w-4 text-muted-foreground" />
-            Session Cost
+            {t('sessionView.costPill.title')}
           </PopoverTitle>
         </PopoverHeader>
         <div className="mt-3 space-y-2 text-xs">
           <div className="flex items-center justify-between gap-3">
-            <span className="text-muted-foreground">Total cost</span>
+            <span className="text-muted-foreground">{t('sessionView.costPill.totalCost')}</span>
             <span className="font-mono font-medium">{formatCurrency(totalCost)}</span>
           </div>
           <div className="flex items-center justify-between gap-3">
-            <span className="text-muted-foreground">Total tokens</span>
+            <span className="text-muted-foreground">{t('sessionView.costPill.totalTokens')}</span>
             {hasSummaryTokens ? (
               <span className="font-mono">{formatTokensShort(totalTokens)}</span>
             ) : (
-              <span className="text-muted-foreground">Session totals are syncing…</span>
+              <span className="text-muted-foreground">
+                {t('sessionView.costPill.totalsSyncing')}
+              </span>
             )}
           </div>
           {hasSummaryTokens ? (
             <div className="grid grid-cols-2 gap-2 border-t border-border/70 pt-2">
               <div className="rounded-lg bg-muted/45 px-2 py-1.5">
-                <div className="text-[10px] uppercase tracking-wide text-muted-foreground">Input</div>
+                <div className="text-[10px] uppercase tracking-wide text-muted-foreground">
+                  {t('sessionView.costPill.input')}
+                </div>
                 <div className="mt-1 font-mono">
                   {formatTokensShort(summary?.input_tokens ?? 0)}
                 </div>
               </div>
               <div className="rounded-lg bg-muted/45 px-2 py-1.5">
                 <div className="text-[10px] uppercase tracking-wide text-muted-foreground">
-                  Output
+                  {t('sessionView.costPill.output')}
                 </div>
                 <div className="mt-1 font-mono">
                   {formatTokensShort(summary?.output_tokens ?? 0)}
@@ -334,7 +386,7 @@ function CostCapsule({
               </div>
               <div className="rounded-lg bg-muted/45 px-2 py-1.5">
                 <div className="text-[10px] uppercase tracking-wide text-muted-foreground">
-                  Cache write
+                  {t('sessionView.costPill.cacheWrite')}
                 </div>
                 <div className="mt-1 font-mono">
                   {formatTokensShort(summary?.cache_write_tokens ?? 0)}
@@ -342,7 +394,7 @@ function CostCapsule({
               </div>
               <div className="rounded-lg bg-muted/45 px-2 py-1.5">
                 <div className="text-[10px] uppercase tracking-wide text-muted-foreground">
-                  Cache read
+                  {t('sessionView.costPill.cacheRead')}
                 </div>
                 <div className="mt-1 font-mono">
                   {formatTokensShort(summary?.cache_read_tokens ?? 0)}
@@ -354,7 +406,7 @@ function CostCapsule({
             <div className="flex items-center justify-between gap-3 border-t border-border/70 pt-2">
               <span className="flex items-center gap-1.5 text-muted-foreground">
                 <Layers3 className="h-3.5 w-3.5" />
-                Model
+                {t('sessionView.costPill.model')}
               </span>
               <span className="truncate font-medium" title={modelSummary.full}>
                 {modelSummary.short}
@@ -365,7 +417,7 @@ function CostCapsule({
             <div className="flex items-center justify-between gap-3">
               <span className="flex items-center gap-1.5 text-muted-foreground">
                 <Clock3 className="h-3.5 w-3.5" />
-                Duration
+                {t('sessionView.costPill.duration')}
               </span>
               <span className="font-mono">{formatDuration(summary.duration_seconds)}</span>
             </div>
@@ -373,7 +425,7 @@ function CostCapsule({
           {summary?.partial && (
             <div className="rounded-lg border border-amber-500/20 bg-amber-500/10 px-2.5 py-2 text-[11px] text-amber-700 dark:text-amber-300">
               <TriangleAlert className="inline h-3 w-3 mr-1" />
-              Partial data — some usage may not be reflected yet.
+              {t('sessionView.costPill.partialData')}
             </div>
           )}
         </div>
@@ -421,13 +473,7 @@ export function SessionHeader({
         lifecycle={lifecycle}
         locked={locked}
       />
-      {!isTerminal && (
-        <ModelSelector
-          sessionId={sessionId}
-          compact
-          showProviderPrefix={false}
-        />
-      )}
+      {!isTerminal && <ModelSelector sessionId={sessionId} compact showProviderPrefix={false} />}
 
       <div className="flex-1" />
 

--- a/src/renderer/src/components/session-hq/cards/AskUserCard.tsx
+++ b/src/renderer/src/components/session-hq/cards/AskUserCard.tsx
@@ -13,6 +13,7 @@ import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
 import { Check, Pencil, ChevronRight } from 'lucide-react'
 import { isComposingKeyboardEvent } from '@/lib/message-composer-shortcuts'
+import { useI18n } from '@/i18n/useI18n'
 
 interface AskUserCardProps {
   question: string
@@ -41,13 +42,12 @@ export function AskUserCard({
   worktreePath,
   answer
 }: AskUserCardProps): React.JSX.Element {
+  const { t } = useI18n()
   const questionsList = questions ?? []
   const isMultiQuestion = questionsList.length > 1
 
   // Interactive state — only used when isPending
-  const [answers, setAnswers] = useState<string[][]>(() =>
-    questionsList.map(() => [])
-  )
+  const [answers, setAnswers] = useState<string[][]>(() => questionsList.map(() => []))
   const [currentTab, setCurrentTab] = useState(0)
   const [editingCustom, setEditingCustom] = useState(false)
   const [customInput, setCustomInput] = useState('')
@@ -74,32 +74,35 @@ export function AskUserCard({
     }
   }, [customInput])
 
-  const handleOptionClick = useCallback((label: string) => {
-    if (sending) return
-    if (isMultiple) {
-      setAnswers((prev) => {
-        const updated = [...prev]
-        const current = updated[currentTab] ?? []
-        updated[currentTab] = current.includes(label)
-          ? current.filter((l) => l !== label)
-          : [...current, label]
-        return updated
-      })
-    } else {
-      setAnswers((prev) => {
-        const updated = [...prev]
-        updated[currentTab] = [label]
-        return updated
-      })
-      // Auto-advance for single-choice multi-question
-      if (isMultiQuestion && !isLastTab) {
-        setTimeout(() => {
-          setCurrentTab((t) => t + 1)
-          setEditingCustom(false)
-        }, 150)
+  const handleOptionClick = useCallback(
+    (label: string) => {
+      if (sending) return
+      if (isMultiple) {
+        setAnswers((prev) => {
+          const updated = [...prev]
+          const current = updated[currentTab] ?? []
+          updated[currentTab] = current.includes(label)
+            ? current.filter((l) => l !== label)
+            : [...current, label]
+          return updated
+        })
+      } else {
+        setAnswers((prev) => {
+          const updated = [...prev]
+          updated[currentTab] = [label]
+          return updated
+        })
+        // Auto-advance for single-choice multi-question
+        if (isMultiQuestion && !isLastTab) {
+          setTimeout(() => {
+            setCurrentTab((t) => t + 1)
+            setEditingCustom(false)
+          }, 150)
+        }
       }
-    }
-  }, [sending, isMultiple, currentTab, isMultiQuestion, isLastTab])
+    },
+    [sending, isMultiple, currentTab, isMultiQuestion, isLastTab]
+  )
 
   const handleCustomSubmit = useCallback(() => {
     const text = customInput.trim()
@@ -147,8 +150,8 @@ export function AskUserCard({
         key="answered"
         accentClass="border-amber-500 bg-amber-500/5"
         headerClass="border-b-amber-500/20 text-amber-700 dark:text-amber-400"
-        headerLeft={<span className="font-semibold">Question for you</span>}
-        headerRight="Answered"
+        headerLeft={<span className="font-semibold">{t('sessionHq.cards.askUser.title')}</span>}
+        headerRight={t('sessionHq.cards.askUser.answered')}
         defaultExpanded={false}
         collapsible
       >
@@ -175,15 +178,17 @@ export function AskUserCard({
                             <span className="text-muted-foreground/40 shrink-0">&middot;</span>
                           )}
                           <div>
-                            <span className={cn(
-                              selected
-                                ? 'text-foreground font-semibold'
-                                : 'text-muted-foreground'
-                            )}>
+                            <span
+                              className={cn(
+                                selected ? 'text-foreground font-semibold' : 'text-muted-foreground'
+                              )}
+                            >
                               {opt.label}
                             </span>
                             {opt.description && (
-                              <span className="text-muted-foreground ml-1.5">&mdash; {opt.description}</span>
+                              <span className="text-muted-foreground ml-1.5">
+                                &mdash; {opt.description}
+                              </span>
                             )}
                           </div>
                         </div>
@@ -191,14 +196,18 @@ export function AskUserCard({
                     })}
 
                     {/* Custom answer — shown when user typed "Other" instead of picking a predefined option */}
-                    {answer && q.options && !q.options.some((opt) => isSelectedAnswer(opt.label)) && (
-                      <div className="mt-1 rounded-lg bg-amber-500/10 px-2.5 py-1.5 -mx-1">
-                        <div className="flex items-start gap-2 text-sm">
-                          <Check className="h-3.5 w-3.5 shrink-0 text-amber-600 dark:text-amber-400 mt-0.5" />
-                          <span className="text-foreground font-semibold whitespace-pre-wrap">{answer}</span>
+                    {answer &&
+                      q.options &&
+                      !q.options.some((opt) => isSelectedAnswer(opt.label)) && (
+                        <div className="mt-1 rounded-lg bg-amber-500/10 px-2.5 py-1.5 -mx-1">
+                          <div className="flex items-start gap-2 text-sm">
+                            <Check className="h-3.5 w-3.5 shrink-0 text-amber-600 dark:text-amber-400 mt-0.5" />
+                            <span className="text-foreground font-semibold whitespace-pre-wrap">
+                              {answer}
+                            </span>
+                          </div>
                         </div>
-                      </div>
-                    )}
+                      )}
                   </div>
                 )}
               </div>
@@ -218,8 +227,8 @@ export function AskUserCard({
       key="pending"
       accentClass="border-amber-500 bg-amber-500/5"
       headerClass="border-b-amber-500/20 text-amber-700 dark:text-amber-400"
-      headerLeft={<span className="font-semibold">Question for you</span>}
-      headerRight="Waiting for reply"
+      headerLeft={<span className="font-semibold">{t('sessionHq.cards.askUser.title')}</span>}
+      headerRight={t('sessionHq.cards.askUser.waitingForReply')}
       defaultExpanded
       collapsible={false}
     >
@@ -229,7 +238,10 @@ export function AskUserCard({
           {questionsList.map((q, i) => (
             <button
               key={i}
-              onClick={() => { setCurrentTab(i); setEditingCustom(false) }}
+              onClick={() => {
+                setCurrentTab(i)
+                setEditingCustom(false)
+              }}
               className={cn(
                 'inline-flex items-center gap-1 rounded-full border px-2.5 py-1 text-[11px] font-medium transition-colors',
                 i === currentTab
@@ -247,9 +259,7 @@ export function AskUserCard({
       {/* Current question */}
       {currentQuestion ? (
         <>
-          <p className="text-sm font-medium text-foreground mb-3">
-            {currentQuestion.question}
-          </p>
+          <p className="text-sm font-medium text-foreground mb-3">{currentQuestion.question}</p>
 
           {/* Clickable option buttons */}
           {currentQuestion.options && currentQuestion.options.length > 0 && (
@@ -321,7 +331,7 @@ export function AskUserCard({
                 >
                   <div className="flex items-center gap-2 text-muted-foreground">
                     <Pencil className="h-3.5 w-3.5 shrink-0" />
-                    <span className="text-sm">Other...</span>
+                    <span className="text-sm">{t('sessionHq.cards.askUser.other')}</span>
                   </div>
                 </button>
               )}
@@ -334,8 +344,12 @@ export function AskUserCard({
                     autoFocus
                     value={customInput}
                     onChange={(e) => setCustomInput(e.target.value)}
-                    onCompositionStart={() => { isImeComposingRef.current = true }}
-                    onCompositionEnd={() => { isImeComposingRef.current = false }}
+                    onCompositionStart={() => {
+                      isImeComposingRef.current = true
+                    }}
+                    onCompositionEnd={() => {
+                      isImeComposingRef.current = false
+                    }}
                     onKeyDown={(e) => {
                       if (
                         e.key === 'Enter' &&
@@ -350,7 +364,7 @@ export function AskUserCard({
                       }
                     }}
                     className="min-h-[44px] max-h-[200px] w-full resize-none rounded-lg border border-border/70 bg-background px-3 py-2 text-sm transition-colors focus:border-amber-400/70 focus:outline-none"
-                    placeholder="Type your answer..."
+                    placeholder={t('questionPrompt.custom.placeholder')}
                     rows={1}
                     disabled={sending}
                   />
@@ -360,7 +374,7 @@ export function AskUserCard({
                       onClick={handleCustomSubmit}
                       disabled={!customInput.trim() || sending}
                     >
-                      OK
+                      {t('sessionHq.cards.askUser.ok')}
                     </Button>
                     <Button
                       size="sm"
@@ -368,7 +382,7 @@ export function AskUserCard({
                       onClick={() => setEditingCustom(false)}
                       disabled={sending}
                     >
-                      Cancel
+                      {t('questionPrompt.actions.cancel')}
                     </Button>
                   </div>
                 </div>
@@ -379,7 +393,9 @@ export function AskUserCard({
       ) : question ? (
         <div className="text-foreground text-sm whitespace-pre-wrap">{question}</div>
       ) : (
-        <div className="text-muted-foreground text-sm italic">Waiting for input...</div>
+        <div className="text-muted-foreground text-sm italic">
+          {t('sessionHq.cards.askUser.waitingForInput')}
+        </div>
       )}
 
       {/* Action bar */}
@@ -390,11 +406,14 @@ export function AskUserCard({
               <Button
                 size="sm"
                 variant="ghost"
-                onClick={() => { setCurrentTab((t) => t - 1); setEditingCustom(false) }}
+                onClick={() => {
+                  setCurrentTab((t) => t - 1)
+                  setEditingCustom(false)
+                }}
                 disabled={sending}
                 className="rounded-full px-3"
               >
-                Back
+                {t('questionPrompt.actions.back')}
               </Button>
             )}
             <Button
@@ -402,15 +421,22 @@ export function AskUserCard({
               onClick={
                 isLastTab
                   ? handleSubmit
-                  : () => { setCurrentTab((t) => t + 1); setEditingCustom(false) }
+                  : () => {
+                      setCurrentTab((t) => t + 1)
+                      setEditingCustom(false)
+                    }
               }
-              disabled={
-                (isLastTab && !allAnswered) || (!isLastTab && !hasCurrentAnswer) || sending
-              }
+              disabled={(isLastTab && !allAnswered) || (!isLastTab && !hasCurrentAnswer) || sending}
               className="rounded-full px-4"
             >
-              {sending ? 'Sending...' : isLastTab ? 'Submit' : (
-                <>Next <ChevronRight className="h-3.5 w-3.5" /></>
+              {sending ? (
+                t('questionPrompt.actions.sending')
+              ) : isLastTab ? (
+                t('questionPrompt.actions.submit')
+              ) : (
+                <>
+                  {t('questionPrompt.actions.next')} <ChevronRight className="h-3.5 w-3.5" />
+                </>
               )}
             </Button>
           </>
@@ -421,7 +447,7 @@ export function AskUserCard({
             disabled={!hasCurrentAnswer || sending}
             className="rounded-full px-4"
           >
-            {sending ? 'Sending...' : 'Submit'}
+            {sending ? t('questionPrompt.actions.sending') : t('questionPrompt.actions.submit')}
           </Button>
         )}
         <Button
@@ -431,7 +457,7 @@ export function AskUserCard({
           disabled={sending}
           className="rounded-full px-3 text-muted-foreground"
         >
-          Dismiss
+          {t('questionPrompt.actions.dismiss')}
         </Button>
       </div>
     </ActionCard>

--- a/src/renderer/src/components/session-hq/cards/BashCard.tsx
+++ b/src/renderer/src/components/session-hq/cards/BashCard.tsx
@@ -110,6 +110,7 @@ function OriginalOutputButton({ archivePath }: { archivePath: string }): React.J
 }
 
 export function BashCard({ toolUse }: BashCardProps): React.JSX.Element {
+  const { t } = useI18n()
   const command = extractCommandText(toolUse.input) || toolUse.name
   const description =
     typeof toolUse.input?.description === 'string' ? toolUse.input.description.trim() : ''
@@ -134,10 +135,16 @@ export function BashCard({ toolUse }: BashCardProps): React.JSX.Element {
           {isSuccess && <Check className="h-3.5 w-3.5 text-celadon" />}
           {isError && <X className="h-3.5 w-3.5 text-red-500" />}
           {isRunning && <Loader2 className="h-3.5 w-3.5 animate-spin text-muted-foreground" />}
-          <span>{isRunning ? 'Running...' : isError ? 'Error' : 'Exit 0'}</span>
+          <span>
+            {isRunning
+              ? t('sessionHq.cards.bash.running')
+              : isError
+                ? t('sessionHq.cards.bash.error')
+                : t('sessionHq.cards.bash.exitZero')}
+          </span>
           {parsed && (
             <span className="rounded border border-emerald-500/25 bg-emerald-500/10 px-1.5 py-0.5 text-[10px] font-semibold text-emerald-700 dark:text-emerald-300">
-              Token Saver -{parsed.savedPercent}%
+              {t('sessionHq.cards.bash.tokenSaverCompact', { percent: parsed.savedPercent })}
             </span>
           )}
         </div>
@@ -153,7 +160,7 @@ export function BashCard({ toolUse }: BashCardProps): React.JSX.Element {
           {cleanOutput && (
             <pre className="max-h-[220px] overflow-y-auto whitespace-pre-wrap break-all font-mono text-xs text-muted-foreground">
               {cleanOutput.length > 2000
-                ? cleanOutput.slice(0, 2000) + '\n... (truncated)'
+                ? `${cleanOutput.slice(0, 2000)}\n${t('sessionHq.cards.bash.truncated')}`
                 : cleanOutput}
             </pre>
           )}

--- a/src/renderer/src/components/session-hq/cards/FileReadCard.tsx
+++ b/src/renderer/src/components/session-hq/cards/FileReadCard.tsx
@@ -5,6 +5,7 @@
 import React from 'react'
 import { ActionCard } from './ActionCard'
 import type { ToolUseInfo } from '@shared/lib/timeline-types'
+import { useI18n } from '@/i18n/useI18n'
 
 interface FileReadCardProps {
   toolUse: ToolUseInfo
@@ -12,9 +13,12 @@ interface FileReadCardProps {
 
 function resolveReadFilePath(toolUse: ToolUseInfo): string {
   const input = (toolUse.input ?? {}) as Record<string, unknown>
-  const direct =
-    (input.filePath || input.file_path || input.path || input.displayName || input.filename ||
-      '') as string
+  const direct = (input.filePath ||
+    input.file_path ||
+    input.path ||
+    input.displayName ||
+    input.filename ||
+    '') as string
   if (direct) return direct
   const paths = input.paths
   if (Array.isArray(paths) && typeof paths[0] === 'string') return paths[0]
@@ -50,6 +54,7 @@ function resolveReadLineCount(toolUse: ToolUseInfo): number | undefined {
 }
 
 export function FileReadCard({ toolUse }: FileReadCardProps): React.JSX.Element {
+  const { t } = useI18n()
   const filePath = resolveReadFilePath(toolUse)
   const lineCount = resolveReadLineCount(toolUse)
 
@@ -57,13 +62,25 @@ export function FileReadCard({ toolUse }: FileReadCardProps): React.JSX.Element 
     <ActionCard
       headerLeft={
         <div className="flex items-center gap-2 min-w-0">
-          <span className="font-semibold text-foreground shrink-0">Read File</span>
+          <span className="font-semibold text-foreground shrink-0">
+            {t('sessionHq.cards.fileRead.title')}
+          </span>
           <span className="font-mono text-xs text-blue-500 bg-blue-500/10 px-1.5 py-0.5 rounded truncate min-w-0">
             {filePath}
           </span>
         </div>
       }
-      headerRight={lineCount ? `${lineCount} lines` : undefined}
+      headerRight={
+        lineCount
+          ? t('sessionHq.cards.fileRead.lineCount', {
+              count: lineCount,
+              label:
+                lineCount === 1
+                  ? t('sessionHq.cards.fileRead.lineSingular')
+                  : t('sessionHq.cards.fileRead.linePlural')
+            })
+          : undefined
+      }
     />
   )
 }

--- a/src/renderer/src/components/session-hq/cards/FileWriteCard.tsx
+++ b/src/renderer/src/components/session-hq/cards/FileWriteCard.tsx
@@ -13,6 +13,7 @@ import { ActionCard } from './ActionCard'
 import { Check, X, Loader2 } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import type { ToolUseInfo } from '@shared/lib/timeline-types'
+import { useI18n } from '@/i18n/useI18n'
 
 interface FileWriteCardProps {
   toolUse: ToolUseInfo
@@ -56,13 +57,12 @@ function readWriteContent(input: Record<string, unknown>): string {
 
 function resolveWriteFilePath(toolUse: ToolUseInfo, fallback?: string): string {
   const input = (toolUse.input ?? {}) as Record<string, unknown>
-  const direct =
-    (input.filePath ||
-      input.file_path ||
-      input.path ||
-      input.displayName ||
-      input.filename ||
-      '') as string
+  const direct = (input.filePath ||
+    input.file_path ||
+    input.path ||
+    input.displayName ||
+    input.filename ||
+    '') as string
   if (direct) return direct
   const paths = input.paths
   if (Array.isArray(paths) && typeof paths[0] === 'string') return paths[0]
@@ -221,6 +221,7 @@ interface DiffPreviewProps {
 }
 
 function DiffPreview({ lines }: DiffPreviewProps): React.JSX.Element {
+  const { t } = useI18n()
   const [expanded, setExpanded] = useState(false)
   const overflow = lines.length > PREVIEW_LINE_LIMIT
   const visible = expanded ? lines : lines.slice(0, PREVIEW_LINE_LIMIT)
@@ -254,7 +255,15 @@ function DiffPreview({ lines }: DiffPreviewProps): React.JSX.Element {
           }}
           className="w-full text-[11px] py-1 border-t border-border/40 text-muted-foreground hover:text-foreground hover:bg-muted/40 transition-colors"
         >
-          {expanded ? '收起' : `展开全部（还有 ${hiddenCount} 行）`}
+          {expanded
+            ? t('sessionHq.cards.fileWrite.collapse')
+            : t('sessionHq.cards.fileWrite.expandAllMore', {
+                count: hiddenCount,
+                label:
+                  hiddenCount === 1
+                    ? t('sessionHq.cards.fileWrite.lineSingular')
+                    : t('sessionHq.cards.fileWrite.linePlural')
+              })}
         </button>
       )}
     </div>
@@ -262,11 +271,10 @@ function DiffPreview({ lines }: DiffPreviewProps): React.JSX.Element {
 }
 
 export function FileWriteCard({ toolUse }: FileWriteCardProps): React.JSX.Element {
+  const { t } = useI18n()
   const codexChanges = getCodexChanges(toolUse)
   const filePath =
-    resolveWriteFilePath(toolUse, codexChanges?.[0]?.path) ||
-    codexChanges?.[0]?.path ||
-    ''
+    resolveWriteFilePath(toolUse, codexChanges?.[0]?.path) || codexChanges?.[0]?.path || ''
   // Codex emits 'Edit' for both pure edits and full rewrites; treat as Edit.
   const isEdit =
     toolUse.name === 'Edit' ||
@@ -286,7 +294,9 @@ export function FileWriteCard({ toolUse }: FileWriteCardProps): React.JSX.Elemen
       headerLeft={
         <div className="flex items-center gap-2 min-w-0">
           <span className="font-semibold text-foreground shrink-0">
-            {isEdit ? 'Edit' : 'Write File'}
+            {isEdit
+              ? t('sessionHq.cards.fileWrite.edit')
+              : t('sessionHq.cards.fileWrite.writeFile')}
           </span>
           <span className="font-mono text-xs text-blue-500 bg-blue-500/10 px-1.5 py-0.5 rounded truncate">
             {filePath}
@@ -308,8 +318,8 @@ export function FileWriteCard({ toolUse }: FileWriteCardProps): React.JSX.Elemen
               )}
             </div>
           )}
-          {isRunning && <span>Writing...</span>}
-          {isError && <span>Error</span>}
+          {isRunning && <span>{t('sessionHq.cards.fileWrite.writing')}</span>}
+          {isError && <span>{t('sessionHq.cards.fileWrite.error')}</span>}
         </div>
       }
       // Default collapsed — click the header to expand the diff preview

--- a/src/renderer/src/components/session-hq/cards/GoalStatusCard.tsx
+++ b/src/renderer/src/components/session-hq/cards/GoalStatusCard.tsx
@@ -3,15 +3,18 @@ import { CheckCircle2, Target, X } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import type { AgentSessionGoalState } from '@shared/types/agent-protocol'
 import { Button } from '@/components/ui/button'
+import { useI18n } from '@/i18n/useI18n'
 
 interface GoalStatusCardProps {
   goal: AgentSessionGoalState
   onDismiss?: () => void
 }
 
-function getGoalTitle(goal: AgentSessionGoalState): string {
+type TFunction = ReturnType<typeof useI18n>['t']
+
+function getGoalTitle(goal: AgentSessionGoalState, t: TFunction): string {
   if (goal.objective.trim()) return goal.objective.trim()
-  return 'Session goal'
+  return t('sessionHq.cards.goal.defaultTitle')
 }
 
 function getSuccessCriteria(goal: AgentSessionGoalState): string | null {
@@ -38,14 +41,16 @@ function formatDuration(seconds: number): string {
   return `${minutes}m ${remainingSeconds}s`
 }
 
-function getGoalDetails(goal: AgentSessionGoalState): string | null {
+function getGoalDetails(goal: AgentSessionGoalState, t: TFunction): string | null {
   const details: string[] = []
   if (typeof goal.tokensUsed === 'number') {
     const used = formatCompactNumber(goal.tokensUsed)
     if (typeof goal.tokenBudget === 'number') {
-      details.push(`${used} / ${formatCompactNumber(goal.tokenBudget)} tokens`)
+      details.push(
+        `${used} / ${formatCompactNumber(goal.tokenBudget)} ${t('sessionHq.cards.goal.tokens')}`
+      )
     } else {
-      details.push(`${used} tokens`)
+      details.push(`${used} ${t('sessionHq.cards.goal.tokens')}`)
     }
   }
   if (typeof goal.timeUsedSeconds === 'number') {
@@ -54,10 +59,13 @@ function getGoalDetails(goal: AgentSessionGoalState): string | null {
   return details.length > 0 ? details.join(' · ') : null
 }
 
-function getGoalStatus(goal: AgentSessionGoalState): string {
+function getGoalStatus(goal: AgentSessionGoalState, t: TFunction): string {
   const status = goal.status
+  const normalized = status.trim().toLowerCase()
+  if (normalized === 'active') return t('sessionHq.cards.goal.active')
+  if (normalized === 'completed') return t('sessionHq.cards.goal.completed')
   if (status.trim()) return status.trim()
-  return 'Active'
+  return t('sessionHq.cards.goal.active')
 }
 
 function isCompletedGoal(goal: AgentSessionGoalState): boolean {
@@ -65,7 +73,8 @@ function isCompletedGoal(goal: AgentSessionGoalState): boolean {
 }
 
 export function GoalStatusCard({ goal, onDismiss }: GoalStatusCardProps): React.JSX.Element {
-  const details = getGoalDetails(goal)
+  const { t } = useI18n()
+  const details = getGoalDetails(goal, t)
   const successCriteria = getSuccessCriteria(goal)
   const completed = isCompletedGoal(goal)
   const Icon = completed ? CheckCircle2 : Target
@@ -91,7 +100,7 @@ export function GoalStatusCard({ goal, onDismiss }: GoalStatusCardProps): React.
         <div className="min-w-0 flex-1">
           <div className="flex items-start gap-2">
             <div className="min-w-0 flex-1 truncate text-sm font-semibold text-foreground">
-              {getGoalTitle(goal)}
+              {getGoalTitle(goal, t)}
             </div>
             <span
               className={cn(
@@ -99,7 +108,7 @@ export function GoalStatusCard({ goal, onDismiss }: GoalStatusCardProps): React.
                 completed ? 'bg-emerald-500/10 text-emerald-500' : 'bg-celadon/10 text-celadon'
               )}
             >
-              {getGoalStatus(goal)}
+              {getGoalStatus(goal, t)}
             </span>
             {completed && onDismiss && (
               <Button
@@ -107,7 +116,7 @@ export function GoalStatusCard({ goal, onDismiss }: GoalStatusCardProps): React.
                 variant="ghost"
                 size="sm"
                 className="h-5 w-5 shrink-0 rounded-full p-0 text-muted-foreground hover:text-foreground"
-                aria-label="Dismiss completed goal"
+                aria-label={t('sessionHq.cards.goal.dismissCompleted')}
                 data-testid="goal-dismiss-button"
                 onClick={onDismiss}
               >
@@ -123,7 +132,7 @@ export function GoalStatusCard({ goal, onDismiss }: GoalStatusCardProps): React.
           {successCriteria && (
             <div className="mt-2 border-t border-border/50 pt-2">
               <div className="text-[10px] font-medium uppercase tracking-normal text-muted-foreground">
-                Criteria
+                {t('sessionHq.cards.goal.criteria')}
               </div>
               <div
                 className="mt-1 line-clamp-2 whitespace-pre-wrap text-xs leading-relaxed text-muted-foreground"

--- a/src/renderer/src/components/session-hq/cards/PlanCard.tsx
+++ b/src/renderer/src/components/session-hq/cards/PlanCard.tsx
@@ -53,10 +53,14 @@ export function PlanCard({
       key={isPending ? 'pending' : 'resolved'}
       accentClass="border-purple-500"
       headerClass="bg-purple-500/10 text-purple-600 dark:text-purple-400 border-b-purple-500/20"
-      headerLeft={<span className="font-semibold">Proposed Execution Plan</span>}
+      headerLeft={<span className="font-semibold">{t('sessionHq.cards.plan.title')}</span>}
       headerRight={
         <div className="flex items-center gap-2">
-          <span>{isPending ? 'Requires Approval' : 'Approved'}</span>
+          <span>
+            {isPending
+              ? t('sessionHq.cards.plan.requiresApproval')
+              : t('sessionHq.cards.plan.approved')}
+          </span>
           {hasCopyableContent && (
             <Button
               type="button"
@@ -91,7 +95,7 @@ export function PlanCard({
               onClick={onReject}
               className="px-4 py-1.5 rounded-md border border-border text-sm font-medium hover:bg-muted transition-colors"
             >
-              Reject / Modify
+              {t('sessionHq.cards.plan.rejectModify')}
             </button>
           )}
           {onApprove && (
@@ -99,7 +103,7 @@ export function PlanCard({
               onClick={onApprove}
               className="px-4 py-1.5 rounded-md bg-blue-500 text-white text-sm font-medium hover:opacity-90 transition-opacity"
             >
-              Approve & Start
+              {t('sessionHq.cards.plan.approveStart')}
             </button>
           )}
         </div>

--- a/src/renderer/src/components/session-hq/cards/SearchCard.tsx
+++ b/src/renderer/src/components/session-hq/cards/SearchCard.tsx
@@ -5,12 +5,14 @@
 import React from 'react'
 import { ActionCard } from './ActionCard'
 import type { ToolUseInfo } from '@shared/lib/timeline-types'
+import { useI18n } from '@/i18n/useI18n'
 
 interface SearchCardProps {
   toolUse: ToolUseInfo
 }
 
 export function SearchCard({ toolUse }: SearchCardProps): React.JSX.Element {
+  const { t } = useI18n()
   const pattern = (toolUse.input?.pattern as string) ?? (toolUse.input?.query as string) ?? ''
   const path = (toolUse.input?.path as string) ?? ''
   const resultCount = toolUse.output
@@ -21,21 +23,31 @@ export function SearchCard({ toolUse }: SearchCardProps): React.JSX.Element {
     <ActionCard
       headerLeft={
         <div className="flex items-center gap-2">
-          <span className="font-semibold text-foreground">Codebase Search</span>
+          <span className="font-semibold text-foreground">{t('sessionHq.cards.search.title')}</span>
           <span className="font-mono text-xs text-muted-foreground bg-muted px-1.5 py-0.5 rounded-full border border-border">
             {toolUse.name}
           </span>
         </div>
       }
-      headerRight={resultCount ? `${resultCount} results` : undefined}
+      headerRight={
+        resultCount
+          ? t('sessionHq.cards.search.resultCount', {
+              count: resultCount,
+              label:
+                resultCount === 1
+                  ? t('sessionHq.cards.search.resultSingular')
+                  : t('sessionHq.cards.search.resultPlural')
+            })
+          : undefined
+      }
     >
       <div className="font-mono text-xs">
-        <span className="text-blue-500">Query:</span>{' '}
+        <span className="text-blue-500">{t('sessionHq.cards.search.query')}</span>{' '}
         <span className="text-foreground">{pattern}</span>
         {path && (
           <>
             {' '}
-            <span className="text-muted-foreground">in</span>{' '}
+            <span className="text-muted-foreground">{t('toolViews.grep.in')}</span>{' '}
             <span className="text-foreground">{path}</span>
           </>
         )}

--- a/src/renderer/src/components/session-hq/cards/SubAgentCard.tsx
+++ b/src/renderer/src/components/session-hq/cards/SubAgentCard.tsx
@@ -4,17 +4,31 @@
 
 import React, { useState, useMemo } from 'react'
 import { ActionCard } from './ActionCard'
-import { ChevronDown, Terminal, FileSearch, FileEdit, Search, CheckCircle2, XCircle, Loader2 } from 'lucide-react'
+import {
+  ChevronDown,
+  Terminal,
+  FileSearch,
+  FileEdit,
+  Search,
+  CheckCircle2,
+  XCircle,
+  Loader2
+} from 'lucide-react'
 import { cn } from '@/lib/utils'
 import type { StreamingPart } from '@shared/lib/timeline-types'
+import { useI18n } from '@/i18n/useI18n'
 
 interface SubAgentCardProps {
   subtask: NonNullable<StreamingPart['subtask']>
   childParts?: StreamingPart[]
 }
 
+type TFunction = ReturnType<typeof useI18n>['t']
+
 /** Compact single-line row for a child tool call */
 function CompactToolRow({ part }: { part: StreamingPart }): React.JSX.Element | null {
+  const { t } = useI18n()
+
   if (part.type === 'text' && part.text) {
     const preview = part.text.length > 120 ? part.text.slice(0, 120) + '...' : part.text
     return (
@@ -28,14 +42,16 @@ function CompactToolRow({ part }: { part: StreamingPart }): React.JSX.Element | 
   if (part.type === 'tool_use' && part.toolUse) {
     const name = part.toolUse.name?.toLowerCase() ?? ''
     const { icon: Icon, color } = getToolMeta(name)
-    const label = getToolLabel(name, part.toolUse.input)
+    const label = getToolLabel(name, part.toolUse.input, t)
     const status = part.toolUse.status
 
     return (
       <div className="flex items-center gap-2 py-0.5 text-[11px]">
         <Icon className={cn('w-3 h-3 shrink-0', color)} />
         <span className="text-muted-foreground truncate flex-1">{label}</span>
-        {status === 'running' && <Loader2 className="w-3 h-3 text-muted-foreground/50 animate-spin shrink-0" />}
+        {status === 'running' && (
+          <Loader2 className="w-3 h-3 text-muted-foreground/50 animate-spin shrink-0" />
+        )}
         {status === 'success' && <CheckCircle2 className="w-3 h-3 text-celadon shrink-0" />}
         {status === 'error' && <XCircle className="w-3 h-3 text-destructive shrink-0" />}
       </div>
@@ -52,7 +68,14 @@ function getToolMeta(name: string): { icon: typeof Terminal; color: string } {
   if (name === 'read' || name === 'readfile' || name === 'read_file') {
     return { icon: FileSearch, color: 'text-muted-foreground/60' }
   }
-  if (name === 'write' || name === 'edit' || name === 'writefile' || name === 'write_file' || name === 'editfile' || name === 'edit_file') {
+  if (
+    name === 'write' ||
+    name === 'edit' ||
+    name === 'writefile' ||
+    name === 'write_file' ||
+    name === 'editfile' ||
+    name === 'edit_file'
+  ) {
     return { icon: FileEdit, color: 'text-muted-foreground/60' }
   }
   if (name === 'grep' || name === 'glob' || name === 'search' || name === 'codebase_search') {
@@ -61,7 +84,11 @@ function getToolMeta(name: string): { icon: typeof Terminal; color: string } {
   return { icon: Terminal, color: 'text-muted-foreground/40' }
 }
 
-function getToolLabel(name: string, input?: Record<string, unknown>): string {
+function getToolLabel(
+  name: string,
+  input: Record<string, unknown> | undefined,
+  t: TFunction
+): string {
   const displayName = name.charAt(0).toUpperCase() + name.slice(1)
   if (!input) return displayName
 
@@ -72,20 +99,34 @@ function getToolLabel(name: string, input?: Record<string, unknown>): string {
   }
   if (name === 'read' || name === 'readfile' || name === 'read_file') {
     const path = (input.file_path as string) ?? (input.path as string) ?? ''
-    return path ? `Read ${path.split('/').pop()}` : displayName
+    return path
+      ? t('sessionHq.cards.subAgent.readPrefix', { name: path.split('/').pop() || path })
+      : displayName
   }
   if (name === 'grep' || name === 'glob' || name === 'search' || name === 'codebase_search') {
     const pattern = (input.pattern as string) ?? (input.query as string) ?? ''
-    return pattern ? `Search: ${pattern.slice(0, 60)}` : displayName
+    return pattern
+      ? t('sessionHq.cards.subAgent.searchPrefix', { query: pattern.slice(0, 60) })
+      : displayName
   }
-  if (name === 'write' || name === 'edit' || name === 'writefile' || name === 'write_file' || name === 'editfile' || name === 'edit_file') {
+  if (
+    name === 'write' ||
+    name === 'edit' ||
+    name === 'writefile' ||
+    name === 'write_file' ||
+    name === 'editfile' ||
+    name === 'edit_file'
+  ) {
     const path = (input.file_path as string) ?? (input.path as string) ?? ''
-    return path ? `Edit ${path.split('/').pop()}` : displayName
+    return path
+      ? t('sessionHq.cards.subAgent.editPrefix', { name: path.split('/').pop() || path })
+      : displayName
   }
   return displayName
 }
 
 export function SubAgentCard({ subtask, childParts = [] }: SubAgentCardProps): React.JSX.Element {
+  const { t } = useI18n()
   const isRunning = subtask.status === 'running'
 
   // Merge subtask.parts (from legacy/subtask-type) with childParts (from streaming routing)
@@ -106,12 +147,20 @@ export function SubAgentCard({ subtask, childParts = [] }: SubAgentCardProps): R
       headerLeft={
         <div className="flex items-center gap-2">
           <div className="w-5 h-5 rounded bg-foreground text-background flex items-center justify-center">
-            <svg viewBox="0 0 24 24" className="w-3 h-3" fill="none" stroke="currentColor" strokeWidth="2">
+            <svg
+              viewBox="0 0 24 24"
+              className="w-3 h-3"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+            >
               <circle cx="12" cy="12" r="10" />
             </svg>
           </div>
           <span className="font-semibold text-foreground">
-            Delegated to {subtask.agent || 'Agent'}
+            {t('sessionHq.cards.subAgent.delegatedTo', {
+              agent: subtask.agent || t('sessionHq.cards.subAgent.agentFallback')
+            })}
           </span>
         </div>
       }
@@ -119,23 +168,25 @@ export function SubAgentCard({ subtask, childParts = [] }: SubAgentCardProps): R
         <div className="flex items-center gap-2">
           {toolCount > 0 && (
             <span className="text-[10px] text-muted-foreground/60 tabular-nums">
-              {toolCount} action{toolCount !== 1 ? 's' : ''}
+              {t('sessionHq.cards.subAgent.actionCount', {
+                count: toolCount,
+                label:
+                  toolCount === 1
+                    ? t('sessionHq.cards.subAgent.actionSingular')
+                    : t('sessionHq.cards.subAgent.actionPlural')
+              })}
             </span>
           )}
-          {isRunning && (
-            <div className="w-1.5 h-1.5 rounded-full bg-purple-500 animate-pulse" />
-          )}
+          {isRunning && <div className="w-1.5 h-1.5 rounded-full bg-purple-500 animate-pulse" />}
           <span className={isRunning ? 'text-purple-500' : undefined}>
-            {isRunning ? 'running' : subtask.status}
+            {isRunning ? t('sessionHq.cards.subAgent.running') : subtask.status}
           </span>
         </div>
       }
       defaultExpanded={false}
     >
       {subtask.description && (
-        <div className="text-sm text-muted-foreground">
-          {subtask.description}
-        </div>
+        <div className="text-sm text-muted-foreground">{subtask.description}</div>
       )}
 
       {allParts.length > 0 && (
@@ -144,8 +195,25 @@ export function SubAgentCard({ subtask, childParts = [] }: SubAgentCardProps): R
             onClick={() => setExpanded((v) => !v)}
             className="text-[11px] text-muted-foreground/60 hover:text-muted-foreground cursor-pointer select-none flex items-center gap-1 transition-colors"
           >
-            <ChevronDown className={cn('h-3 w-3 transition-transform duration-200', expanded && 'rotate-180')} />
-            {expanded ? 'Hide' : 'Show'} {toolCount > 0 ? `${toolCount} action${toolCount !== 1 ? 's' : ''}` : `${allParts.length} item${allParts.length !== 1 ? 's' : ''}`}
+            <ChevronDown
+              className={cn('h-3 w-3 transition-transform duration-200', expanded && 'rotate-180')}
+            />
+            {expanded ? t('sessionHq.cards.subAgent.hide') : t('sessionHq.cards.subAgent.show')}{' '}
+            {toolCount > 0
+              ? t('sessionHq.cards.subAgent.actionCount', {
+                  count: toolCount,
+                  label:
+                    toolCount === 1
+                      ? t('sessionHq.cards.subAgent.actionSingular')
+                      : t('sessionHq.cards.subAgent.actionPlural')
+                })
+              : t('sessionHq.cards.subAgent.itemCount', {
+                  count: allParts.length,
+                  label:
+                    allParts.length === 1
+                      ? t('sessionHq.cards.subAgent.itemSingular')
+                      : t('sessionHq.cards.subAgent.itemPlural')
+                })}
           </button>
 
           {expanded && (

--- a/src/renderer/src/components/session-hq/cards/ThinkingCard.tsx
+++ b/src/renderer/src/components/session-hq/cards/ThinkingCard.tsx
@@ -8,12 +8,14 @@
 import React, { useState, useRef, useEffect } from 'react'
 import { ChevronDown } from 'lucide-react'
 import { cn } from '@/lib/utils'
+import { useI18n } from '@/i18n/useI18n'
 
 interface ThinkingCardProps {
   content: string
 }
 
 export function ThinkingCard({ content }: ThinkingCardProps): React.JSX.Element {
+  const { t } = useI18n()
   const [expanded, setExpanded] = useState(false)
   const [isOverflowing, setIsOverflowing] = useState(false)
   const contentRef = useRef<HTMLDivElement>(null)
@@ -28,7 +30,7 @@ export function ThinkingCard({ content }: ThinkingCardProps): React.JSX.Element 
   return (
     <div className="border-l-[3px] border-border pl-3.5 py-1">
       <div className="text-xs font-semibold text-muted-foreground flex items-center gap-1.5 mb-1.5">
-        Thinking Process
+        {t('sessionHq.cards.thinking.title')}
       </div>
       <div
         ref={contentRef}
@@ -45,12 +47,9 @@ export function ThinkingCard({ content }: ThinkingCardProps): React.JSX.Element 
           className="text-[11px] text-muted-foreground/60 hover:text-muted-foreground mt-1.5 cursor-pointer select-none flex items-center gap-1 transition-colors"
         >
           <ChevronDown
-            className={cn(
-              'h-3 w-3 transition-transform duration-200',
-              expanded && 'rotate-180'
-            )}
+            className={cn('h-3 w-3 transition-transform duration-200', expanded && 'rotate-180')}
           />
-          {expanded ? 'Show less' : 'Show more'}
+          {expanded ? t('toolViews.common.showLess') : t('sessionHq.cards.thinking.showMore')}
         </button>
       )}
     </div>

--- a/src/renderer/src/components/session-hq/cards/TodoCard.tsx
+++ b/src/renderer/src/components/session-hq/cards/TodoCard.tsx
@@ -10,6 +10,7 @@ import React from 'react'
 import { ActionCard } from './ActionCard'
 import { CheckCircle2, Circle, Loader2, AlertCircle } from 'lucide-react'
 import type { ToolUseInfo } from '@shared/lib/timeline-types'
+import { useI18n } from '@/i18n/useI18n'
 
 interface TodoCardPropsToolUse {
   toolUse: ToolUseInfo
@@ -81,17 +82,22 @@ function StatusIcon({ status }: { status?: string }): React.JSX.Element {
 }
 
 function TaskRow({ item, index }: { item: TodoItem; index: number }): React.JSX.Element {
+  const { t } = useI18n()
+
   return (
     <div className="flex items-center gap-2 py-0.5">
       <StatusIcon status={item.status} />
       <div className="flex-1 min-w-0">
         <div className="text-sm text-foreground">
-          {item.step ?? item.content ?? item.subject ?? item.activeForm ?? item.description ?? `Task ${index + 1}`}
+          {item.step ??
+            item.content ??
+            item.subject ??
+            item.activeForm ??
+            item.description ??
+            t('sessionHq.cards.todo.taskFallback', { index: index + 1 })}
         </div>
         {(item.subject || item.content || item.step) && item.description && (
-          <div className="text-xs text-muted-foreground mt-0.5 truncate">
-            {item.description}
-          </div>
+          <div className="text-xs text-muted-foreground mt-0.5 truncate">{item.description}</div>
         )}
       </div>
     </div>
@@ -99,6 +105,8 @@ function TaskRow({ item, index }: { item: TodoItem; index: number }): React.JSX.
 }
 
 export function TodoCard(props: TodoCardProps): React.JSX.Element {
+  const { t } = useI18n()
+
   // --- Aggregated tasks mode ---
   if (props.tasks) {
     const allDone = props.tasks.every((t) => t.status === 'completed')
@@ -106,8 +114,10 @@ export function TodoCard(props: TodoCardProps): React.JSX.Element {
       <ActionCard
         accentClass="border-celadon/30"
         headerClass="border-b-celadon/20 text-celadon"
-        headerLeft={<span className="font-semibold">Task List</span>}
-        headerRight={allDone ? 'Done' : 'In progress'}
+        headerLeft={<span className="font-semibold">{t('sessionHq.cards.todo.title')}</span>}
+        headerRight={
+          allDone ? t('sessionHq.cards.todo.done') : t('sessionHq.cards.todo.inProgress')
+        }
         defaultExpanded
         collapsible={props.tasks.length > 5}
       >
@@ -130,9 +140,9 @@ export function TodoCard(props: TodoCardProps): React.JSX.Element {
   const lowerToolName = toolUse.name.toLowerCase()
   const toolLabel =
     toolUse.name === 'TodoWrite'
-      ? 'Task List'
+      ? t('sessionHq.cards.todo.title')
       : lowerToolName === 'update_plan'
-        ? 'Plan Update'
+        ? t('sessionHq.cards.todo.planUpdate')
         : toolUse.name
 
   return (
@@ -141,9 +151,11 @@ export function TodoCard(props: TodoCardProps): React.JSX.Element {
       headerClass="border-b-green-500/20 text-green-700 dark:text-green-400"
       headerLeft={<span className="font-semibold">{toolLabel}</span>}
       headerRight={
-        toolUse.status === 'running' ? 'Running...'
-          : toolUse.status === 'success' ? 'Done'
-          : toolUse.status
+        toolUse.status === 'running'
+          ? t('sessionHq.cards.todo.running')
+          : toolUse.status === 'success'
+            ? t('sessionHq.cards.todo.done')
+            : toolUse.status
       }
       defaultExpanded
       collapsible={items.length > 5}
@@ -156,7 +168,7 @@ export function TodoCard(props: TodoCardProps): React.JSX.Element {
         </div>
       ) : (
         <div className="text-sm text-muted-foreground">
-          {toolUse.output ? toolUse.output.slice(0, 200) : 'No tasks'}
+          {toolUse.output ? toolUse.output.slice(0, 200) : t('sessionHq.cards.todo.noTasks')}
         </div>
       )}
     </ActionCard>

--- a/src/renderer/src/i18n/messages.ts
+++ b/src/renderer/src/i18n/messages.ts
@@ -1348,45 +1348,6 @@ export const messages: Record<AppLocale, MessageTree> = {
         microphonePermissionDenied: 'Microphone permission was not granted'
       }
     },
-    sessionHq: {
-      composer: {
-        reviewPlan: 'Review the plan above',
-        plan: 'Plan',
-        goal: 'Goal',
-        togglePlanMode: 'Toggle Plan Mode (Tab)',
-        toggleGoalMode: 'Toggle Goal Mode',
-        moreSendActions: 'More send actions',
-        queuedMessages: '{count} message(s) queued',
-        placeholders: {
-          successCriteria: 'Success criteria...',
-          planFeedback: 'Provide feedback on the plan...',
-          reply: 'Type your reply...',
-          queueFollowUp: 'Type a follow-up to queue after the current run...',
-          stopAndSend: 'Type to stop and send...',
-          message: 'Type a message...'
-        },
-        actions: {
-          disconnected: 'Disconnected',
-          send: 'Send',
-          sendQueued: 'Send (queued)',
-          queueLater: 'Queue for later',
-          steer: 'Steer (redirect agent)',
-          stopAndSend: 'Stop & Send',
-          reply: 'Reply'
-        },
-        voice: {
-          finishing: 'Finishing voice input',
-          preparing: 'Preparing voice engine',
-          listening: 'Listening',
-          holdCtrl: 'Hold Ctrl',
-          hint: 'Speak naturally. Release Ctrl or click the mic to finish.',
-          recordingTitle: 'Recording. Click to stop, or release Ctrl if using push-to-talk.',
-          idleTitle: 'Voice input. Click once to record, or hold Ctrl to speak.',
-          stopAriaLabel: 'Stop voice input',
-          startAriaLabel: 'Start voice input'
-        }
-      }
-    },
     sessionView: {
       compacting: 'Compressing context...',
       tokenSaverBanner: {
@@ -1514,6 +1475,189 @@ export const messages: Record<AppLocale, MessageTree> = {
         createSuperchargeSessionError: 'Failed to create supercharge session',
         startLocalSuperchargeSessionError: 'Could not start local supercharge session',
         createLocalSuperchargeSessionError: 'Failed to create local supercharge session'
+      }
+    },
+    sessionHq: {
+      composer: {
+        reviewPlan: 'Review the plan above',
+        plan: 'Plan',
+        goal: 'Goal',
+        togglePlanMode: 'Toggle Plan Mode (Tab)',
+        toggleGoalMode: 'Toggle Goal Mode',
+        moreSendActions: 'More send actions',
+        successCriteriaPlaceholder: 'Success criteria...',
+        reviewPlanAbove: 'Review the plan above',
+        togglePlanTitle: 'Toggle Plan Mode (Tab)',
+        toggleGoalTitle: 'Toggle Goal Mode',
+        planLabel: 'Plan',
+        goalLabel: 'Goal',
+        moreActions: 'More send actions',
+        planFeedbackPlaceholder: 'Provide feedback on the plan...',
+        interruptReplyPlaceholder: 'Type your reply...',
+        queuePlaceholder: 'Type a follow-up to queue after the current run...',
+        stopAndSendPlaceholder: 'Type to stop and send...',
+        messagePlaceholder: 'Type a message...',
+        queuedMessages: '{count} message(s) queued',
+        messageSingular: 'message',
+        messagePlural: 'messages',
+        placeholders: {
+          successCriteria: 'Success criteria...',
+          planFeedback: 'Provide feedback on the plan...',
+          reply: 'Type your reply...',
+          queueFollowUp: 'Type a follow-up to queue after the current run...',
+          stopAndSend: 'Type to stop and send...',
+          message: 'Type a message...'
+        },
+        actions: {
+          disconnected: 'Disconnected',
+          reply: 'Reply',
+          send: 'Send',
+          sendQueued: 'Send (queued)',
+          queue: 'Queue',
+          queueLater: 'Queue for later',
+          steer: 'Steer (redirect agent)',
+          stop: 'Stop',
+          stopAndSend: 'Stop & Send'
+        },
+        voice: {
+          finishing: 'Finishing voice input',
+          preparing: 'Preparing voice engine',
+          listening: 'Listening',
+          holdCtrl: 'Hold Ctrl',
+          hint: 'Speak naturally. Release Ctrl or click the mic to finish.',
+          recordingTitle: 'Recording. Click to stop, or release Ctrl if using push-to-talk.',
+          idleTitle: 'Voice input. Click once to record, or hold Ctrl to speak.',
+          stopAriaLabel: 'Stop voice input',
+          startAriaLabel: 'Start voice input'
+        }
+      },
+      timeline: {
+        thinking: 'Thinking…',
+        emptyTitle: 'No messages yet',
+        emptySubtitle: 'Send a message to start the conversation',
+        steered: 'STEERED',
+        genericToolStatus: {
+          running: 'Running...',
+          error: 'Error',
+          done: 'Done'
+        }
+      },
+      header: {
+        providerUpdateError: 'Failed to update provider',
+        lifecycle: {
+          idle: 'Idle',
+          busy: 'Working',
+          retry: 'Retrying',
+          error: 'Error',
+          materializing: 'Starting'
+        },
+        tokens: 'tokens',
+        compressingContext: 'Compressing context...'
+      },
+      agentRail: {
+        status: {
+          working: 'Working...',
+          retrying: 'Retrying...'
+        },
+        pending: 'Pending ({count})',
+        unread: '{count} unread {label}',
+        messageSingular: 'message',
+        messagePlural: 'messages',
+        interrupts: {
+          question: 'Question pending',
+          permission: 'Permission needed',
+          commandApproval: 'Command approval',
+          plan: 'Plan approval'
+        }
+      },
+      missionControl: {
+        allTasksCompleted: 'All tasks completed',
+        taskCount: '{completed}/{total} tasks'
+      },
+      cards: {
+        plan: {
+          title: 'Proposed Execution Plan',
+          requiresApproval: 'Requires Approval',
+          approved: 'Approved',
+          rejectModify: 'Reject / Modify',
+          approveStart: 'Approve & Start'
+        },
+        askUser: {
+          title: 'Question for you',
+          answered: 'Answered',
+          waitingForReply: 'Waiting for reply',
+          other: 'Other...',
+          ok: 'OK',
+          waitingForInput: 'Waiting for input...'
+        },
+        todo: {
+          title: 'Task List',
+          done: 'Done',
+          inProgress: 'In progress',
+          planUpdate: 'Plan Update',
+          running: 'Running...',
+          taskFallback: 'Task {index}',
+          noTasks: 'No tasks'
+        },
+        bash: {
+          running: 'Running...',
+          error: 'Error',
+          exitZero: 'Exit 0',
+          tokenSaverCompact: 'Token Saver -{percent}%',
+          truncated: '... (truncated)'
+        },
+        search: {
+          title: 'Codebase Search',
+          resultCount: '{count} {label}',
+          resultSingular: 'result',
+          resultPlural: 'results',
+          query: 'Query:'
+        },
+        thinking: {
+          title: 'Thinking Process',
+          showMore: 'Show more'
+        },
+        goal: {
+          defaultTitle: 'Session goal',
+          active: 'Active',
+          completed: 'Completed',
+          tokens: 'tokens',
+          dismissCompleted: 'Dismiss completed goal',
+          criteria: 'Criteria'
+        },
+        fileRead: {
+          title: 'Read File',
+          lineCount: '{count} {label}',
+          lineSingular: 'line',
+          linePlural: 'lines'
+        },
+        fileWrite: {
+          edit: 'Edit',
+          writeFile: 'Write File',
+          writing: 'Writing...',
+          error: 'Error',
+          collapse: 'Collapse',
+          expandAllMore: 'Show all ({count} more {label})',
+          lineSingular: 'line',
+          linePlural: 'lines'
+        },
+        subAgent: {
+          delegatedTo: 'Delegated to {agent}',
+          defaultDescription: 'Delegated task',
+          agentFallback: 'Agent',
+          actionCount: '{count} {label}',
+          itemCount: '{count} {label}',
+          actionSingular: 'action',
+          actionPlural: 'actions',
+          itemSingular: 'item',
+          itemPlural: 'items',
+          running: 'running',
+          show: 'Show',
+          hide: 'Hide',
+          readPrefix: 'Read {name}',
+          editPrefix: 'Edit {name}',
+          searchPrefix: 'Search: {query}'
+        }
       }
     },
     sessionTerminalView: {
@@ -3993,45 +4137,6 @@ export const messages: Record<AppLocale, MessageTree> = {
         microphonePermissionDenied: '麦克风权限未授权'
       }
     },
-    sessionHq: {
-      composer: {
-        reviewPlan: '请先查看上方计划',
-        plan: '计划',
-        goal: '目标',
-        togglePlanMode: '切换 Plan 模式（Tab）',
-        toggleGoalMode: '切换 Goal 模式',
-        moreSendActions: '更多发送操作',
-        queuedMessages: '已排队 {count} 条消息',
-        placeholders: {
-          successCriteria: '成功标准...',
-          planFeedback: '输入对计划的反馈...',
-          reply: '输入你的回复...',
-          queueFollowUp: '输入要在当前执行后排队的后续消息...',
-          stopAndSend: '输入内容以停止并发送...',
-          message: '输入消息...'
-        },
-        actions: {
-          disconnected: '未连接',
-          send: '发送',
-          sendQueued: '发送（已排队）',
-          queueLater: '稍后排队',
-          steer: '转向（重定向 Agent）',
-          stopAndSend: '停止并发送',
-          reply: '回复'
-        },
-        voice: {
-          finishing: '正在结束语音输入',
-          preparing: '正在准备语音引擎',
-          listening: '正在聆听',
-          holdCtrl: '按住 Ctrl',
-          hint: '自然说话即可。松开 Ctrl 或点击麦克风结束。',
-          recordingTitle: '正在录音。点击停止；如果是按住说话，松开 Ctrl 即可结束。',
-          idleTitle: '语音输入。点击一次开始录音，或按住 Ctrl 说话。',
-          stopAriaLabel: '停止语音输入',
-          startAriaLabel: '开始语音输入'
-        }
-      }
-    },
     sessionView: {
       compacting: '正在压缩上下文窗口...',
       tokenSaverBanner: {
@@ -4158,6 +4263,189 @@ export const messages: Record<AppLocale, MessageTree> = {
         createSuperchargeSessionError: '创建 supercharge 会话失败',
         startLocalSuperchargeSessionError: '无法启动本地 supercharge 会话',
         createLocalSuperchargeSessionError: '创建本地 supercharge 会话失败'
+      }
+    },
+    sessionHq: {
+      composer: {
+        reviewPlan: '请先查看上方计划',
+        plan: '计划',
+        goal: '目标',
+        togglePlanMode: '切换 Plan 模式（Tab）',
+        toggleGoalMode: '切换 Goal 模式',
+        moreSendActions: '更多发送操作',
+        successCriteriaPlaceholder: '成功标准...',
+        reviewPlanAbove: '请先审阅上方计划',
+        togglePlanTitle: '切换 Plan 模式（Tab）',
+        toggleGoalTitle: '切换目标模式',
+        planLabel: '计划',
+        goalLabel: '目标',
+        moreActions: '更多发送操作',
+        planFeedbackPlaceholder: '输入对计划的反馈...',
+        interruptReplyPlaceholder: '输入你的回复...',
+        queuePlaceholder: '输入要排队到本轮之后的后续消息...',
+        stopAndSendPlaceholder: '输入内容以停止并发送...',
+        messagePlaceholder: '输入消息...',
+        queuedMessages: '已排队 {count} 条消息',
+        messageSingular: '消息',
+        messagePlural: '消息',
+        placeholders: {
+          successCriteria: '成功标准...',
+          planFeedback: '输入对计划的反馈...',
+          reply: '输入你的回复...',
+          queueFollowUp: '输入要在当前执行后排队的后续消息...',
+          stopAndSend: '输入内容以停止并发送...',
+          message: '输入消息...'
+        },
+        actions: {
+          disconnected: '未连接',
+          reply: '回复',
+          send: '发送',
+          sendQueued: '发送（已排队）',
+          queue: '排队',
+          queueLater: '稍后发送',
+          steer: '引导当前 Agent',
+          stop: '停止',
+          stopAndSend: '停止并发送'
+        },
+        voice: {
+          finishing: '正在结束语音输入',
+          preparing: '正在准备语音引擎',
+          listening: '正在聆听',
+          holdCtrl: '按住 Ctrl',
+          hint: '自然说话即可。松开 Ctrl 或点击麦克风结束。',
+          recordingTitle: '正在录音。点击停止；如果是按住说话，松开 Ctrl 即可结束。',
+          idleTitle: '语音输入。点击一次开始录音，或按住 Ctrl 说话。',
+          stopAriaLabel: '停止语音输入',
+          startAriaLabel: '开始语音输入'
+        }
+      },
+      timeline: {
+        thinking: '思考中…',
+        emptyTitle: '暂无消息',
+        emptySubtitle: '发送一条消息以开始对话',
+        steered: '已引导',
+        genericToolStatus: {
+          running: '运行中...',
+          error: '错误',
+          done: '完成'
+        }
+      },
+      header: {
+        providerUpdateError: '更新提供方失败',
+        lifecycle: {
+          idle: '空闲',
+          busy: '执行中',
+          retry: '重试中',
+          error: '错误',
+          materializing: '启动中'
+        },
+        tokens: 'tokens',
+        compressingContext: '正在压缩上下文...'
+      },
+      agentRail: {
+        status: {
+          working: '执行中...',
+          retrying: '重试中...'
+        },
+        pending: '待处理（{count}）',
+        unread: '{count} 条未读{label}',
+        messageSingular: '消息',
+        messagePlural: '消息',
+        interrupts: {
+          question: '有待回答的问题',
+          permission: '需要授权',
+          commandApproval: '需要命令审批',
+          plan: '需要批准计划'
+        }
+      },
+      missionControl: {
+        allTasksCompleted: '全部任务已完成',
+        taskCount: '{completed}/{total} 个任务'
+      },
+      cards: {
+        plan: {
+          title: '待执行计划',
+          requiresApproval: '需要批准',
+          approved: '已批准',
+          rejectModify: '拒绝 / 修改',
+          approveStart: '批准并开始'
+        },
+        askUser: {
+          title: '需要你回答',
+          answered: '已回答',
+          waitingForReply: '等待回复',
+          other: '其他...',
+          ok: '确定',
+          waitingForInput: '等待输入...'
+        },
+        todo: {
+          title: '任务列表',
+          done: '完成',
+          inProgress: '进行中',
+          planUpdate: '计划更新',
+          running: '运行中...',
+          taskFallback: '任务 {index}',
+          noTasks: '没有任务'
+        },
+        bash: {
+          running: '运行中...',
+          error: '错误',
+          exitZero: '退出 0',
+          tokenSaverCompact: 'Token 节省 -{percent}%',
+          truncated: '...（已截断）'
+        },
+        search: {
+          title: '代码搜索',
+          resultCount: '{count} {label}',
+          resultSingular: '条结果',
+          resultPlural: '条结果',
+          query: '查询：'
+        },
+        thinking: {
+          title: '思考过程',
+          showMore: '展开'
+        },
+        goal: {
+          defaultTitle: '会话目标',
+          active: '进行中',
+          completed: '已完成',
+          tokens: 'tokens',
+          dismissCompleted: '关闭已完成目标',
+          criteria: '标准'
+        },
+        fileRead: {
+          title: '读取文件',
+          lineCount: '{count} {label}',
+          lineSingular: '行',
+          linePlural: '行'
+        },
+        fileWrite: {
+          edit: '编辑',
+          writeFile: '写入文件',
+          writing: '写入中...',
+          error: '错误',
+          collapse: '收起',
+          expandAllMore: '展开全部（还有 {count} {label}）',
+          lineSingular: '行',
+          linePlural: '行'
+        },
+        subAgent: {
+          delegatedTo: '委托给 {agent}',
+          defaultDescription: '委托任务',
+          agentFallback: 'Agent',
+          actionCount: '{count} 个{label}',
+          itemCount: '{count} 个{label}',
+          actionSingular: '操作',
+          actionPlural: '操作',
+          itemSingular: '项目',
+          itemPlural: '项目',
+          running: '运行中',
+          show: '显示',
+          hide: '隐藏',
+          readPrefix: '读取 {name}',
+          editPrefix: '编辑 {name}',
+          searchPrefix: '搜索：{query}'
+        }
       }
     },
     sessionTerminalView: {

--- a/test/phase-23/composer-bar.test.tsx
+++ b/test/phase-23/composer-bar.test.tsx
@@ -3,6 +3,15 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { act, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { ComposerBar } from '../../src/renderer/src/components/session-hq/ComposerBar'
+
+vi.mock('react-syntax-highlighter', () => ({
+  Prism: ({ children }: { children: unknown }) => <pre>{children as string}</pre>
+}))
+
+vi.mock('react-syntax-highlighter/dist/esm/styles/prism', () => ({
+  oneDark: {}
+}))
+
 ;(
   globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
 ).IS_REACT_ACT_ENVIRONMENT = true
@@ -24,6 +33,24 @@ beforeEach(() => {
     configurable: true,
     value: {
       commands: vi.fn().mockResolvedValue({ success: true, commands: [] })
+    }
+  })
+
+  Object.defineProperty(window, 'voiceOps', {
+    writable: true,
+    configurable: true,
+    value: {
+      onRuntimeProgress: vi.fn().mockReturnValue(() => {}),
+      onTranscript: vi.fn().mockReturnValue(() => {}),
+      onVoiceError: vi.fn().mockReturnValue(() => {}),
+      disconnectTranscription: vi.fn().mockResolvedValue(undefined),
+      finishUtterance: vi.fn().mockResolvedValue(undefined),
+      ensureRuntime: vi.fn().mockResolvedValue({ status: 'ready', wsUrl: 'ws://127.0.0.1:10095' }),
+      detectRuntime: vi.fn().mockResolvedValue({ status: 'ready', wsUrl: 'ws://127.0.0.1:10095' }),
+      getMicrophonePermissionStatus: vi.fn().mockResolvedValue('granted'),
+      requestMicrophonePermission: vi.fn().mockResolvedValue('granted'),
+      connectTranscription: vi.fn().mockResolvedValue({ sessionId: 'voice-session-1' }),
+      sendAudioChunk: vi.fn().mockResolvedValue(undefined)
     }
   })
 })

--- a/test/phase-23/goal-status-card.test.tsx
+++ b/test/phase-23/goal-status-card.test.tsx
@@ -40,7 +40,7 @@ describe('GoalStatusCard', () => {
       />
     )
 
-    expect(screen.getByTestId('goal-status-card')).toHaveTextContent('completed')
+    expect(screen.getByTestId('goal-status-card')).toHaveTextContent('Completed')
     expect(screen.getByTestId('goal-dismiss-button')).toBeInTheDocument()
 
     await user.click(screen.getByTestId('goal-dismiss-button'))

--- a/test/settings-i18n.test.tsx
+++ b/test/settings-i18n.test.tsx
@@ -242,6 +242,21 @@ describe('Settings i18n', () => {
     expect(translate('zh-CN', 'contextIndicator.cost.session', { cost: '$1.2345' })).toBe(
       '会话成本：$1.2345'
     )
+    expect(translate('zh-CN', 'sessionHq.composer.successCriteriaPlaceholder')).toBe('成功标准...')
+    expect(translate('zh-CN', 'sessionHq.composer.queuePlaceholder')).toBe(
+      '输入要排队到本轮之后的后续消息...'
+    )
+    expect(translate('zh-CN', 'sessionHq.timeline.emptyTitle')).toBe('暂无消息')
+    expect(translate('zh-CN', 'sessionHq.header.providerUpdateError')).toBe('更新提供方失败')
+    expect(translate('zh-CN', 'sessionHq.agentRail.interrupts.commandApproval')).toBe(
+      '需要命令审批'
+    )
+    expect(translate('zh-CN', 'sessionHq.missionControl.allTasksCompleted')).toBe('全部任务已完成')
+    expect(translate('zh-CN', 'sessionHq.cards.plan.requiresApproval')).toBe('需要批准')
+    expect(translate('zh-CN', 'sessionHq.cards.askUser.waitingForReply')).toBe('等待回复')
+    expect(translate('zh-CN', 'sessionHq.cards.bash.truncated')).toBe('...（已截断）')
+    expect(translate('zh-CN', 'sessionHq.cards.search.query')).toBe('查询：')
+    expect(translate('zh-CN', 'sessionHq.cards.goal.dismissCompleted')).toBe('关闭已完成目标')
     expect(translate('zh-CN', 'helpOverlay.title')).toBe('键盘快捷键')
     expect(translate('zh-CN', 'helpOverlay.panels.setup')).toBe('启动脚本')
     expect(translate('zh-CN', 'helpOverlay.dynamic.pinnedPrefix', { name: 'foo' })).toBe(


### PR DESCRIPTION
## Summary
- Add a dedicated `sessionHq` i18n namespace with zh-CN/en strings for the composer, timeline, header, Agent Rail, Mission Control, and Session HQ cards.
- Replace high-visibility hardcoded Session HQ UI copy with `useI18n()` translations while keeping the pure composer state machine unchanged.
- Extend i18n coverage assertions and update goal status expectations for localized labels.

## Verification
- `pnpm vitest run test/settings-i18n.test.tsx test/phase-23/composer-bar.test.tsx test/phase-23/plan-card-copy.test.tsx test/phase-23/bash-card.test.tsx test/phase-23/goal-status-card.test.tsx test/phase-23/agent-timeline-connector.test.tsx test/phase-23/agent-timeline-user-actions.test.tsx`
- `pnpm lint` (passes with existing warnings)
- `pnpm build`
- `git diff --check`
- Session HQ direct JSX English scan: no matches for visible `>English<`, `placeholder=`, `aria-label=`, or `title=` patterns