### PR TITLE
Reduce lint warning noise

### DIFF
--- a/src/main/field/claude-haiku-compactor.ts
+++ b/src/main/field/claude-haiku-compactor.ts
@@ -307,9 +307,6 @@ function truncate(s: string, max: number): string {
   return single.length <= max ? single : single.slice(0, Math.max(0, max - 1)) + '…'
 }
 
-const SECRET_INLINE_REGEX =
-  /(api[_-]?key|password|token|secret|authorization|bearer)\s*[:=]?\s*\S+/gi
-
 // NOTE: This local regex is no longer used at runtime — sharedRedactSecrets
 // from `./redact` is the real implementation. The wrapper preserves the old
 // exported test surface (`__HAIKU_COMPACTOR_TUNABLES_FOR_TEST.redactSecrets`).

--- a/src/main/services/codex-implementer.ts
+++ b/src/main/services/codex-implementer.ts
@@ -2534,17 +2534,10 @@ export class CodexImplementer implements AgentSdkImplementer, AgentRuntimeAdapte
       if (!turnObj) continue
 
       const turnId = asString(turnObj.id)
-      // Codex turns expose `startedAt` / `completedAt` as Unix epoch SECONDS.
-      // Older code looked at `createdAt` / `updatedAt` which don't exist on
-      // codex's wire format, so every item ended up timestamped with
-      // `Date.now()` of the readThread call. That made real assistant
-      // messages sort AFTER any synthetic activity (tool cards, plan
-      // cards, AskUserQuestion cards) emitted during the turn — visually,
-      // synthetic cards jumped to the top of the turn batch. Pinning the
-      // turn timestamp to `startedAt` puts real messages early so
-      // synthetics fall after them in chronological order.
+      // Codex turns expose `startedAt` as Unix epoch seconds. Older code looked
+      // at `createdAt` / `updatedAt`, so items often fell back to read time and
+      // sorted after synthetic activity emitted during the same turn.
       const startedAtSec = asNumber(turnObj.startedAt)
-      const completedAtSec = asNumber(turnObj.completedAt)
       const turnStartIso = startedAtSec
         ? new Date(startedAtSec * 1000).toISOString()
         : undefined

--- a/src/renderer/src/components/connections/ConnectionItem.tsx
+++ b/src/renderer/src/components/connections/ConnectionItem.tsx
@@ -112,45 +112,6 @@ export function ConnectionItem({
 
   const isSelected = selectedConnectionId === connection.id
 
-  // Derive display status text + color
-  const { displayStatus, statusClass } =
-    connectionStatus === 'answering'
-      ? { displayStatus: t('pinned.status.answering'), statusClass: 'font-semibold text-amber-500' }
-      : connectionStatus === 'command_approval'
-        ? {
-            displayStatus: t('pinned.status.commandApproval'),
-            statusClass: 'font-semibold text-orange-500'
-          }
-        : connectionStatus === 'permission'
-          ? {
-              displayStatus: t('pinned.status.permission'),
-              statusClass: 'font-semibold text-amber-500'
-            }
-          : connectionStatus === 'planning'
-            ? {
-                displayStatus: t('pinned.status.planning'),
-                statusClass: 'font-semibold text-blue-400'
-              }
-            : connectionStatus === 'working'
-              ? {
-                  displayStatus: t('pinned.status.working'),
-                  statusClass: 'font-semibold text-primary'
-                }
-              : connectionStatus === 'plan_ready'
-                ? {
-                    displayStatus: t('pinned.status.planReady'),
-                    statusClass: 'font-semibold text-blue-400'
-                  }
-                : connectionStatus === 'completed'
-                  ? {
-                      displayStatus: t('pinned.status.ready'),
-                      statusClass: 'font-semibold text-green-400'
-                    }
-                  : {
-                      displayStatus: t('pinned.status.ready'),
-                      statusClass: 'text-muted-foreground'
-                    }
-
   // Marquee animation state for overflowing display name
   const containerRef = useRef<HTMLDivElement>(null)
   const textRef = useRef<HTMLSpanElement>(null)

--- a/src/renderer/src/components/file-viewer/CodeMirrorEditor.tsx
+++ b/src/renderer/src/components/file-viewer/CodeMirrorEditor.tsx
@@ -49,6 +49,8 @@ export function CodeMirrorEditor({
   worktreeIdRef.current = worktreeId
   const filePathRef = useRef(filePath)
   filePathRef.current = filePath
+  const initialContentRef = useRef(content)
+  const initialFilePathRef = useRef(filePath)
 
   // Phase 21 file.selection reporter — throttled + non-caret-only.
   // Debounce 250ms so drag-select doesn't spam events. Only reports ranges
@@ -57,16 +59,14 @@ export function CodeMirrorEditor({
   const lastReportedRef = useRef<string>('')
 
   // Initializes the EditorView once on mount and cleans it up on unmount.
-  // The parent component keys this component by filePath, so a new file
-  // causes a full remount. content, filePath, and onContentChange are
-  // intentionally excluded — they are only needed at initialization time
-  // (content/filePath captured in the closure, onContentChange accessed
-  // via onContentChangeRef to always use the latest callback).
+  // The parent component keys this component by filePath, so a new file causes
+  // a full remount. EditorView consumes the initial content/language once;
+  // callbacks and selection reporting use refs to stay current afterward.
   useEffect(() => {
     if (!containerRef.current) return
 
     const state = EditorState.create({
-      doc: content,
+      doc: initialContentRef.current,
       extensions: [
         oneDark,
         editorTheme,
@@ -88,7 +88,7 @@ export function CodeMirrorEditor({
           ...searchKeymap,
           indentWithTab
         ]),
-        getLanguageExtension(filePath),
+        getLanguageExtension(initialFilePathRef.current),
         EditorView.updateListener.of((update) => {
           if (update.docChanged && onContentChangeRef.current) {
             onContentChangeRef.current(update.state.doc.toString())

--- a/src/renderer/src/components/layout/PinnedList.tsx
+++ b/src/renderer/src/components/layout/PinnedList.tsx
@@ -391,45 +391,6 @@ function PinnedWorktreeItem({ worktreeId }: { worktreeId: string }): React.JSX.E
   const displayBranch = liveBranch?.name ?? worktree.name
   const hasNamedBranch = Boolean(worktree.branch_name)
 
-  // Derive display status text + color
-  const { displayStatus: _displayStatus, statusClass: _statusClass } =
-    worktreeStatus === 'answering'
-      ? { displayStatus: t('pinned.status.answering'), statusClass: 'font-semibold text-amber-500' }
-      : worktreeStatus === 'command_approval'
-        ? {
-            displayStatus: t('pinned.status.commandApproval'),
-            statusClass: 'font-semibold text-orange-500'
-          }
-        : worktreeStatus === 'permission'
-          ? {
-              displayStatus: t('pinned.status.permission'),
-              statusClass: 'font-semibold text-amber-500'
-            }
-          : worktreeStatus === 'planning'
-            ? {
-                displayStatus: t('pinned.status.planning'),
-                statusClass: 'font-semibold text-blue-400'
-              }
-            : worktreeStatus === 'working'
-              ? {
-                  displayStatus: t('pinned.status.working'),
-                  statusClass: 'font-semibold text-primary'
-                }
-              : worktreeStatus === 'plan_ready'
-                ? {
-                    displayStatus: t('pinned.status.planReady'),
-                    statusClass: 'font-semibold text-blue-400'
-                  }
-                : worktreeStatus === 'completed'
-                  ? {
-                      displayStatus: t('pinned.status.ready'),
-                      statusClass: 'font-semibold text-green-400'
-                    }
-                  : {
-                      displayStatus: t('pinned.status.ready'),
-                      statusClass: 'text-muted-foreground'
-                    }
-
   const handleClick = (): void => {
     selectWorktree(worktreeId)
     selectProject(project.id)
@@ -923,45 +884,6 @@ function PinnedConnectionItem({
   const displayName = hasCustomName
     ? connection.custom_name!
     : projectNames || connection.name || t('pinned.connectionFallback')
-
-  // Derive display status text + color
-  const { displayStatus: _displayStatus2, statusClass: _statusClass2 } =
-    connectionStatus === 'answering'
-      ? { displayStatus: t('pinned.status.answering'), statusClass: 'font-semibold text-amber-500' }
-      : connectionStatus === 'command_approval'
-        ? {
-            displayStatus: t('pinned.status.commandApproval'),
-            statusClass: 'font-semibold text-orange-500'
-          }
-        : connectionStatus === 'permission'
-          ? {
-              displayStatus: t('pinned.status.permission'),
-              statusClass: 'font-semibold text-amber-500'
-            }
-          : connectionStatus === 'planning'
-            ? {
-                displayStatus: t('pinned.status.planning'),
-                statusClass: 'font-semibold text-blue-400'
-              }
-            : connectionStatus === 'working'
-              ? {
-                  displayStatus: t('pinned.status.working'),
-                  statusClass: 'font-semibold text-primary'
-                }
-              : connectionStatus === 'plan_ready'
-                ? {
-                    displayStatus: t('pinned.status.planReady'),
-                    statusClass: 'font-semibold text-blue-400'
-                  }
-                : connectionStatus === 'completed'
-                  ? {
-                      displayStatus: t('pinned.status.ready'),
-                      statusClass: 'font-semibold text-green-400'
-                    }
-                  : {
-                      displayStatus: t('pinned.status.ready'),
-                      statusClass: 'text-muted-foreground'
-                    }
 
   const handleClick = (): void => {
     selectConnection(connectionId)

--- a/src/renderer/src/components/session-hq/AgentRail.tsx
+++ b/src/renderer/src/components/session-hq/AgentRail.tsx
@@ -56,11 +56,9 @@ function InterruptQueueItem({ item }: { item: InterruptItem }): React.JSX.Elemen
 // ---------------------------------------------------------------------------
 
 export function AgentRail({
-  sessionId,
   lifecycle,
   interruptQueue,
   unreadCount,
-  commandsAvailable,
   collapsed = false
 }: AgentRailProps): React.JSX.Element | null {
   // Don't render the rail when there's nothing to show

--- a/src/renderer/src/components/sessions/SessionView.tsx
+++ b/src/renderer/src/components/sessions/SessionView.tsx
@@ -691,7 +691,7 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
   const [isSending, setIsSending] = useState(false)
   const [editingMessageId, setEditingMessageId] = useState<string | null>(null)
   const [editingContent, setEditingContent] = useState<string>('')
-  const [_editingAttachments, _setEditingAttachments] = useState<MessagePart[]>([])
+  const [, setEditingAttachments] = useState<MessagePart[]>([])
   const [queuedMessages, setQueuedMessages] = useState<QueuedMsg[]>([])
   const [attachments, setAttachments] = useState<Attachment[]>(() =>
     useDraftAttachmentStore.getState().restore(sessionId)
@@ -1258,6 +1258,7 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
   }, [
     getModelForRequests,
     sessionId,
+    sessionAgentSdk,
     sessionRecord?.model_provider_id,
     sessionRecord?.model_id,
     sessionRecord?.model_variant
@@ -4323,13 +4324,13 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
         ? message.content.slice(ASK_MODE_PREFIX.length)
         : message.content
     setEditingContent(displayContent)
-    _setEditingAttachments(message.attachments ?? [])
+    setEditingAttachments(message.attachments ?? [])
   }, [])
 
   const handleCancelEdit = useCallback(() => {
     setEditingMessageId(null)
     setEditingContent('')
-    _setEditingAttachments([])
+    setEditingAttachments([])
   }, [])
 
   const handleSaveEdit = useCallback(
@@ -4351,7 +4352,7 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
 
       setEditingMessageId(null)
       setEditingContent('')
-      _setEditingAttachments([])
+      setEditingAttachments([])
 
       await handleSend(contentToSend)
     },

--- a/src/renderer/src/lib/codex-timeline.ts
+++ b/src/renderer/src/lib/codex-timeline.ts
@@ -94,10 +94,6 @@ function parsePlanPart(activity: SessionActivity): StreamingPart | null {
   }
 }
 
-function hasCanonicalTurnScopedId(messageId: string | null | undefined): boolean {
-  return typeof messageId === 'string' && /:user(?::|$)|:assistant(?::|$)/.test(messageId)
-}
-
 function extractAssistantTurnId(messageId: string): string | null {
   const assistantMatch = messageId.match(/^(.*):assistant(?::.*)?$/)
   return assistantMatch?.[1] ?? null

--- a/src/renderer/src/lib/context-usage.ts
+++ b/src/renderer/src/lib/context-usage.ts
@@ -1,5 +1,5 @@
 import type { AgentSessionContextUsageData } from '@shared/types/agent-protocol'
-import type { ContextUsageCategory, SessionModelRef, TokenInfo } from '@/stores/useContextStore'
+import type { ContextUsageCategory, TokenInfo } from '@/stores/useContextStore'
 import { useContextStore } from '@/stores/useContextStore'
 
 function normalizeTokens(

--- a/test/phase-14/session-2/file-changes-dual.test.ts
+++ b/test/phase-14/session-2/file-changes-dual.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, vi, beforeEach } from 'vitest'
+import { describe, test, expect } from 'vitest'
 import { join } from 'path'
 
 // Replicate the processing logic from GitService.getFileStatuses()

--- a/test/phase-20/session-10/auto-update-behavior.test.tsx
+++ b/test/phase-20/session-10/auto-update-behavior.test.tsx
@@ -12,29 +12,25 @@ const toastMocks = vi.hoisted(() => ({
 }))
 
 const sonnerToasterMock = vi.hoisted(() => vi.fn(() => null))
+const sonnerToastMocks = vi.hoisted(() => ({
+  custom: vi.fn().mockReturnValue('prompt-toast'),
+  dismiss: vi.fn()
+}))
 
 vi.mock('@/lib/toast', () => ({
   toast: toastMocks
 }))
 
 vi.mock('sonner', () => ({
-  Toaster: sonnerToasterMock
+  Toaster: sonnerToasterMock,
+  toast: sonnerToastMocks
 }))
 
 type UpdateAvailableData = { version: string; releaseNotes?: string; releaseDate?: string }
-type DownloadProgressData = {
-  percent: number
-  bytesPerSecond: number
-  transferred: number
-  total: number
-}
 type UpdateDownloadedData = { version: string; releaseNotes?: string }
-type UpdateErrorData = { message: string }
 
 let onUpdateAvailableCb: ((data: UpdateAvailableData) => void) | null = null
-let onProgressCb: ((data: DownloadProgressData) => void) | null = null
 let onUpdateDownloadedCb: ((data: UpdateDownloadedData) => void) | null = null
-let onErrorCb: ((data: UpdateErrorData) => void) | null = null
 
 const installUpdateMock = vi.fn().mockResolvedValue(undefined)
 
@@ -43,13 +39,12 @@ describe('Auto update behavior', () => {
     vi.clearAllMocks()
 
     onUpdateAvailableCb = null
-    onProgressCb = null
     onUpdateDownloadedCb = null
-    onErrorCb = null
 
     toastMocks.info.mockReturnValue('toast-available')
     toastMocks.loading.mockReturnValue('toast-progress')
     toastMocks.success.mockReturnValue('toast-downloaded')
+    sonnerToastMocks.custom.mockReturnValue('prompt-toast')
 
     Object.defineProperty(window, 'updaterOps', {
       configurable: true,
@@ -66,24 +61,22 @@ describe('Auto update behavior', () => {
           }
         }),
         onUpdateNotAvailable: vi.fn().mockReturnValue(() => {}),
-        onProgress: vi.fn((cb: (data: DownloadProgressData) => void) => {
-          onProgressCb = cb
-          return () => {
-            onProgressCb = null
-          }
-        }),
+        onProgress: vi.fn().mockReturnValue(() => {}),
         onUpdateDownloaded: vi.fn((cb: (data: UpdateDownloadedData) => void) => {
           onUpdateDownloadedCb = cb
           return () => {
             onUpdateDownloadedCb = null
           }
         }),
-        onError: vi.fn((cb: (data: UpdateErrorData) => void) => {
-          onErrorCb = cb
-          return () => {
-            onErrorCb = null
-          }
-        })
+        onError: vi.fn().mockReturnValue(() => {})
+      }
+    })
+
+    Object.defineProperty(window, 'systemOps', {
+      configurable: true,
+      writable: true,
+      value: {
+        openInChrome: vi.fn().mockResolvedValue(undefined)
       }
     })
   })
@@ -92,16 +85,15 @@ describe('Auto update behavior', () => {
     cleanup()
   })
 
-  test('update available toast does not require download button click', () => {
+  test('update available uses custom prompt and does not auto-download', () => {
     renderHook(() => useAutoUpdate())
 
     act(() => {
       onUpdateAvailableCb?.({ version: '1.2.3' })
     })
 
-    expect(toastMocks.info).toHaveBeenCalledTimes(1)
-    const options = toastMocks.info.mock.calls[0]?.[1] as { action?: unknown } | undefined
-    expect(options?.action).toBeUndefined()
+    expect(sonnerToastMocks.custom).toHaveBeenCalledTimes(1)
+    expect(window.updaterOps.downloadUpdate).not.toHaveBeenCalled()
   })
 
   test('downloaded toast exposes restart action that installs update', () => {

--- a/test/phase-21-5/emit-agent-tool.test.ts
+++ b/test/phase-21-5/emit-agent-tool.test.ts
@@ -25,21 +25,6 @@ import type { FieldEvent } from '../../src/shared/types/field-event'
 
 const WORKTREE_PATH = '/Users/dev/proj/wt'
 
-function captureLastEnqueued(): FieldEvent | null {
-  const sink = getFieldEventSink()
-  let last: FieldEvent | null = null
-  vi.spyOn(sink, 'enqueue').mockImplementation((evt: FieldEvent) => {
-    last = evt
-    return undefined as unknown as void
-  })
-  return new Proxy(
-    {},
-    {
-      get: (_t, prop) => (prop === 'value' ? last : undefined)
-    }
-  ) as { value: FieldEvent | null }
-}
-
 beforeEach(() => {
   resetFieldEventSink()
   resetEventBus()

--- a/test/phase-21/field-events/semantic-memory-loader.test.ts
+++ b/test/phase-21/field-events/semantic-memory-loader.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
-import { tmpdir, homedir } from 'os'
+import { tmpdir } from 'os'
 import { join } from 'path'
 import { mkdtempSync, rmSync, mkdirSync, writeFileSync, utimesSync } from 'fs'
 

--- a/test/phase-21/session-11/codex-canonical-routing.test.ts
+++ b/test/phase-21/session-11/codex-canonical-routing.test.ts
@@ -22,7 +22,6 @@ vi.mock('../../../src/main/services/codex-app-server-manager', () => ({
 
 import { AgentRuntimeManager } from '../../../src/main/services/agent-runtime-manager'
 import { CodexImplementer } from '../../../src/main/services/codex-implementer'
-import type { AgentRuntimeAdapter } from '../../../src/main/services/agent-runtime-types'
 
 describe('Codex Canonical Protocol Routing', () => {
   let manager: AgentRuntimeManager
@@ -75,7 +74,7 @@ describe('Codex Canonical Protocol Routing', () => {
   })
 
   it('should handle Codex session lifecycle', async () => {
-    const connectSpy = vi.spyOn(codexImpl, 'connect').mockResolvedValue({ sessionId: 'thread-1' })
+    vi.spyOn(codexImpl, 'connect').mockResolvedValue({ sessionId: 'thread-1' })
     const promptSpy = vi.spyOn(codexImpl, 'prompt').mockResolvedValue(undefined)
     const getMessagesSpy = vi.spyOn(codexImpl, 'getMessages').mockResolvedValue([])
     const disconnectSpy = vi.spyOn(codexImpl, 'disconnect').mockResolvedValue(undefined)

--- a/test/phase-21/session-11/opencode-canonical-routing.test.ts
+++ b/test/phase-21/session-11/opencode-canonical-routing.test.ts
@@ -11,7 +11,6 @@ vi.mock('../../../src/main/services/logger', () => ({
 
 import { AgentRuntimeManager } from '../../../src/main/services/agent-runtime-manager'
 import type { AgentRuntimeAdapter } from '../../../src/main/services/agent-runtime-types'
-import type { DatabaseService } from '../../../src/main/db/database'
 
 function createMockOpenCodeImpl(): AgentRuntimeAdapter {
   return {
@@ -50,22 +49,13 @@ function createMockOpenCodeImpl(): AgentRuntimeAdapter {
   }
 }
 
-function createMockDbService(): DatabaseService {
-  return {
-    getRuntimeIdForSession: vi.fn().mockReturnValue('opencode'),
-    getAgentSdkForSession: vi.fn().mockReturnValue('opencode')
-  } as unknown as DatabaseService
-}
-
 describe('OpenCode Canonical Protocol Routing', () => {
   let manager: AgentRuntimeManager
   let mockOC: AgentRuntimeAdapter
-  let mockDb: DatabaseService
 
   beforeEach(() => {
     mockOC = createMockOpenCodeImpl()
     manager = new AgentRuntimeManager([mockOC])
-    mockDb = createMockDbService()
   })
 
   it('should route agent:connect to OpenCode implementer', async () => {

--- a/test/phase-21/session-7/worktree-breed-collision-retry.test.ts
+++ b/test/phase-21/session-7/worktree-breed-collision-retry.test.ts
@@ -43,7 +43,7 @@ describe('Worktree breed-name collision retry', () => {
     // First git worktree add call fails with "already exists",
     // second call succeeds
     mockRaw
-      .mockImplementationOnce(async (args: string[]) => {
+      .mockImplementationOnce(async (_args: string[]) => {
         // getCurrentBranch raw call — not used directly (branch() is)
         return ''
       })

--- a/test/phase-21/session-8/menu-capability-gating.test.ts
+++ b/test/phase-21/session-8/menu-capability-gating.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
 /**

--- a/test/server/config.test.ts
+++ b/test/server/config.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { writeFileSync, mkdirSync, rmSync } from 'node:fs'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
-import { loadHeadlessConfig, type HeadlessConfig } from '../../src/server/config'
+import { loadHeadlessConfig } from '../../src/server/config'
 
 describe('loadHeadlessConfig', () => {
   let tempDir: string


### PR DESCRIPTION
## Summary
- remove unused runtime/test code and stale imports that were generating lint noise
- make CodeMirror's one-time initialization intent explicit without suppressing hook lint
- update auto-update behavior test mocks to match the current custom prompt flow

## Verification
- pnpm lint (0 errors, 15 remaining warnings; down from 42 on main)
- pnpm vitest run test/phase-14/session-2/file-changes-dual.test.ts test/phase-20/session-10/auto-update-behavior.test.tsx test/phase-21-5/emit-agent-tool.test.ts test/phase-21/field-events/semantic-memory-loader.test.ts test/phase-21/session-11/codex-canonical-routing.test.ts test/phase-21/session-11/opencode-canonical-routing.test.ts test/phase-21/session-7/worktree-breed-collision-retry.test.ts test/phase-21/session-8/menu-capability-gating.test.ts test/server/config.test.ts
- pnpm build
- git diff --check