### PR TITLE
fix(codex): harden runtime turn lifecycle

### DIFF
--- a/docs/plans/2026-05-17-context-kernel-and-provider-local-capabilities.md
+++ b/docs/plans/2026-05-17-context-kernel-and-provider-local-capabilities.md
@@ -1,0 +1,680 @@
+# Xuanpu — Context Kernel + Provider-local Model Capabilities
+
+**Date**: 2026-05-17  
+**Status**: Draft  
+**Target window**: v1.5.x / v1.6.x  
+**Scope**: Context package, capability-aware model fit, explainable prompt injection  
+
+---
+
+## 0. 背景
+
+玄圃已经具备个人 AI OS 的第一层地基：
+
+- Field Event Stream：把 worktree、文件、终端、用户消息、agent 工具调用沉淀为结构化事件
+- Field Context：每次 prompt 前把当前现场编译成 markdown 前缀
+- Memory：Pinned Facts / Episodic / Semantic / Session Checkpoint
+- Agent Runtime：Claude Code / Codex / OpenCode / Terminal
+- Token Saver：Claude Code Bash 输出可压缩并归档
+
+下一阶段不应该做“跨 agent 的模型路由”。玄圃接入的是 **agent runtime**，不是裸模型 API。Claude Code、Codex、OpenCode 不是同质执行器，它们有不同的工具协议、会话状态、权限模型、文件 checkpoint、计划模式、goal mode、流式事件形态。
+
+所以这里的正确方向是：
+
+> 玄圃不自动把一个任务从 Claude 切到 Codex，也不把 OpenCode 当成 Claude 的便宜替代。玄圃应该在用户选定的 agent / provider 内，管理上下文包、模型能力、预算、附件兼容性和注入可解释性。
+
+换句话说，玄圃的核心不是 **Model Router**，而是 **Context Kernel + Model Fit Advisor**。
+
+---
+
+## 1. 产品原则
+
+### 1.1 Agent runtime 不是可互换模型
+
+禁止把以下事情做成自动化默认行为：
+
+- Claude Code session 自动切到 Codex
+- Codex session 自动切到 OpenCode
+- OpenCode session 自动切到 Claude Code
+- 根据一句用户输入自动换 runtime
+
+原因：
+
+- session state 不可无损迁移
+- 工具调用和权限语义不同
+- agent 的计划/执行风格不同
+- 用户选 runtime 往往是在选工作方式，不只是选模型
+
+允许做的是：
+
+- 在当前 runtime 内建议模型或 reasoning variant
+- 在当前 runtime 内提示模型能力不匹配
+- 按当前模型能力生成不同 context package
+- 提供明确的手动切换入口和迁移提示
+
+### 1.2 Router 先路由上下文，不路由 agent
+
+玄圃真正可控、也最有差异化的是 context supply chain：
+
+- 哪些现场进入 prompt
+- 以原文、摘要、路径引用还是统计信息进入
+- 给多少 token 预算
+- 哪些被裁剪、为什么裁剪
+- 这次上下文是否足够回答用户问题
+
+因此本计划里的“路由”只指：
+
+- Context mode selection
+- Context budget allocation
+- Capability fit check
+- Provider-local model/variant suggestion
+
+不指跨 runtime dispatch。
+
+### 1.3 用户保持控制
+
+系统可以建议：
+
+- “当前模型不支持图片，建议换到同 provider 下支持图片的模型”
+- “这次上下文包被裁剪到 compact 模式”
+- “这是 debug 请求，已优先注入 terminal output 和 focus file”
+
+但不静默改变：
+
+- agent runtime
+- selected model
+- permission policy
+- field collection setting
+
+---
+
+## 2. 当前基线
+
+### 2.1 已有能力
+
+| 能力 | 当前落点 |
+|---|---|
+| Field events | `field_events` / `src/shared/types/field-event.ts` |
+| Snapshot builder | `src/main/field/context-builder.ts` |
+| Markdown formatter | `src/main/field/context-formatter.ts` |
+| Prompt injection | `src/main/ipc/agent-handlers.ts` |
+| Last injection cache | `src/main/field/last-injection-cache.ts` |
+| Memory UI | `src/renderer/src/components/sessions/MemoryPanel.tsx` |
+| Debug UI | `src/renderer/src/components/sessions/FieldContextDebug.tsx` |
+| Runtime abstraction | `src/main/services/agent-runtime-types.ts` |
+| Model selector | `src/renderer/src/components/sessions/ModelSelector.tsx` |
+| Context usage UI | `src/renderer/src/components/sessions/ContextIndicator.tsx` |
+
+### 2.2 主要缺口
+
+1. Field Context 是 markdown 字符串，不是可审计的 context package。
+2. Formatter 只有 `tokenBudget`，没有 `mode`、section metadata、drop reasons。
+3. 模型元数据只有 `limit.context/output` 和 `variants`，缺少 capabilities。
+4. UI 能看 last injection，但看不到“为什么这样注入”。
+5. 当前没有 prompt preflight：附件/模型能力不匹配时只能靠 runtime 失败。
+6. Context decision 没有持久 trace，无法评估注入质量。
+
+---
+
+## 3. 目标
+
+### 3.1 P0：Context Package Contract
+
+把 Field Context 从“markdown 字符串”升级为结构化产物：
+
+```ts
+interface ContextPackage {
+  id: string
+  worktreeId: string
+  runtimeId: AgentRuntimeId
+  model: {
+    providerID: string
+    modelID: string
+    variant?: string
+  } | null
+  mode: ContextMode
+  budget: ContextBudget
+  snapshot: FieldContextSnapshot
+  rendered: {
+    markdown: string
+    approxTokens: number
+    wasTruncated: boolean
+  }
+  sections: ContextPackageSection[]
+  decision: ContextDecisionTrace
+  createdAt: number
+}
+
+type ContextMode = 'tiny' | 'compact' | 'standard' | 'deep' | 'audit'
+
+interface ContextPackageSection {
+  id:
+    | 'worktree'
+    | 'current_focus'
+    | 'checkpoint'
+    | 'pinned_facts'
+    | 'semantic_memory'
+    | 'worktree_notes'
+    | 'episodic_summary'
+    | 'last_terminal'
+    | 'recent_activity'
+  label: string
+  included: boolean
+  approxTokens: number
+  source: 'field_event' | 'db' | 'file' | 'derived'
+  sourceRefs: string[]
+  dropReason?: 'not_available' | 'privacy_disabled' | 'budget' | 'mode' | 'stale'
+}
+```
+
+MVP 不要求 formatter 内部完全按 section 渲染重写；可以先在现有 formatter 外层补 metadata。
+
+### 3.2 P0：Context Decision Trace
+
+每次 prompt 注入时记录一份可解释决策：
+
+```ts
+interface ContextDecisionTrace {
+  taskType: TaskType
+  mode: ContextMode
+  reasons: string[]
+  warnings: string[]
+  modelFit: ModelFitResult
+  budgetTier: number
+  fallbackUsed: boolean
+}
+
+type TaskType =
+  | 'debug'
+  | 'implement'
+  | 'review'
+  | 'explain'
+  | 'summarize'
+  | 'write'
+  | 'plan'
+  | 'unknown'
+```
+
+示例：
+
+```json
+{
+  "taskType": "debug",
+  "mode": "standard",
+  "reasons": [
+    "user message contains debug cue",
+    "last terminal command exited non-zero",
+    "focused file available"
+  ],
+  "warnings": ["terminal output was truncated at capture time"],
+  "modelFit": {
+    "status": "ok",
+    "issues": []
+  },
+  "budgetTier": 3,
+  "fallbackUsed": false
+}
+```
+
+这不是模型路由记录，而是 context decision 记录。
+
+### 3.3 P0：Provider-local Model Capability Catalog
+
+在当前 runtime 的 model metadata 中补充能力信息：
+
+```ts
+interface ModelCapabilities {
+  contextWindow: number
+  maxOutputTokens?: number
+  supportsImages: boolean
+  supportsPdf: boolean
+  supportsComputerUse?: boolean
+  supportsTools: boolean
+  supportsReasoningEffort: boolean
+  recommendedContextModes: ContextMode[]
+  defaultContextMode: ContextMode
+}
+```
+
+现有模型返回值可扩展为：
+
+```ts
+{
+  id: string
+  name: string
+  limit: { context: number; input?: number; output: number }
+  capabilities?: ModelCapabilities
+  variants?: Record<string, Record<string, never>>
+}
+```
+
+MVP 要求：
+
+- Claude 模型补 `supportsImages/supportsPdf/contextWindow/output`
+- Codex 模型补 `contextWindow/output/reasoningEffort`
+- OpenCode 对未知 provider 给保守 default，并允许 provider config 后续覆盖
+
+### 3.4 P0：Prompt Preflight
+
+发送前做轻量检查，不拦正常文本：
+
+| 场景 | 行为 |
+|---|---|
+| message 带图片，但当前模型标记 `supportsImages=false` | 阻止发送或提示换当前 provider 下支持图片的模型 |
+| message 带 PDF，但当前模型标记 `supportsPdf=false` | 阻止发送或提示 |
+| context package 超预算 | 自动降 mode，并在 trace 里展示 |
+| field collection disabled | 明确显示“只会注入用户手写 worktree context / memory” |
+| debug 问题但没有 terminal output | 提示“没有捕获到最近终端输出” |
+
+Preflight 只在当前 runtime/provider 内给建议，不自动切 runtime。
+
+### 3.5 P1：Context Inspector
+
+把 dev-only `FieldContextDebug` 的能力产品化为 Context Inspector：
+
+- Last Package：本次实际发送的 context package
+- Included：已发送 section 列表
+- Dropped：未发送 section 和原因
+- Model Fit：附件和模型能力兼容性
+- Budget：mode、tier、approx tokens、裁剪说明
+- Raw Markdown：可展开，不默认展示
+
+入口建议：
+
+- Composer 旁边的 `ContextIndicator` tooltip 增强
+- MemoryPanel 旁边增加 “Context” tab
+- Session header 增加小型 package pill
+
+### 3.6 P1：Field Event 扩展
+
+为更准确的现场补 P1 事件：
+
+```ts
+type FieldEventType =
+  | existing
+  | 'file.edit'
+  | 'git.status_change'
+  | 'session.approval'
+  | 'context.package_created'
+```
+
+优先级：
+
+1. `git.status_change`：dirty files、branch、ahead/behind、staged count
+2. `file.edit`：手动编辑摘要，不存全文
+3. `session.approval`：用户允许/拒绝的工具请求
+4. `context.package_created`：记录 context package trace
+
+这些事件的价值是让 context decision 有证据来源，而不是纯 UI 状态。
+
+---
+
+## 4. 非目标
+
+- 不做跨 Claude / Codex / OpenCode 自动切换
+- 不做全局“选择最便宜 agent”
+- 不做 LLM-based 自动长期记忆写入
+- 不做 Claim Store / Outcome Loop 的大设计回归
+- 不做向量检索
+- 不默认上传任何 context / trace
+- 不改变用户已选模型，只提供同 provider 内的建议
+
+---
+
+## 5. 技术设计
+
+### 5.1 新模块：Context Kernel
+
+建议新增目录：
+
+```text
+src/main/context-kernel/
+  types.ts
+  intent.ts
+  model-capabilities.ts
+  budget.ts
+  compiler.ts
+  trace-repository.ts
+```
+
+核心接口：
+
+```ts
+interface CompileContextInput {
+  userMessage: string
+  messageParts?: Array<{ type: string; mime?: string }>
+  worktreeId: string
+  runtimeId: AgentRuntimeId
+  model: { providerID: string; modelID: string; variant?: string } | null
+  requestedMode?: ContextMode
+}
+
+async function compileContextPackage(
+  input: CompileContextInput
+): Promise<ContextPackage | null>
+```
+
+`agent-handlers.ts` 中的注入逻辑变成：
+
+```ts
+const contextPackage = await compileContextPackage({
+  userMessage,
+  messageParts,
+  worktreeId,
+  runtimeId,
+  model
+})
+
+if (contextPackage) {
+  messageOrParts = prependToMessage(
+    messageOrParts,
+    `${contextPackage.rendered.markdown}\n\n[User Message]\n`
+  )
+  cacheLastContextPackage(...)
+}
+```
+
+### 5.2 Intent v0：规则优先
+
+不调 LLM，先用规则：
+
+```ts
+function classifyTaskType(userMessage: string): TaskType {
+  const text = userMessage.toLowerCase()
+  if (/报错|错误|failed|failure|error|stack|trace|why.*break/.test(text)) return 'debug'
+  if (/review|审查|看看 diff|风险|问题/.test(text)) return 'review'
+  if (/实现|修复|加一个|改一下|build|implement/.test(text)) return 'implement'
+  if (/解释|为什么|原理|explain/.test(text)) return 'explain'
+  if (/总结|summary|summarize/.test(text)) return 'summarize'
+  if (/计划|规划|plan/.test(text)) return 'plan'
+  return 'unknown'
+}
+```
+
+规则只影响 context mode，不影响 runtime。
+
+### 5.3 Context mode 策略
+
+| Mode | 目标 | 预算建议 | 主要内容 |
+|---|---|---:|---|
+| tiny | 分类/预检 | 300-600 tokens | user message + model fit + minimal worktree |
+| compact | 日常问答 | 1000-1500 tokens | focus + pinned + terminal summary |
+| standard | debug/implement 默认 | 2000-4000 tokens | focus + terminal + recent activity + memory |
+| deep | 跨文件/长任务 | 6000-12000 tokens | wider event window + semantic + episodic |
+| audit | review | 4000-8000 tokens | diff/git status + approvals + tests |
+
+MVP 不需要一次实现所有 mode 的完全差异化。先把 mode 参数透传到 formatter：
+
+```ts
+formatFieldContext(snapshot, {
+  tokenBudget,
+  mode
+})
+```
+
+再逐步细化 section priority。
+
+### 5.4 Model fit 不是 Model route
+
+```ts
+interface ModelFitResult {
+  status: 'ok' | 'warn' | 'blocked'
+  issues: Array<{
+    code:
+      | 'image_unsupported'
+      | 'pdf_unsupported'
+      | 'context_budget_small'
+      | 'unknown_capabilities'
+    message: string
+    suggestedModelIds?: string[]
+  }>
+}
+```
+
+示例：
+
+```json
+{
+  "status": "blocked",
+  "issues": [
+    {
+      "code": "image_unsupported",
+      "message": "Current Claude model does not advertise image support.",
+      "suggestedModelIds": ["claude-sonnet-4-5", "claude-opus-4-5"]
+    }
+  ]
+}
+```
+
+注意：`suggestedModelIds` 只能来自当前 runtime/provider 的 available models。
+
+### 5.5 Trace 存储
+
+新增表：
+
+```sql
+CREATE TABLE IF NOT EXISTS field_context_packages (
+  id TEXT PRIMARY KEY,
+  created_at INTEGER NOT NULL,
+  worktree_id TEXT NOT NULL,
+  session_id TEXT,
+  runtime_id TEXT NOT NULL,
+  provider_id TEXT,
+  model_id TEXT,
+  model_variant TEXT,
+  task_type TEXT NOT NULL,
+  mode TEXT NOT NULL,
+  approx_tokens INTEGER NOT NULL,
+  was_truncated INTEGER NOT NULL DEFAULT 0,
+  budget_tier INTEGER,
+  sections_json TEXT NOT NULL,
+  decision_json TEXT NOT NULL,
+  preview_md TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_field_context_packages_session_created
+  ON field_context_packages(session_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_field_context_packages_worktree_created
+  ON field_context_packages(worktree_id, created_at DESC);
+```
+
+`preview_md` 可限制 20KB，避免 DB 膨胀。完整 markdown 仍可只存在 last injection cache；MVP 可先不落全文。
+
+---
+
+## 6. UI 设计
+
+### 6.1 Composer Context Pill
+
+现有 `ContextIndicator` 增强：
+
+```text
+Context: standard · ~2.8k · 7 sections
+```
+
+Tooltip：
+
+```text
+Context Package
+Mode: standard
+Task: debug
+Included:
+- Current Focus
+- Last Terminal Activity
+- Pinned Facts
+- Worktree Summary
+
+Dropped:
+- Recent Activity: budget
+
+Model Fit:
+- OK
+```
+
+### 6.2 Context Inspector Panel
+
+建议作为 Session HQ 底部面板里的新 tab：
+
+```text
+[Memory] [Context]
+```
+
+Context tab：
+
+- Latest Package
+- Decision Trace
+- Sections
+- Raw Markdown
+- Privacy
+
+### 6.3 Preflight Dialog
+
+只在 blocked 场景弹：
+
+```text
+当前模型可能无法处理这条消息
+
+原因：
+- 包含 2 张图片
+- 当前模型未声明图片能力
+
+可选：
+[换到 Sonnet] [仍然发送] [取消]
+```
+
+是否允许“仍然发送”由 runtime 决定。若 runtime 明确会失败，则不允许。
+
+---
+
+## 7. 分阶段实施
+
+### Phase A — Context Package Metadata
+
+目标：不改变行为，只让每次注入可解释。
+
+改动：
+
+- 新增 `ContextPackage` / `ContextDecisionTrace` 类型
+- `formatFieldContext()` 返回 section metadata 或外层包装 metadata
+- `agent-handlers.ts` 缓存 context package
+- `fieldOps.getLastContextPackage(sessionId)` IPC
+- Context Inspector 最小 UI
+
+验收：
+
+- 发 prompt 后能看到 mode、taskType、sections、tokens
+- Raw markdown 与实际注入一致
+- 不改变现有 prompt 注入结果
+
+### Phase B — Provider-local Model Capabilities
+
+目标：让模型选择器和 preflight 知道模型能不能处理附件。
+
+改动：
+
+- 扩展 model metadata 类型
+- Claude / Codex catalog 填 capabilities
+- OpenCode unknown provider 使用 conservative default
+- ModelSelector 展示能力 icon：image / pdf / context
+- Preflight 检查图片/PDF
+
+验收：
+
+- 带图片消息在不支持图片的模型下出现提示
+- 不跨 runtime 推荐
+- 所有旧模型列表仍能渲染
+
+### Phase C — Context Modes
+
+目标：按任务和模型预算生成不同 context package。
+
+改动：
+
+- `classifyTaskType()`
+- `selectContextMode()`
+- `resolveContextBudget(modelCapabilities, mode)`
+- formatter 支持 mode
+- UI 显示 mode
+
+验收：
+
+- debug 请求默认 standard
+- explain/summarize 默认 compact
+- review 默认 audit
+- budget 裁剪原因可见
+
+### Phase D — Field Event Expansion
+
+目标：补现场证据。
+
+改动：
+
+- `git.status_change`
+- `file.edit`
+- `session.approval`
+- `context.package_created`
+
+验收：
+
+- Context Inspector 能显示 git dirty/staged 信息来源
+- 审查/implement 场景能注入最近 diff 摘要或至少 dirty file 列表
+- approval trace 能用于 audit mode
+
+---
+
+## 8. 测试计划
+
+### Unit
+
+- `context-kernel/intent.test.ts`
+- `context-kernel/model-fit.test.ts`
+- `context-kernel/budget.test.ts`
+- `context-kernel/compiler.test.ts`
+- `field/context-formatter-modes.test.ts`
+
+### IPC
+
+- `field:getLastContextPackage`
+- backward compatibility with `field:getLastInjection`
+
+### UI
+
+- ContextIndicator tooltip shows package metadata
+- ModelSelector renders capabilities
+- Preflight blocks unsupported image/PDF
+
+### Regression
+
+- Slash commands still bypass Field Context prefix
+- Privacy off still suppresses event-derived context
+- Existing MemoryPanel behavior unchanged
+- Existing agent runtime selection unchanged
+
+---
+
+## 9. 风险
+
+| 风险 | 影响 | 对策 |
+|---|---|---|
+| capabilities 过时 | 错误提示或误拦 | 默认 warn，不默认 hard block；只对明确不支持的附件 block |
+| UI 信息过载 | 用户看不懂 | 默认只显示 pill，详情折叠到 Inspector |
+| trace DB 膨胀 | 本地库变大 | preview 限长；只保留最近 N 天或提供清理 |
+| 误分类 taskType | mode 不合适 | 用户可手动切 mode；规则保守 |
+| formatter 改动引入注入退化 | agent 表现变差 | Phase A 先 metadata-only，不改 markdown |
+
+---
+
+## 10. 成功标准
+
+这项特性成功，不是因为玄圃“自动选了更聪明模型”，而是因为用户能清楚看到：
+
+1. 这次 AI 到底看到了什么现场
+2. 为什么这些上下文被带入
+3. 哪些上下文因为预算/隐私/模式没带入
+4. 当前模型是否适合这条消息
+5. 玄圃没有越权替用户换 agent
+
+一句话目标：
+
+> 让玄圃从“会注入现场”升级为“会解释、预算和校验现场”。
+

--- a/docs/plans/2026-05-17-v1.4.9-stability-closure.md
+++ b/docs/plans/2026-05-17-v1.4.9-stability-closure.md
@@ -1,0 +1,254 @@
+# 1.4.9 Stability Closure
+
+> **Target**: v1.4.9  
+> **Scope**: 消息渲染稳定性 + 远程控制稳定性  
+> **Non-goals**: 模型路由、Context Kernel、跨 provider 自动切换
+
+## 背景
+
+当前仓库已经大到不能靠“整体感觉”推进。当前 tracked files 约 1322 个、总行数约 478k；`src/` 约 621 个文件，`test/` 约 427 个文件，`docs/` 约 139 个文件，`mobile/` 约 34 个文件。现在要收口的不是新能力，而是两条现有主链路：
+
+1. Claude Code / Codex 的消息渲染链路
+2. 玄圃 Hub 的远程控制链路
+
+1.4.9 的目标不是再叠一层功能，而是把这两条链路的稳定性合同写死。
+
+---
+
+## 1. 当前现状
+
+### 1.1 Canonical agent protocol 已经存在
+
+核心合同已经在共享层：
+
+- `src/shared/types/agent-protocol.ts`
+- `src/shared/lib/normalize-agent-event.ts`
+- `src/shared/lib/timeline-types.ts`
+
+目前已经有：
+
+- `eventId`
+- `sessionSequence`
+- `runEpoch`
+- `statusPayload` 兼容
+- tool / question / permission / plan / goal / context usage 等事件类型
+
+这说明协议不是空白，问题在于 **协议、渲染层、远程控制层之间还没收口成单一行为合同**。当前链路里最强的不是“协议缺失”，而是“实现和文档还没有完全对齐”。
+
+### 1.2 消息渲染链路是“两套 UI + 一套守卫”
+
+当前主渲染链路并不是一个单体：
+
+- `src/renderer/src/hooks/useAgentEventBridge.ts`
+- `src/renderer/src/stores/useSessionRuntimeStore.ts`
+- `src/renderer/src/components/session-hq/SessionShell.tsx`
+- `src/renderer/src/components/sessions/SessionView.tsx`
+
+现状是：
+
+- `useAgentEventBridge` 负责接收 `agent:stream`
+- `acceptSessionEvent()` 按 `sessionId + runEpoch + sessionSequence` 过滤过时事件
+- `writeEventToStreamingBuffer()` 维护 live overlay
+- `SessionShell` 默认走 `useTimeline()` + `useStreamingMirror()`
+- `SessionView` 仍保留兼容路径，自己做更多 transcript merge / finalize / fallback 逻辑
+- `sessionUiV2Enabled` 默认是 `true`，所以产品默认路径已经是 `SessionShell`
+
+结论：
+
+- `SessionShell` 更接近 TUI 的稳定形态
+- `SessionView` 仍然是大而杂的兼容层
+- 两者都还没有被一个明确的“单一真相源”彻底约束住
+- 默认产品路径已经偏向 `sessionUiV2Enabled = true`，但旧路径仍然存在，不能把“默认没走到”当成“行为已统一”。
+
+### 1.3 Claude Code / Codex 两条链路都已经标准化，但稳定性来源不同
+
+#### Claude Code
+
+主要路径：
+
+- `src/main/services/claude-code-implementer.ts`
+- `src/shared/lib/normalize-agent-event.ts`
+- `src/renderer/src/hooks/useAgentEventBridge.ts`
+- `src/renderer/src/components/sessions/SessionView.tsx` / `SessionShell.tsx`
+
+Claude Code 侧有：
+
+- SDK stream_event / assistant / result / status 事件
+- 文件 checkpoint / rewind / resume
+- `session.materialized` / `session.compaction_started` / `session.context_compacted`
+
+它的优势是 transport 本身更统一，缺点是渲染层仍有较多“历史兼容分支”。
+
+#### Codex
+
+主要路径：
+
+- `src/main/services/codex-implementer.ts`
+- `src/main/services/codex-event-mapper.ts`
+- `src/renderer/src/components/sessions/SessionView.tsx`
+- `src/renderer/src/components/session-hq/SessionShell.tsx`
+
+Codex 的稳定性更依赖 main-process 里的 canonical 化：
+
+- `thread/read`
+- `message.part.updated`
+- `message.updated`
+- `turn/completed`
+- `session.context_usage`
+- `session.status`
+
+它的优势是已经在 main 里做了较多归一化，缺点是 live draft / durable transcript / renderer fallback 三者还没有完全变成单一路径。
+
+### 1.4 Hub 远程控制链路已经有协议，但产品契约还不一致
+
+主要路径：
+
+- `src/main/services/hub/hub-protocol.ts`
+- `src/main/services/hub/hub-bridge.ts`
+- `src/main/services/hub/hub-registry.ts`
+- `src/main/services/hub/hub-server.ts`
+- `src/main/services/hub/hub-controller.ts`
+- `mobile/src/api/ws.ts`
+- `mobile/src/hooks/useSessionStream.ts`
+
+现状：
+
+- `seq` 单调递增
+- `resume{lastSeq}` 支持回放
+- `NEED_FULL_RELOAD` 支持兜底
+- `snapshot + live frame` 模式已经成型
+- `prompt / interrupt / permission / question / plan / command_approval` 都有 inbound/outbound 合同
+
+但有一个明显问题：
+
+- 当前代码已经是 prompt 直达 runtime；文档和 checklist 也已开始统一这个口径
+- 但 `require_desktop_confirm` 仍留在设置层，设置面板/注释里还有历史遗留说法
+- `NEED_FULL_RELOAD` 在 server / protocol 层已经存在，但 mobile hook 当前只是把它当普通 error 渲染，还没有自动 REST history reload
+- Hub live stream 不是完整 lossless：`message.part.updated`、status、permission/question/plan/command approval 等常见事件有专门翻译，部分未建模 live event 会被跳过；`UnknownPart` 主要还体现在协议能力和部分历史映射，不应当把它描述成所有 live event 的兜底
+- 这意味着远程控制的“运行时合同”已经统一，但“配置/UI 语义”还需要一次清理
+
+这不是“小差异”，这是远程控制的产品契约不一致。
+
+---
+
+## 2. 1.4.9 验收标准
+
+### 2.1 消息渲染稳定性
+
+1. Claude Code / Codex 的一个 turn，任何时候都只能表现为一条可解释的 assistant 结果，不允许 refresh / reconnect / finalize 后重复出卡。
+2. streaming text / tool / reasoning 的局部更新必须幂等，不能因为 `message.updated`、`message.part.updated`、idle、reload 的到达顺序不同而重复渲染。
+3. `runEpoch` 必须真正切分 turn 代际，旧 turn 的晚到事件不能污染新 turn。
+4. durable transcript 必须是主真相源；live overlay 只能是 transient，不允许反向污染 durable 结构。
+5. plan / question / permission / tool_result 这类交互卡必须在“流中显示”和“落盘后显示”之间保持单一表现，不允许双份。
+6. abort / retry / idle 的生命周期切换必须稳定，不出现 stop 按钮卡死、overlay 残留或重复 finalize。
+7. Claude Code 和 Codex 最终要收敛到同一套可解释 UI 行为，不是两个彼此独立的“各自能跑”的系统。
+
+### 2.2 远程控制稳定性
+
+1. Hub 登录、WS 连接、Origin 校验、鉴权模式必须一致，不允许文档和代码说法分裂。
+2. `resume{lastSeq}` 必须能准确回放缺失 frame，且不会重复 snapshot 已经包含的内容。
+3. 当 ring buffer 丢 gap 时，`NEED_FULL_RELOAD` 必须稳定触发，并且客户端有明确回填路径。
+4. prompt / interrupt / permission / question / plan / command approval 的 round trip 必须可预测，响应后状态能稳定清空。
+5. 断线重连不能把当前 session 变成“半在线半离线”的幽灵态。
+6. 远程控制的产品合同必须单口径：要么明确“prompt 直接进 runtime”，要么重新引入可测试的桌面 gate。不能继续文档、设置、代码三套说法。
+
+---
+
+## 3. 当前差距
+
+| Area | Current | Gap | Impact | Priority |
+|---|---|---|---|---|
+| Canonical transcript | main 里已经做了 event 标准化 | renderer 仍在做多源 merge 和 fallback | 重连、refresh、idle 后容易出现重复 bubble | P0 |
+| SessionShell vs SessionView | SessionShell 已经更接近稳定路径 | `SessionView` 仍是复杂兼容层 | 默认路径之外仍有不稳定面 | P0 |
+| Codex turn shape | main 里已经 canonical 化不少 | durable transcript / live draft / timeline backfill 还没彻底单源化 | tool / plan / assistant bubble 重复风险仍在 | P0 |
+| Run guard | `sessionSequence` + `runEpoch` 已存在 | 行为合同主要靠 store 守卫，缺少端到端验收 | 乱序 / 晚到事件可能只在边界条件暴露 | P1 |
+| Hub replay | `seq` / `resume` / ring buffer 已实现 | 只有 API / bridge 级测试，缺少完整 ws 恢复行为验证 | 断线恢复体验不稳 | P0 |
+| Hub full reload | server 能发 `NEED_FULL_RELOAD` | mobile 还不会自动 REST 拉 `/api/sessions/:id/history` | 长断线后用户只能看到错误 / 手动刷新 | P0 |
+| Hub live translation | 常见 live event 已翻译 | 未建模 live event 不是全量 `UnknownPart` 兜底 | 手机端可能丢状态或只看到不完整过程 | P1 |
+| Hub prompt policy | 代码直通 runtime | `require_desktop_confirm` 的历史设置/注释还没清完 | 配置语义和真实行为仍有残留不一致 | P1 |
+| Hub product copy | 文档已改成多 runtime | 部分 UI / checklist 仍有 Claude-only 或 M1.5 旧口径 | 用户会误判 Codex / OpenCode 能力边界 | P1 |
+| Source tests | 有一些 source-verification 测试 | 不是行为测试，只能证明“代码里写了什么” | 容易把字符串当验收 | P1 |
+
+---
+
+## 4. 1.4.9 必须落下来的 P0
+
+### 4.1 消息渲染 P0
+
+1. 默认产品路径固定到 `SessionShell`，v1 `SessionView` 不再作为稳定性主战场。
+2. 给 `useSessionRuntimeStore` / `useAgentEventBridge` 补行为测试：
+   - 同一 `runEpoch` 下重复 `message.part.updated` / `message.updated` 不重复渲染
+   - 新 `runEpoch` 清 live overlay，但保留 optimistic user message / compaction chip
+   - `session.status idle`、`session.idle`、refresh、remount 顺序互换后不出双 assistant bubble
+   - Claude Code / Codex 都走同一组用例
+3. 只允许 durable timeline 作为完成态真相源，live overlay 只负责 transient。
+4. 把 `SessionView` 的 duplicate/fallback 逻辑压到 legacy 兼容边界，不能继续复制到新链路。
+
+### 4.2 Hub 远程控制 P0
+
+1. mobile `NEED_FULL_RELOAD` 自动 REST 回填或至少有明确的“一键重新加载历史”路径。
+2. 增加 WebSocket 断线重连行为测试：连接、收 frame、断开、断线期间广播、重连 resume、只补缺失帧。
+3. prompt policy 单口径：1.4.9 如果继续采用直达 runtime，就清理所有二次确认 UI / 文档 / checklist 残留。
+4. mobile 状态清空行为测试：permission / question / plan / command approval response 后卡片必定清空，失败路径可见。
+
+---
+
+## 5. 结论
+
+1. **消息渲染** 的核心问题不是“有没有能渲染”，而是“有没有单一、幂等、可回放的 transcript contract”。
+2. **远程控制** 的核心问题不是“能不能连”，而是“断线、回放、确认、状态清空”是不是一个一致的产品合同。
+3. 1.4.9 最适合收口的不是 Context Kernel，而是：
+   - canonical transcript first
+   - live overlay 只做 transient
+   - Hub replay / resume / auth / prompt policy 统一口径
+
+---
+
+## 6. 建议的 1.4.9 收口顺序
+
+### 6.1 先收消息渲染
+
+优先把 Claude Code / Codex 的可见行为统一到一条主链上：
+
+- canonical durable transcript 优先
+- 直播层只负责临时态
+- refresh / reconnect / finalize 不重复出卡
+- 旧 UI 只保留兼容，不再扩散新逻辑
+
+### 6.2 再收远程控制
+
+把 Hub 的产品契约一次讲清：
+
+- prompt 是否需要桌面确认
+- replay / reload 的边界
+- 断线重连的 UX
+- 文档与代码统一
+
+当前代码是“prompt 直通 runtime”，所以如果 1.4.9 不准备恢复桌面 gate，就应该把所有文档、设置文案和 e2e checklist 一起改成这个口径。
+
+### 6.3 不在 1.4.9 做的事
+
+- 不做跨 provider 自动切换
+- 不做新的 Model Router
+- 不做 Context Kernel 重构
+- 不把 Hub 再拆成更多协议层
+
+---
+
+## 7. 相关文件
+
+- `src/shared/types/agent-protocol.ts`
+- `src/shared/lib/normalize-agent-event.ts`
+- `src/renderer/src/stores/useSessionRuntimeStore.ts`
+- `src/renderer/src/hooks/useAgentEventBridge.ts`
+- `src/renderer/src/components/session-hq/SessionShell.tsx`
+- `src/renderer/src/components/sessions/SessionView.tsx`
+- `src/main/services/claude-code-implementer.ts`
+- `src/main/services/codex-implementer.ts`
+- `src/main/services/codex-event-mapper.ts`
+- `src/main/services/hub/hub-protocol.ts`
+- `src/main/services/hub/hub-bridge.ts`
+- `src/main/services/hub/hub-server.ts`
+- `src/main/services/hub/hub-controller.ts`
+- `mobile/src/api/ws.ts`
+- `mobile/src/hooks/useSessionStream.ts`

--- a/docs/plans/2026-05-18-agent-runtime-stability-hardening.md
+++ b/docs/plans/2026-05-18-agent-runtime-stability-hardening.md
@@ -1,0 +1,439 @@
+# Agent Runtime Stability Hardening Plan
+
+目标：在继续做 durable queue 之前，先把 Claude Code / Codex 在玄圃里的 runtime 底座收稳。这里的重点不是 UI 视觉，而是 turn 生命周期、stream ingress、abort/steer 边界、durable transcript 和热路径是否能支撑 TUI/CLI 级别的高频交互。
+
+配套文档：
+
+- Queue / composer 语义：`docs/plans/2026-05-18-agent-runtime-tui-parity.md`
+- Session HQ 架构计划：`docs/plans/2026-04-11-session-ui-agent-hq-lite-replan.md`
+- Codex transcript 归一化：`docs/plans/2026-03-31-codex-transcript-normalization.md`
+- Claude Code SDK docs: https://docs.claude.com/en/docs/claude-code/sdk/sdk-typescript
+- Codex CLI features: https://developers.openai.com/codex/cli/features
+- Codex App Server docs: https://developers.openai.com/codex/app-server
+
+## Why This Comes Before More UX Work
+
+当前最危险的问题不是聊天页观感，而是 runtime 状态没有形成可靠的事务边界。
+
+如果 `CodexImplementer.prompt()`、`abort()`、`waitForTurnCompletion()`、`readThread()` 仍然只按 `threadId` 工作，那么任何更好的 queue UI、快捷键、steer 菜单都会建立在不稳定的底座上：
+
+- stop 后立刻 send，旧 turn 的 late `turn/completed` 可能让新 prompt 提前完成
+- 旧 turn 的 late `thread/read` snapshot 可能整体替换新 turn 的 `session.messages`
+- abort 清掉 live draft 后，用户刚看到的 partial output / running tool 可能从 durable timeline 消失
+- renderer runEpoch guard 可以挡住 stale stream event，但挡不住 main process 自己的 stale `readThread()` 写库
+
+因此本计划优先级高于 durable queue 的完整实现。queue PR 可以和本计划并行设计，但落地顺序应先修 Codex lifecycle。
+
+## Current Architecture Snapshot
+
+Main process:
+
+- `src/main/services/agent-runtime-types.ts` 定义 provider 抽象。
+- `src/main/services/agent-runtime-manager.ts` 管理 runtime implementer。
+- `src/main/services/claude-code-implementer.ts` 使用 Claude Code SDK `query()` async generator。
+- `src/main/services/codex-implementer.ts` 使用 `CodexAppServerManager`，接收 JSON-RPC event，转换为 canonical stream event，并在 turn 完成后 `thread/read`。
+- `src/main/services/codex-app-server-manager.ts` 负责 `codex app-server` child process、`turn/start`、`turn/steer`、`turn/interrupt`、`thread/read`。
+- `src/main/services/session-timeline-service.ts` 负责 main-side durable timeline 合成。
+
+Renderer:
+
+- `src/renderer/src/hooks/useAgentEventBridge.ts` 是目标上的唯一 raw stream ingress。
+- `src/renderer/src/stores/useSessionRuntimeStore.ts` 保存 lifecycle、streaming buffer、interrupt queue、pending messages。
+- `src/renderer/src/components/session-hq/SessionShell.tsx` 是默认 Session HQ UI。
+- `src/renderer/src/components/sessions/SessionView.tsx` 是旧 UI fallback，但仍维护独立 streaming 重建逻辑。
+- `src/renderer/src/hooks/usePRDetection.ts` 仍然直接订阅 `window.agentOps.onStream`，绕过 runtime guard。
+
+## Risk Register
+
+### P0: Codex Prompt/Abort Are Not Turn-Scoped
+
+Affected files:
+
+- `src/main/services/codex-implementer.ts`
+- `src/main/services/codex-app-server-manager.ts`
+- `src/main/ipc/agent-handlers.ts`
+
+Symptoms:
+
+- `prompt()` 内部 event listener 只按 `threadId` 过滤。
+- `waitForTurnCompletion()` 看到同 thread 的任意 `turn/completed` 就 resolve。
+- `abort()` 只调用 `turn/interrupt`，然后清 `liveAssistantDraft` 并 emit idle。
+- `readThread()` 后直接 `session.messages = parsed`，然后 destructive `replaceSessionMessages()`。
+- `stop_and_send` 在 renderer 侧固定 sleep 100ms，不能保证旧 prompt 已 finalized。
+
+Target behavior:
+
+- 每次 `prompt()` 都有本地 `runId`，并绑定 expected `turnId`。
+- 旧 run 的 event 不能更新当前 run 的 live draft / status / messages。
+- 旧 run 的 `thread/read` 结果不能覆盖新 run 的 synthetic user message 或 canonical transcript。
+- abort 是一个 terminal transition：必须先 materialize live draft，再清理 current run。
+- interrupted turn 必须显式 settle，不能等 300 秒 timeout。
+
+Implementation sketch:
+
+```ts
+interface CodexActiveRun {
+  runId: string
+  expectedTurnId: string | null
+  state: 'starting' | 'running' | 'aborting' | 'finalizing' | 'settled'
+  startedAt: number
+  abortController: AbortController
+}
+```
+
+Changes:
+
+- Add `activeRun: CodexActiveRun | null` and `settledRunIds: Set<string>` to `CodexSessionState`.
+- In `prompt()`, generate `runId` before `beginSessionRun(session.hiveSessionId)`.
+- Bind the `turnId` returned by `manager.sendTurn()` to the active run.
+- Event handler accepts lifecycle/content events only when:
+  - `event.threadId === session.threadId`
+  - active run still has the same `runId`
+  - if the event has `turnId`, it matches `expectedTurnId`
+- `waitForTurnCompletion()` takes `runId`, `expectedTurnId`, and `AbortSignal`.
+- `turn/interrupted` for the expected turn settles as aborted.
+- On abort:
+  - mark active run as aborting
+  - call `manager.interruptTurn(session.threadId, expectedTurnId)`
+  - materialize `liveAssistantDraft` into an assistant message with `aborted: true`
+  - convert running tools to terminal `cancelled` or `error` state with end time
+  - persist canonical messages
+  - emit terminal tool update events and idle
+  - clear active run only if it is still the same run
+- On `thread/read` completion:
+  - only replace `session.messages` if the run is still current and the snapshot contains the expected turn/user message
+  - otherwise log stale snapshot and skip replacement
+
+Tests:
+
+- `test/phase-22/session-5/codex-prompt-streaming.test.ts`
+  - prompt A starts, abort A, prompt B starts, A late `turn/completed` does not complete B
+  - wrong turn completion does not resolve current prompt
+  - `turn/interrupted` settles the interrupted run
+- `test/phase-22/session-6/codex-abort-getmessages.test.ts`
+  - abort preserves live text/tool draft in `getMessages()`
+  - running tool becomes terminal aborted/cancelled
+  - stale A `thread/read` cannot overwrite B synthetic user message
+- `test/phase-22/session-4/codex-lifecycle.test.ts`
+  - reconnect after interrupted/finalizing run reports idle only after finalization state is coherent
+
+Acceptance criteria:
+
+- No overlapping prompt loop can write stale messages into the current session.
+- `abort()` is idempotent and safe if called multiple times.
+- Stop + immediate send is safe without renderer sleep.
+- Partial output after abort remains visible in durable timeline.
+
+### P1: Renderer Has More Than One Raw Stream Ingress
+
+Affected files:
+
+- `src/renderer/src/hooks/useAgentEventBridge.ts`
+- `src/renderer/src/hooks/usePRDetection.ts`
+- `src/renderer/src/stores/useSessionRuntimeStore.ts`
+
+Symptoms:
+
+- `useAgentEventBridge` claims to be the sole `window.agentOps.onStream` subscriber.
+- `usePRDetection` also subscribes directly and bypasses `acceptSessionEvent()`.
+- PR detection can observe stale duplicate events that runtime mirror already rejected.
+
+Target behavior:
+
+- Only `useAgentEventBridge` subscribes to `window.agentOps.onStream`.
+- PR detection receives guarded per-session events from `useSessionRuntimeStore.subscribeToSessionEvents(...)`.
+- Backstop transcript polling may remain, but stream path must be guarded.
+
+Implementation sketch:
+
+- Move stream scanning logic in `usePRDetection` behind runtime store callbacks:
+  - subscribe only when `prCreation.creating` and `prCreation.sessionId` exist
+  - use the same event payload scanner for `message.part.updated` and `message.updated`
+  - unsubscribe when PR creation ends
+- Add a test or source assertion that `rg "agentOps.onStream" src/renderer/src` only finds `useAgentEventBridge.ts`.
+- Keep polling fallback scoped to active PR creation, but avoid JSON-stringifying huge transcripts on every tick if the event path already found a URL.
+
+Tests:
+
+- `test/phase-23/pr-detection-stream-ingress.test.tsx`
+  - stale run event rejected by bridge does not attach PR
+  - accepted event attaches PR
+  - polling fallback still attaches PR when stream shape misses URL
+- `test/phase-23/agent-event-bridge-run-epoch.test.ts`
+  - extend to cover side-effect subscriber ordering if needed
+
+Acceptance criteria:
+
+- `window.agentOps.onStream` has one renderer subscriber.
+- All stream-driven side effects see only accepted runEpoch/sessionSequence events.
+
+### P1: SessionShell And SessionView Still Reconstruct Streams Differently
+
+Affected files:
+
+- `src/renderer/src/components/session-hq/SessionShell.tsx`
+- `src/renderer/src/components/sessions/SessionView.tsx`
+- `src/renderer/src/stores/useSessionRuntimeStore.ts`
+- `src/shared/lib/timeline-mappers.ts`
+- `src/renderer/src/lib/codex-timeline.ts`
+
+Symptoms:
+
+- `SessionShell` renders `durable timeline + runtime mirror`.
+- `SessionView` still maintains local `streamingPartsRef`, `streamingContentRef`, own finalization and provider-specific event parsing.
+- This creates drift: bug fixes in one path do not necessarily affect the other.
+
+Target behavior:
+
+- `SessionShell + useSessionRuntimeStore` is the active, authoritative path.
+- `SessionView` remains a fallback only and stops receiving new provider-specific logic.
+- Shared parsing/classification stays in `src/shared/lib/*` and main-side timeline services.
+
+Implementation stages:
+
+1. Add comments and tests that freeze `SessionView` as fallback.
+2. Move remaining reusable mapping helpers out of `SessionView` into shared utilities if still needed by `SessionShell`.
+3. Avoid changing `SessionView` for new Codex/Claude behavior unless it is a compatibility patch.
+4. Eventually remove the `sessionUiV2Enabled` fallback after a separate release gate.
+
+Tests:
+
+- `test/phase-23/session-shell-runtime-mirror.test.tsx`
+  - stale run does not reappear after remount
+  - new run clears old overlay while preserving durable messages
+  - compaction/status rows do not duplicate
+- `test/phase-23/session-timeline-service.test.ts`
+  - durable timeline remains provider-independent
+- Existing `test/session-8/session-view.test.tsx`
+  - keep as fallback regression only
+
+Acceptance criteria:
+
+- New Codex/Claude runtime features are tested against `SessionShell`.
+- Old `SessionView` does not become a second active runtime implementation.
+
+### P1: Stop And Steer Need Event-Driven Boundaries
+
+Affected files:
+
+- `src/renderer/src/lib/session-send-actions.ts`
+- `src/renderer/src/components/session-hq/SessionShell.tsx`
+- `src/main/services/codex-implementer.ts`
+- `src/main/services/claude-code-implementer.ts`
+
+Symptoms:
+
+- `stop_and_send` does `abort()` then sleeps 100ms before `prompt()`.
+- `SessionShell` calls `resetLiveOverlay(true)` for `send`, `stop_and_send`, and `steer`.
+- For Codex, `steer` semantically injects into the active turn; clearing overlay makes active output disappear.
+
+Target behavior:
+
+- Stop without content interrupts and finalizes the active run.
+- Stop with content waits for an explicit abort boundary, then starts a new turn.
+- Steer never clears current assistant overlay; it may render a small user intervention marker, but the output continues.
+
+Implementation sketch:
+
+- Extend `SendContext` with optional boundary waiters:
+
+```ts
+type SendContext = {
+  waitForAbortBoundary?: (sessionId: string, previousRunEpoch: number) => Promise<void>
+  waitForRunAdvance?: (sessionId: string, previousRunEpoch: number) => Promise<void>
+}
+```
+
+- Replace fixed sleep with:
+  - call abort
+  - wait for main process abort finalization event or runtime store idle with advanced/settled run boundary
+  - then prompt
+- In `SessionShell`, only call `resetLiveOverlay(true)` for new-turn actions, not `steer`.
+- Add optimistic steer marker separately from queued/sent user message.
+
+Tests:
+
+- `test/phase-23/session-send-actions.test.ts`
+  - `stop_and_send` calls wait boundary instead of sleeping
+  - boundary failure restores composer content
+- `test/phase-23/session-shell-composer-actions.test.tsx`
+  - steer does not clear overlay
+  - pure stop flips lifecycle idle only after abort success/finalization
+  - stop-and-send waits before prompt
+- `test/phase-22/session-6/codex-abort-getmessages.test.ts`
+  - abort emits enough state for renderer boundary wait
+
+Acceptance criteria:
+
+- No fixed timer is needed to sequence abort -> next prompt.
+- Steer feels like a continuous TUI interaction, not a reset.
+
+### P2: Hot Path Needs Throttling And Log Hygiene
+
+Affected files:
+
+- `src/renderer/src/hooks/useAgentEventBridge.ts`
+- `src/renderer/src/stores/useSessionRuntimeStore.ts`
+- `src/renderer/src/components/session-hq/SessionShell.tsx`
+- `src/renderer/src/components/sessions/SessionView.tsx`
+- `src/main/services/codex-app-server-manager.ts`
+- `src/main/services/codex-implementer.ts`
+
+Symptoms:
+
+- Every accepted event writes streaming buffer, dispatches callbacks, and touches activity.
+- `touchActivity()` clones the sessions map per event.
+- Session callbacks can run heavier side effects synchronously.
+- Runtime buffer stores both structured `parts` and continuously concatenated `streamingContent`.
+- Codex manager still has debug-style notification logging in the hot path.
+- `SessionShell` event subscription depends on many changing values, creating resubscribe windows.
+
+Target behavior:
+
+- Token/tool delta path does minimal work.
+- Heavy work only runs on lifecycle transitions, idle, or debounced frames.
+- Logging is either debug-gated or sampled.
+
+Implementation plan:
+
+- Throttle `touchActivity()` per session, e.g. once per animation frame or every 250ms.
+- Keep `writeEventToStreamingBuffer()` as the only hot-path mutation.
+- Move usage refresh, timeline refresh, mission extraction, queue drain and notification side effects to idle/transition microtasks.
+- Convert `SessionShell` event effect dependencies to stable refs where safe, so stream callbacks do not unsubscribe when composer options change.
+- Remove or downgrade `DEBUG handleServerNotification` and provider title debug logs.
+- Gradually stop appending full `streamingContent` on every delta; prefer structured `parts` and derive text where needed.
+
+Tests:
+
+- `test/phase-23/use-session-runtime-store.test.ts`
+  - many delta events coalesce into bounded notifications
+  - `touchActivity` throttle preserves latest timestamp
+- `test/phase-23/session-shell-runtime-mirror.test.tsx`
+  - changing goal/composer options does not drop idle/drain event
+- logger smoke tests only if existing pattern supports it
+
+Acceptance criteria:
+
+- High-frequency token/tool output does not trigger synchronous heavy side effects per delta.
+- Codex app-server logs do not spam notification payload snapshots in normal runs.
+
+## PR Split
+
+### PR A: Codex Lifecycle Correctness
+
+Must land first.
+
+Files:
+
+- `src/main/services/codex-implementer.ts`
+- `src/main/services/codex-app-server-manager.ts`
+- `test/phase-22/session-5/codex-prompt-streaming.test.ts`
+- `test/phase-22/session-6/codex-abort-getmessages.test.ts`
+
+Exit criteria:
+
+- stop -> immediate send is safe
+- stale completion/readThread cannot overwrite new run
+- abort preserves partial assistant output
+
+### PR B: Stop/Steer Event Boundary
+
+Files:
+
+- `src/renderer/src/lib/session-send-actions.ts`
+- `src/renderer/src/components/session-hq/SessionShell.tsx`
+- main runtime event support if PR A does not already expose enough state
+- `test/phase-23/session-send-actions.test.ts`
+- `test/phase-23/session-shell-composer-actions.test.tsx`
+
+Exit criteria:
+
+- no fixed `setTimeout(100)` sequencing
+- steer keeps live overlay
+- pure stop / stop-and-send behavior is test-covered in mounted SessionShell
+
+### PR C: Single Stream Ingress
+
+Files:
+
+- `src/renderer/src/hooks/usePRDetection.ts`
+- `src/renderer/src/hooks/useAgentEventBridge.ts`
+- `src/renderer/src/stores/useSessionRuntimeStore.ts`
+- `test/phase-23/pr-detection-stream-ingress.test.tsx`
+- `test/phase-23/agent-event-bridge-run-epoch.test.ts`
+
+Exit criteria:
+
+- only one raw `window.agentOps.onStream` subscriber in renderer
+- PR detection observes only guarded events
+
+### PR D: SessionShell Runtime Mirror Tests
+
+Files:
+
+- `test/phase-23/session-shell-runtime-mirror.test.tsx`
+- targeted fixes in `SessionShell` / runtime store as needed
+
+Exit criteria:
+
+- mounted SessionShell validates runEpoch isolation
+- remount does not resurrect stale overlay
+- source-code smoke tests are no longer the only guard
+
+### PR E: Hot Path Cleanup
+
+Files:
+
+- `src/renderer/src/hooks/useAgentEventBridge.ts`
+- `src/renderer/src/stores/useSessionRuntimeStore.ts`
+- `src/renderer/src/components/session-hq/SessionShell.tsx`
+- `src/main/services/codex-app-server-manager.ts`
+- `src/main/services/codex-implementer.ts`
+
+Exit criteria:
+
+- activity touches and heavy side effects are throttled/deferred
+- debug logs are gated
+- no behavior regressions in runtime mirror tests
+
+## Test Gate Before Merging Each PR
+
+Minimum targeted tests:
+
+```bash
+pnpm vitest run test/phase-22/session-5/codex-prompt-streaming.test.ts
+pnpm vitest run test/phase-22/session-6/codex-abort-getmessages.test.ts
+pnpm vitest run test/phase-23/agent-event-bridge-run-epoch.test.ts
+pnpm vitest run test/phase-23/session-send-actions.test.ts
+```
+
+When touching SessionShell behavior:
+
+```bash
+pnpm vitest run test/phase-23/session-shell-composer-actions.test.tsx
+pnpm vitest run test/phase-23/session-shell-runtime-mirror.test.tsx
+```
+
+When touching stream ingress:
+
+```bash
+pnpm vitest run test/phase-23/pr-detection-stream-ingress.test.tsx
+```
+
+Before shipping a stacked batch:
+
+```bash
+pnpm lint
+pnpm test
+```
+
+## Done Criteria
+
+- Codex runtime has run/turn-scoped state transitions.
+- Abort finalizes partial output instead of deleting it.
+- Stop-and-send has no fixed sleep.
+- Steer is continuous and does not clear active output.
+- Renderer has one raw stream ingress.
+- SessionShell behavior is covered by mounted tests.
+- Old SessionView is treated as fallback, not an active expansion surface.
+- Hot-path logs and updates are bounded enough for high-frequency Codex/Claude output.

--- a/docs/plans/2026-05-18-agent-runtime-tui-parity.md
+++ b/docs/plans/2026-05-18-agent-runtime-tui-parity.md
@@ -1,0 +1,323 @@
+# Agent Runtime TUI Parity Plan
+
+目标：让玄圃内置 Claude Code / Codex 的会话体验接近各自 TUI/CLI 的稳定性和流畅度，尤其是 busy 状态下的输入、排队、steer、stop、恢复、可见反馈和测试覆盖。
+
+## Source Documents
+
+本计划以当前仓库实现和官方文档共同作为约束。
+
+- Claude Code SDK TypeScript reference: https://docs.claude.com/en/docs/claude-code/sdk/sdk-typescript
+- Codex CLI features: https://developers.openai.com/codex/cli/features
+- Codex App Server: https://developers.openai.com/codex/app-server
+- Existing Xuanpu Session HQ plan: `docs/plans/2026-04-11-session-ui-agent-hq-lite-replan.md`
+- Existing Codex transcript plan: `docs/plans/2026-03-31-codex-transcript-normalization.md`
+- Runtime stability hardening plan: `docs/plans/2026-05-18-agent-runtime-stability-hardening.md`
+- Legacy queued-message PRDs: `docs/prd/phase-06.md`, `docs/prd/phase-12.md`
+
+## What The Official Docs Change
+
+### Claude Code
+
+Claude Code SDK `query()` accepts either a plain prompt string or an `AsyncIterable<SDKUserMessage>`. It returns a `Query` async generator. The `Query` object exposes `streamInput(...)`, `interrupt()`, `setModel(...)`, and related controls, but the docs mark several of those controls as only available in streaming input mode.
+
+Current Xuanpu behavior is not a long-lived streaming-input session for normal prompts. `ClaudeCodeImplementer.prompt()` usually calls `sdk.query({ prompt: string, options })`. It only uses an async iterable as a single structured user message when file attachments are present. That means a true Claude TUI-like busy input channel is not currently modeled as "append input into the same open input stream"; Xuanpu mostly starts separate prompt calls and depends on renderer-side queueing.
+
+Implication: for Claude Code, the safe first implementation is a local, durable next-turn queue plus robust interrupt/finalization. A future streaming-input upgrade can add true mid-turn input, but it must be explicit and tested separately.
+
+### Codex
+
+Codex CLI documents a distinct busy-state UX:
+
+- `Enter` while Codex is running injects new instructions into the current turn.
+- `Tab` while Codex is running queues follow-up input for the next turn.
+- Queued input can be a normal prompt, a slash command, or a `!` shell command.
+
+Codex App Server exposes the same split at protocol level:
+
+- `turn/start` starts a new turn.
+- `turn/steer` appends user input to the active in-flight turn without creating a new turn, and requires the expected active turn id.
+- `turn/interrupt` requests cancellation; a successful interruption ends the turn with `status: "interrupted"`.
+- `thread/read` reads stored thread history without resuming or subscribing to it.
+
+Implication: Xuanpu should not treat "busy + text" as queue-first for Codex. TUI parity means "steer current turn" and "queue next turn" are separate first-class actions with separate shortcuts and state transitions.
+
+## Current Gaps
+
+### 1. Queue Semantics Are Provider-Agnostic In The Wrong Way
+
+`session-send-actions.ts` currently models busy draft content as:
+
+- primary: `queue`
+- alternatives: `steer`, `stop_and_send`
+
+That contradicts Codex CLI behavior, where the running-turn default is steer/inject and queue is an explicit next-turn action. It is also not fully correct for Claude Code because the current Claude implementation does not maintain a persistent streaming input channel for normal text prompts.
+
+### 2. Queue Storage Is Too Weak
+
+`useSessionRuntimeStore.pendingMessages` is an in-memory renderer `Map`. It is useful for immediate UI, but it is not a source of truth.
+
+Problems:
+
+- queued text can be lost on renderer reload, crash, or some remount paths
+- queued attachments are not durable
+- queue state only syncs a boolean to the main-process notification service
+- `requeueMessageFront()` does not sync queued state back to true after a failed drain
+- no explicit `pending -> sending -> sent/failed/cancelled` state
+
+### 3. Queue Drain Is Not Transactional
+
+`SessionShell` drains queued messages on idle:
+
+1. refresh timeline
+2. dequeue from runtime store
+3. call `window.agentOps.prompt(...)`
+4. requeue on failure
+
+This has race and UX gaps:
+
+- the queued bubble can disappear before the new prompt is accepted
+- auto-drain can overlap timeline refresh from the previous turn
+- failed send can briefly clear the native queued state
+- no per-session drain lock prevents multiple idle events from racing
+- the drained prompt is not represented as a "sending queued item" with stable UI identity
+
+### 4. Codex Lifecycle Races Make Queue Unsafe
+
+Before queue can be trusted, Codex `prompt()` / `abort()` / `readThread()` must become turn-scoped.
+
+Current risks:
+
+- prompt event listeners filter by `threadId`, not by local run id or expected `turnId`
+- `waitForTurnCompletion()` accepts any `turn/completed` for the thread
+- `abort()` clears live draft instead of materializing partial output
+- `readThread()` can replace all `session.messages` with a stale non-empty snapshot
+- `stop_and_send` waits a fixed 100ms before starting a new prompt
+
+If those remain, auto-drained queued messages can be overwritten by late completions from older turns.
+
+### 5. Renderer Event Ingress Is Still Not Single-Path
+
+`useAgentEventBridge` is intended to be the only raw `window.agentOps.onStream` subscriber, but `usePRDetection` still subscribes directly. That bypasses the runEpoch/sessionSequence guard.
+
+This matters for queue UX because PR detection, completion notification suppression, pending-message drain, and timeline refresh all depend on consistent event ordering.
+
+## Target Composer Semantics
+
+### Idle / Error
+
+- `Enter`: start a new turn with `turn/start` or Claude `query()`
+- primary button: `Send`
+- pending queued items are visible and can be reordered/cancelled before drain
+
+### Busy With Empty Composer
+
+- primary button: `Stop`
+- `Esc` or stop button: interrupt current turn
+- no hidden "stop and send" because there is no content to send
+
+### Busy With Draft Content
+
+Provider-specific defaults:
+
+- Codex: `Enter` = steer current turn via `turn/steer`
+- Codex: `Tab` or explicit menu action = queue for next turn
+- Codex: explicit destructive action = stop current turn, then send
+- Claude Code MVP: `Enter` = queue for next turn, unless/until Claude runtime is upgraded to a real streaming-input channel
+- Claude Code MVP: explicit stop action uses `query.interrupt()` plus draft flush, then optional send
+- OpenCode: keep existing support, but route through the same durable queue state
+
+The button label should describe the action that pressing Enter will take. Alternatives should remain visible in the dropdown, with shortcut hints.
+
+## Durable Queue Model
+
+Introduce a main-process-backed queue table instead of treating renderer memory as truth.
+
+Suggested table:
+
+```sql
+CREATE TABLE session_pending_messages (
+  id TEXT PRIMARY KEY,
+  session_id TEXT NOT NULL,
+  agent_session_id TEXT,
+  runtime_id TEXT NOT NULL,
+  status TEXT NOT NULL CHECK (status IN ('pending', 'sending', 'sent', 'failed', 'cancelled')),
+  content TEXT NOT NULL,
+  attachments_json TEXT,
+  prompt_options_json TEXT,
+  model_json TEXT,
+  enqueued_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  sending_run_epoch INTEGER,
+  sending_turn_id TEXT,
+  error TEXT
+);
+```
+
+Rules:
+
+- enqueue writes to DB first, then mirrors into `useSessionRuntimeStore`
+- dequeue does not remove the row; it transitions `pending -> sending`
+- only after prompt acceptance and durable user message commit does it become `sent`
+- failures transition to `failed` or back to `pending` depending on retry policy
+- cancel transitions to `cancelled`
+- renderer reload hydrates pending/sending/failed rows from DB
+- notification suppression reads durable queued state, not a renderer boolean
+
+## Drain State Machine
+
+Per session, keep one drain lock:
+
+```text
+idle event for run N
+  -> verify active session is not in interrupt/approval/plan-blocked state
+  -> wait for durable timeline refresh for run N
+  -> acquire drain lock
+  -> load first pending item from DB
+  -> mark sending
+  -> render queued bubble as "sending"
+  -> call provider send path
+  -> on prompt accepted:
+       keep item as sending until first user message / session.busy / runEpoch advanced
+  -> on durable commit:
+       mark sent
+       release lock
+  -> on failure:
+       mark failed or pending
+       release lock
+```
+
+Do not drain while:
+
+- a question / permission / command approval / plan approval is pending
+- the provider lifecycle is still materializing
+- a previous queued item is `sending`
+- Codex has an unresolved old prompt finalization
+
+## Provider Runtime Contract
+
+Add runtime capabilities that describe input behavior, not just availability.
+
+```ts
+type RuntimeInputSemantics = {
+  canStartTurn: boolean
+  canSteerActiveTurn: boolean
+  canQueueNextTurn: boolean
+  canInterruptTurn: boolean
+  supportsExpectedTurnId: boolean
+  supportsStreamingInput: boolean
+}
+```
+
+Initial mapping:
+
+- Codex: `canSteerActiveTurn=true`, `supportsExpectedTurnId=true`, `canQueueNextTurn=true`
+- Claude Code current implementation: `canSteerActiveTurn=false`, `supportsStreamingInput=false`, `canQueueNextTurn=true`, `canInterruptTurn=true`
+- Claude Code future implementation: enable `supportsStreamingInput=true` only after normal text prompts run through a persistent input iterable
+- OpenCode: map existing behavior after a separate check
+
+## Implementation Plan
+
+### PR 1: Codex Turn Lifecycle Correctness
+
+Scope:
+
+- add local run/turn token to `CodexSessionState`
+- bind prompt event handling to expected run and turn
+- make `waitForTurnCompletion()` accept only the matching turn completion
+- treat `turn/interrupted` as an explicit terminal state for the interrupted turn
+- make `abort()` materialize live draft before clearing it
+- prevent stale `thread/read` snapshots from replacing newer messages
+- pass `expectedTurnId` when calling `turn/steer`
+
+Tests:
+
+- stop A -> start B -> A late completion does not complete B
+- stale A `thread/read` does not overwrite B user message
+- abort preserves partial assistant text/tool as aborted/cancelled
+- wrong turn completion does not resolve current prompt
+- `turn/interrupted` settles the interrupted run
+
+### PR 2: Durable Pending Message Queue
+
+Scope:
+
+- add DB migration and IPC for pending messages
+- hydrate pending queue on session mount
+- render queued/sending/failed bubbles with stable ids
+- replace renderer-only `pendingMessages` truth with durable queue mirror
+- sync notification suppression from durable pending count
+
+Tests:
+
+- enqueue persists and survives store reset
+- failed drain does not lose content or attachments
+- cancel marks row cancelled and removes visible bubble
+- notification suppression follows durable pending state
+
+### PR 3: Composer Semantics Aligned With Runtime Docs
+
+Scope:
+
+- update `determineComposerActions()` to use runtime input semantics
+- Codex busy `Enter` steers; `Tab` queues next turn
+- Claude Code busy `Enter` queues until streaming input is implemented
+- stop-with-content becomes explicit destructive menu action, not hidden default
+- steer no longer clears live overlay
+- stop-and-send no longer sleeps 100ms; it waits on an explicit lifecycle boundary
+
+Tests:
+
+- Codex busy + draft -> primary steer
+- Codex busy + Tab -> queue
+- Claude busy + draft -> queue
+- steer keeps live overlay
+- stop-and-send waits for abort boundary instead of fixed timer
+
+### PR 4: Single Renderer Event Ingress
+
+Scope:
+
+- move PR URL detection behind `useAgentEventBridge` / session event callbacks
+- ensure `rg "agentOps.onStream" src/renderer/src` only finds `useAgentEventBridge`
+- throttle hot-path activity touches
+- keep `SessionShell + runtime mirror` as the active path
+- stop expanding old `SessionView` provider-specific logic
+
+Tests:
+
+- stale run events are invisible to PR detection
+- duplicate stream events are dropped before side effects
+- tab switch/remount does not resurrect stale live overlay
+
+### PR 5: Claude Code Streaming Input Spike
+
+Scope:
+
+- prototype a real persistent `AsyncIterable<SDKUserMessage>` channel for normal Claude prompts
+- verify `streamInput()` behavior with the current SDK version
+- only if stable: add Claude steer-like mid-turn input capability
+- otherwise keep Claude on durable next-turn queue and document the limitation
+
+Exit criteria:
+
+- no overlapping Claude `query()` loops per session
+- interrupt still flushes in-flight draft
+- queued messages preserve order and do not duplicate SDK user echoes
+
+## Acceptance Criteria
+
+- Busy-state behavior matches each provider's documented semantics.
+- Queued messages are visible, cancellable, durable, and not lost on reload.
+- A queued item is not removed until the provider accepts it.
+- Auto-drain never starts a new turn until the previous turn is durably committed or safely finalized.
+- Codex late events and stale snapshots cannot overwrite newer turns.
+- Renderer has one raw stream ingress path.
+- Tests cover service-level races and mounted `SessionShell` behavior, not only source-code smoke checks.
+
+## Work Not To Do Yet
+
+- Do not remove `SessionView` in the same PR as queue/lifecycle fixes.
+- Do not implement Claude mid-turn steering until the SDK streaming-input path is proven with tests.
+- Do not rely on fixed sleep intervals for stop/abort/send sequencing.
+- Do not make queued messages renderer-only again.
+- Do not conflate "queue next turn" and "steer current turn" in the UI copy.

--- a/src/main/services/codex-app-server-manager.ts
+++ b/src/main/services/codex-app-server-manager.ts
@@ -810,7 +810,9 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
       activeTurnId: null
     })
 
-    this.emitLifecycleEvent(context, 'turn/interrupted', 'Turn interrupted')
+    this.emitLifecycleEvent(context, 'turn/interrupted', 'Turn interrupted', {
+      turnId: targetTurnId ?? undefined
+    })
   }
 
   async readThread(threadId: string): Promise<unknown> {
@@ -1152,7 +1154,12 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
 
   // ── Event emission helpers ────────────────────────────────────
 
-  private emitLifecycleEvent(context: CodexSessionContext, method: string, message: string): void {
+  private emitLifecycleEvent(
+    context: CodexSessionContext,
+    method: string,
+    message: string,
+    extra?: { turnId?: string }
+  ): void {
     this.emitEvent({
       id: randomUUID(),
       kind: 'session',
@@ -1160,7 +1167,8 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
       threadId: context.session.threadId ?? '',
       createdAt: new Date().toISOString(),
       method,
-      message
+      message,
+      ...(extra?.turnId ? { turnId: extra.turnId } : {})
     })
   }
 

--- a/src/main/services/codex-implementer.ts
+++ b/src/main/services/codex-implementer.ts
@@ -1,6 +1,11 @@
 import type { BrowserWindow } from 'electron'
+import { randomUUID } from 'node:crypto'
 
-import type { AgentSdkCapabilities, AgentSdkImplementer, PromptOptions } from './agent-runtime-types'
+import type {
+  AgentSdkCapabilities,
+  AgentSdkImplementer,
+  PromptOptions
+} from './agent-runtime-types'
 import type { AgentRuntimeAdapter } from './agent-runtime-types'
 import { CODEX_CAPABILITIES } from './agent-runtime-types'
 import {
@@ -37,6 +42,8 @@ export interface CodexSessionState {
   status: 'connecting' | 'ready' | 'running' | 'error' | 'closed'
   messages: unknown[]
   liveAssistantDraft?: CodexLiveAssistantDraft | null
+  activeRun?: CodexActiveRun | null
+  settledRunIds?: Set<string>
   revertMessageID: string | null
   revertDiff: string | null
   titleGenerated: boolean
@@ -60,15 +67,25 @@ export interface CodexSessionState {
   itemTimestampsByTurn: Map<string, string[]>
 }
 
+interface CodexActiveRun {
+  runId: string
+  expectedTurnId: string | null
+  state: 'starting' | 'running' | 'aborting' | 'finalizing' | 'settled'
+  startedAt: number
+  abortController: AbortController
+}
+
 interface CodexLiveToolPart {
   type: 'tool'
   callID: string
   tool: string
   state: {
-    status: 'running' | 'completed' | 'error'
+    status: 'running' | 'completed' | 'error' | 'cancelled'
     input?: unknown
     output?: unknown
     error?: unknown
+    metadata?: Record<string, unknown>
+    time?: { start?: number; end?: number }
   }
 }
 
@@ -286,8 +303,7 @@ export class CodexImplementer implements AgentSdkImplementer, AgentRuntimeAdapte
         event.kind === 'notification' &&
         (event.method === 'item/started' || event.method === 'item.started')
       ) {
-        const turnId =
-          event.turnId ?? asString(asObject(event.payload)?.turnId) ?? null
+        const turnId = event.turnId ?? asString(asObject(event.payload)?.turnId) ?? null
         if (turnId) {
           const list =
             targetSession.itemTimestampsByTurn.get(turnId) ??
@@ -396,9 +412,7 @@ export class CodexImplementer implements AgentSdkImplementer, AgentRuntimeAdapte
         hiveSessionId: targetSession.hiveSessionId,
         worktreePath: targetSession.worktreePath,
         turnId:
-          event.turnId ??
-          this.manager.getSession(targetSession.threadId)?.activeTurnId ??
-          undefined
+          event.turnId ?? this.manager.getSession(targetSession.threadId)?.activeTurnId ?? undefined
       })
 
       const payload = asObject(event.payload)
@@ -427,9 +441,7 @@ export class CodexImplementer implements AgentSdkImplementer, AgentRuntimeAdapte
         // Same fallback as the durable activity below — codex's
         // requestUserInput JSON-RPC params don't always carry turn.id.
         turnId:
-          event.turnId ??
-          this.manager.getSession(targetSession.threadId)?.activeTurnId ??
-          undefined
+          event.turnId ?? this.manager.getSession(targetSession.threadId)?.activeTurnId ?? undefined
       })
 
       const payload = asObject(event.payload)
@@ -453,7 +465,10 @@ export class CodexImplementer implements AgentSdkImplementer, AgentRuntimeAdapte
           ? optionsRaw.map((opt) =>
               typeof opt === 'string'
                 ? { label: opt, description: '' }
-                : ((opt as { label?: string; description?: string }) ?? { label: '', description: '' })
+                : ((opt as { label?: string; description?: string }) ?? {
+                    label: '',
+                    description: ''
+                  })
             )
           : []
         questions = [
@@ -525,9 +540,7 @@ export class CodexImplementer implements AgentSdkImplementer, AgentRuntimeAdapte
             // the timeline (rendered after all post-question text). The
             // manager already tracks activeTurnId from turn/started events.
             turn_id:
-              event.turnId ??
-              this.manager.getSession(targetSession.threadId)?.activeTurnId ??
-              null,
+              event.turnId ?? this.manager.getSession(targetSession.threadId)?.activeTurnId ?? null,
             item_id: requestId,
             request_id: requestId,
             kind: 'tool.started',
@@ -609,6 +622,8 @@ export class CodexImplementer implements AgentSdkImplementer, AgentRuntimeAdapte
       status: this.mapProviderStatus(providerSession.status),
       messages: [],
       liveAssistantDraft: null,
+      activeRun: null,
+      settledRunIds: new Set(),
       revertMessageID: null,
       revertDiff: null,
       titleGenerated: false,
@@ -681,12 +696,14 @@ export class CodexImplementer implements AgentSdkImplementer, AgentRuntimeAdapte
         status: this.mapProviderStatus(providerSession.status),
         messages: [],
         liveAssistantDraft: null,
+        activeRun: null,
+        settledRunIds: new Set(),
         revertMessageID: null,
         revertDiff: null,
         titleGenerated: true,
         titleGenerationStarted: true,
         mapperState: createCodexMapperState(),
-      itemTimestampsByTurn: new Map()
+        itemTimestampsByTurn: new Map()
       }
       this.sessions.set(newKey, state)
 
@@ -765,8 +782,6 @@ export class CodexImplementer implements AgentSdkImplementer, AgentRuntimeAdapte
       throw new Error(`Prompt failed: session not found for ${worktreePath} / ${agentSessionId}`)
     }
 
-    beginSessionRun(session.hiveSessionId)
-
     // Extract text from message
     let text: string
     if (typeof message === 'string') {
@@ -782,6 +797,10 @@ export class CodexImplementer implements AgentSdkImplementer, AgentRuntimeAdapte
       log.warn('Prompt: empty text, ignoring', { worktreePath, agentSessionId })
       return
     }
+
+    const activeRun = this.beginCodexRun(session)
+    const runId = activeRun.runId
+    beginSessionRun(session.hiveSessionId)
 
     // Immediate title: set truncated first message as title for instant UX feedback
     const isFirstMessage = session.messages.length === 0 && !session.titleGenerated
@@ -835,6 +854,7 @@ export class CodexImplementer implements AgentSdkImplementer, AgentRuntimeAdapte
     let pendingPlanText: string | null = null
     let turnCompleted = false
     let turnFailed = false
+    let turnInterrupted = false
     let completedTurnId: string | undefined
     // Track whether a question was raised in this turn. When the agent uses
     // request_user_input (a Plan-mode tool) inside an otherwise-Plan turn,
@@ -845,8 +865,10 @@ export class CodexImplementer implements AgentSdkImplementer, AgentRuntimeAdapte
     let userInputAskedInTurn = false
 
     const handleEvent = (event: CodexManagerEvent) => {
-      // Only handle events for this thread
-      if (event.threadId !== session.threadId) return
+      // Only the currently active local run may mutate this session. This
+      // prevents late events from a stopped turn from completing or repainting
+      // a newly-started prompt on the same Codex thread.
+      if (!this.eventMatchesActiveRun(session, runId, event)) return
 
       const streamEvents = mapCodexEventToStreamEvents(
         event,
@@ -920,6 +942,15 @@ export class CodexImplementer implements AgentSdkImplementer, AgentRuntimeAdapte
         if (status === 'failed') {
           turnFailed = true
         }
+        if (status === 'interrupted') {
+          turnInterrupted = true
+        }
+      }
+
+      if (event.method === 'turn/interrupted') {
+        turnCompleted = true
+        turnInterrupted = true
+        completedTurnId = this.extractEventTurnId(event) ?? completedTurnId
       }
 
       // Track if request_user_input fires anywhere in this turn so we know
@@ -976,53 +1007,156 @@ export class CodexImplementer implements AgentSdkImplementer, AgentRuntimeAdapte
         }
       }
 
-      await this.manager.sendTurn(session.threadId, {
+      const turnStart = await this.manager.sendTurn(session.threadId, {
         text: turnText,
         model,
         ...(options?.codexFastMode ? { serviceTier: 'fast' } : {}),
         interactionMode
       })
 
+      if (!this.isRunCurrent(session, runId)) {
+        log.info('Prompt: stale run finished after a newer run started, skipping finalization', {
+          worktreePath,
+          agentSessionId,
+          runId,
+          activeRunId: session.activeRun?.runId ?? null
+        })
+        return
+      }
+
+      activeRun.expectedTurnId = turnStart.turnId || null
+      activeRun.state = 'running'
+
       // Wait for turn completion (the sendTurn starts the turn, but
       // events stream asynchronously via the manager's event emitter)
-      await this.waitForTurnCompletion(session, () => turnCompleted)
+      const completionState = await this.waitForTurnCompletion(session, {
+        runId,
+        expectedTurnId: activeRun.expectedTurnId,
+        isComplete: () => turnCompleted,
+        signal: activeRun.abortController.signal
+      })
+
+      if (!this.isRunCurrent(session, runId)) {
+        log.info('Prompt: stale run finished after wait, skipping finalization', {
+          worktreePath,
+          agentSessionId,
+          runId,
+          activeRunId: session.activeRun?.runId ?? null
+        })
+        return
+      }
+
+      if (completionState === 'interrupted' || turnInterrupted) {
+        activeRun.state = 'finalizing'
+        this.materializeLiveAssistantDraft(session, {
+          aborted: true,
+          terminalizeRunningTools: true,
+          emitTerminalTools: true
+        })
+        session.liveAssistantDraft = null
+        this.persistCanonicalMessages(session)
+        session.status = 'ready'
+        this.settleRun(session, runId)
+        this.emitStatus(session.hiveSessionId, 'idle')
+        return
+      }
 
       // Read canonical thread for properly separated messages
       try {
+        activeRun.state = 'finalizing'
         const threadSnapshot = await this.manager.readThread(session.threadId)
+        if (!this.isRunCurrent(session, runId)) {
+          log.info('Prompt: stale run finished during thread/read, skipping snapshot', {
+            worktreePath,
+            agentSessionId,
+            runId,
+            activeRunId: session.activeRun?.runId ?? null
+          })
+          return
+        }
         const parsed = this.parseThreadSnapshot(threadSnapshot, session.itemTimestampsByTurn)
-        if (parsed.length > 0) {
+        const snapshotMatchesPrompt = this.parsedMessagesContainUserText(parsed, [text, turnText])
+        if (parsed.length > 0 && snapshotMatchesPrompt) {
           session.messages = parsed
+        } else if (parsed.length > 0) {
+          log.warn(
+            'prompt: stale or mismatched thread/read snapshot ignored, preserving live draft',
+            {
+              worktreePath,
+              agentSessionId,
+              runId
+            }
+          )
+          if (!this.materializeLiveAssistantDraft(session)) {
+            const assistantParts: unknown[] = []
+            if (assistantText) {
+              assistantParts.push({
+                type: 'text',
+                text: assistantText,
+                timestamp: new Date().toISOString()
+              })
+            }
+            if (reasoningText) {
+              assistantParts.push({
+                type: 'reasoning',
+                text: reasoningText,
+                timestamp: new Date().toISOString()
+              })
+            }
+            if (assistantParts.length > 0) {
+              session.messages.push({
+                role: 'assistant',
+                parts: assistantParts,
+                timestamp: new Date().toISOString()
+              })
+            }
+          }
+        } else if (parsed.length === 0) {
+          this.materializeLiveAssistantDraft(session)
         }
         this.persistCanonicalMessages(session)
         session.liveAssistantDraft = null
       } catch (readError) {
+        if (!this.isRunCurrent(session, runId)) {
+          log.info(
+            'Prompt: stale run readThread failed after newer run started, skipping fallback',
+            {
+              worktreePath,
+              agentSessionId,
+              runId,
+              activeRunId: session.activeRun?.runId ?? null
+            }
+          )
+          return
+        }
         log.warn('prompt: readThread after turn failed, falling back to accumulated text', {
           agentSessionId,
           error: readError instanceof Error ? readError.message : String(readError)
         })
-        // Fallback: use accumulated text as single message
-        const assistantParts: unknown[] = []
-        if (assistantText) {
-          assistantParts.push({
-            type: 'text',
-            text: assistantText,
-            timestamp: new Date().toISOString()
-          })
-        }
-        if (reasoningText) {
-          assistantParts.push({
-            type: 'reasoning',
-            text: reasoningText,
-            timestamp: new Date().toISOString()
-          })
-        }
-        if (assistantParts.length > 0) {
-          session.messages.push({
-            role: 'assistant',
-            parts: assistantParts,
-            timestamp: new Date().toISOString()
-          })
+        if (!this.materializeLiveAssistantDraft(session)) {
+          // Fallback: use accumulated text as single message
+          const assistantParts: unknown[] = []
+          if (assistantText) {
+            assistantParts.push({
+              type: 'text',
+              text: assistantText,
+              timestamp: new Date().toISOString()
+            })
+          }
+          if (reasoningText) {
+            assistantParts.push({
+              type: 'reasoning',
+              text: reasoningText,
+              timestamp: new Date().toISOString()
+            })
+          }
+          if (assistantParts.length > 0) {
+            session.messages.push({
+              role: 'assistant',
+              parts: assistantParts,
+              timestamp: new Date().toISOString()
+            })
+          }
         }
         this.persistCanonicalMessages(session)
         session.liveAssistantDraft = null
@@ -1091,6 +1225,7 @@ export class CodexImplementer implements AgentSdkImplementer, AgentRuntimeAdapte
       }
 
       session.status = turnFailed ? 'error' : 'ready'
+      this.settleRun(session, runId)
       this.emitStatus(session.hiveSessionId, 'idle')
 
       log.info('Prompt: completed', {
@@ -1100,6 +1235,16 @@ export class CodexImplementer implements AgentSdkImplementer, AgentRuntimeAdapte
         reasoningTextLength: reasoningText.length
       })
     } catch (error) {
+      if (!this.isRunCurrent(session, runId)) {
+        log.info('Prompt: stale run failed after newer run started, ignoring error', {
+          worktreePath,
+          agentSessionId,
+          runId,
+          error: error instanceof Error ? error.message : String(error)
+        })
+        return
+      }
+
       const errorMessage = error instanceof Error ? error.message : String(error)
       log.error(
         'Prompt streaming error',
@@ -1109,6 +1254,9 @@ export class CodexImplementer implements AgentSdkImplementer, AgentRuntimeAdapte
 
       session.status = 'error'
       session.liveAssistantDraft = null
+      if (this.isRunCurrent(session, runId)) {
+        this.settleRun(session, runId)
+      }
       emitAgentEvent(this.mainWindow, {
         type: 'session.error',
         sessionId: session.hiveSessionId,
@@ -1181,8 +1329,35 @@ export class CodexImplementer implements AgentSdkImplementer, AgentRuntimeAdapte
       return false
     }
 
+    const activeRun = session.activeRun
+    if (activeRun) {
+      activeRun.state = 'aborting'
+    }
+
+    const managerSession = this.manager.getSession(session.threadId)
+    const expectedTurnId = activeRun?.expectedTurnId ?? managerSession?.activeTurnId ?? null
+
+    const materialized = this.materializeLiveAssistantDraft(session, {
+      aborted: true,
+      terminalizeRunningTools: true,
+      emitTerminalTools: true
+    })
+    if (materialized) {
+      this.persistCanonicalMessages(session)
+    }
+    session.liveAssistantDraft = null
+
+    if (activeRun) {
+      activeRun.abortController.abort()
+      this.settleRun(session, activeRun.runId)
+    }
+
     try {
-      await this.manager.interruptTurn(session.threadId)
+      if (expectedTurnId) {
+        await this.manager.interruptTurn(session.threadId, expectedTurnId)
+      } else {
+        await this.manager.interruptTurn(session.threadId)
+      }
     } catch (error) {
       log.warn('Abort: interruptTurn failed, continuing cleanup', {
         worktreePath,
@@ -1192,7 +1367,6 @@ export class CodexImplementer implements AgentSdkImplementer, AgentRuntimeAdapte
     }
 
     session.status = 'ready'
-    session.liveAssistantDraft = null
     this.emitStatus(session.hiveSessionId, 'idle')
     return true
   }
@@ -1994,6 +2168,87 @@ export class CodexImplementer implements AgentSdkImplementer, AgentRuntimeAdapte
     })
   }
 
+  private beginCodexRun(session: CodexSessionState): CodexActiveRun {
+    const previousRun = session.activeRun
+    if (previousRun && previousRun.state !== 'settled') {
+      previousRun.abortController.abort()
+      session.settledRunIds?.add(previousRun.runId)
+    }
+
+    const activeRun: CodexActiveRun = {
+      runId: randomUUID(),
+      expectedTurnId: null,
+      state: 'starting',
+      startedAt: Date.now(),
+      abortController: new AbortController()
+    }
+    session.activeRun = activeRun
+    session.settledRunIds ??= new Set()
+    return activeRun
+  }
+
+  private isRunCurrent(session: CodexSessionState, runId: string): boolean {
+    return session.activeRun?.runId === runId
+  }
+
+  private settleRun(session: CodexSessionState, runId: string): void {
+    session.settledRunIds ??= new Set()
+    session.settledRunIds.add(runId)
+    if (session.activeRun?.runId === runId) {
+      session.activeRun.state = 'settled'
+      session.activeRun = null
+    }
+  }
+
+  private extractEventTurnId(event: CodexManagerEvent): string | undefined {
+    const payload = asObject(event.payload)
+    return event.turnId ?? asString(payload?.turnId) ?? asString(asObject(payload?.turn)?.id)
+  }
+
+  private eventMatchesActiveRun(
+    session: CodexSessionState,
+    runId: string,
+    event: CodexManagerEvent
+  ): boolean {
+    if (event.threadId !== session.threadId) return false
+    const activeRun = session.activeRun
+    if (!activeRun || activeRun.runId !== runId) return false
+
+    const expectedTurnId = activeRun.expectedTurnId
+    const eventTurnId = this.extractEventTurnId(event)
+    if (!expectedTurnId && eventTurnId) {
+      return false
+    }
+    if (expectedTurnId && eventTurnId && eventTurnId !== expectedTurnId) {
+      return false
+    }
+    return true
+  }
+
+  private parsedMessagesContainUserText(messages: unknown[], candidates: string[]): boolean {
+    const targets = candidates.map((candidate) => candidate.trim()).filter(Boolean)
+    if (targets.length === 0) return true
+
+    for (const message of messages) {
+      const record = asObject(message)
+      if (record?.role !== 'user') continue
+      const parts = Array.isArray(record.parts) ? record.parts : []
+      const text = parts
+        .map((part) => asObject(part))
+        .filter((part) => part?.type === 'text')
+        .map((part) => asString(part?.text) ?? '')
+        .join('\n')
+        .trim()
+      if (!text) continue
+      if (
+        targets.some((target) => text === target || text.includes(target) || target.includes(text))
+      ) {
+        return true
+      }
+    }
+    return false
+  }
+
   private resetLiveAssistantDraft(session: CodexSessionState): void {
     session.liveAssistantDraft = {
       id: `codex-live-${session.threadId}`,
@@ -2035,10 +2290,12 @@ export class CodexImplementer implements AgentSdkImplementer, AgentRuntimeAdapte
       callID: string
       tool: string
       state: {
-        status: 'running' | 'completed' | 'error'
+        status: 'running' | 'completed' | 'error' | 'cancelled'
         input?: unknown
         output?: unknown
         error?: unknown
+        metadata?: Record<string, unknown>
+        time?: { start?: number; end?: number }
       }
     }
   ): void {
@@ -2098,7 +2355,9 @@ export class CodexImplementer implements AgentSdkImplementer, AgentRuntimeAdapte
       const state = asObject(part.state)
       const statusValue = asString(state?.status)
       const status =
-        statusValue === 'completed' || statusValue === 'error' ? statusValue : 'running'
+        statusValue === 'completed' || statusValue === 'error' || statusValue === 'cancelled'
+          ? statusValue
+          : 'running'
 
       this.upsertLiveAssistantTool(session, {
         callID: asString(part.callID) ?? asString(part.id) ?? '',
@@ -2113,9 +2372,14 @@ export class CodexImplementer implements AgentSdkImplementer, AgentRuntimeAdapte
     }
   }
 
-  private cloneLiveAssistantDraftMessage(session: CodexSessionState): unknown | null {
+  private cloneLiveAssistantDraftMessage(
+    session: CodexSessionState,
+    options?: { aborted?: boolean; terminalizeRunningTools?: boolean }
+  ): unknown | null {
     const draft = session.liveAssistantDraft
     if (!draft || draft.parts.length === 0) return null
+
+    const now = Date.now()
 
     return {
       id: draft.id,
@@ -2129,24 +2393,84 @@ export class CodexImplementer implements AgentSdkImplementer, AgentRuntimeAdapte
           type: 'tool',
           callID: part.callID,
           tool: part.tool,
-          state: { ...part.state }
+          state:
+            options?.terminalizeRunningTools && part.state.status === 'running'
+              ? {
+                  ...part.state,
+                  status: 'cancelled',
+                  metadata: { ...(part.state.metadata ?? {}), aborted: true },
+                  time: { ...(part.state.time ?? {}), end: now }
+                }
+              : { ...part.state }
         }
       }),
-      timestamp: draft.timestamp
+      timestamp: draft.timestamp,
+      ...(options?.aborted ? { aborted: true } : {})
     }
+  }
+
+  private materializeLiveAssistantDraft(
+    session: CodexSessionState,
+    options?: { aborted?: boolean; terminalizeRunningTools?: boolean; emitTerminalTools?: boolean }
+  ): boolean {
+    const message = this.cloneLiveAssistantDraftMessage(session, options)
+    if (!message) return false
+
+    const messageId = asString(asObject(message)?.id)
+    const existingIndex = messageId
+      ? session.messages.findIndex((candidate) => asString(asObject(candidate)?.id) === messageId)
+      : -1
+
+    if (existingIndex >= 0) {
+      session.messages[existingIndex] = message
+    } else {
+      session.messages.push(message)
+    }
+
+    if (options?.emitTerminalTools) {
+      const parts = asObject(message)?.parts
+      if (Array.isArray(parts)) {
+        for (const part of parts) {
+          const record = asObject(part)
+          const state = asObject(record?.state)
+          if (record?.type !== 'tool' || state?.status !== 'cancelled') continue
+          emitAgentEvent(this.mainWindow, {
+            type: 'message.part.updated',
+            sessionId: session.hiveSessionId,
+            data: { part }
+          })
+        }
+      }
+    }
+
+    return true
   }
 
   private waitForTurnCompletion(
     session: CodexSessionState,
-    isComplete: () => boolean,
-    timeoutMs = 300_000
-  ): Promise<void> {
-    if (isComplete()) return Promise.resolve()
+    params: {
+      runId: string
+      expectedTurnId?: string | null
+      isComplete: () => boolean
+      signal?: AbortSignal
+      timeoutMs?: number
+    }
+  ): Promise<'completed' | 'interrupted'> {
+    const { runId, expectedTurnId = null, isComplete, signal, timeoutMs = 300_000 } = params
 
-    return new Promise<void>((resolve, reject) => {
+    if (expectedTurnId && session.activeRun?.runId === runId) {
+      session.activeRun.expectedTurnId = expectedTurnId
+    }
+
+    if (isComplete()) return Promise.resolve('completed')
+    if (signal?.aborted) return Promise.resolve('interrupted')
+
+    return new Promise<'completed' | 'interrupted'>((resolve, reject) => {
       let remainingMs = timeoutMs
       let timerStartedAt = Date.now()
       let timer: ReturnType<typeof setTimeout> | null = null
+      let settled = false
+      let onAbort: (() => void) | null = null
 
       const hasPendingHitlForThread = (): boolean => {
         for (const entry of this.pendingQuestions.values()) {
@@ -2158,6 +2482,12 @@ export class CodexImplementer implements AgentSdkImplementer, AgentRuntimeAdapte
         return false
       }
 
+      const clearSignalListener = () => {
+        if (onAbort) {
+          signal?.removeEventListener('abort', onAbort)
+        }
+      }
+
       const clearTimer = () => {
         if (timer) {
           clearTimeout(timer)
@@ -2165,12 +2495,33 @@ export class CodexImplementer implements AgentSdkImplementer, AgentRuntimeAdapte
         }
       }
 
+      const cleanup = () => {
+        if (settled) return
+        settled = true
+        clearTimer()
+        clearSignalListener()
+        this.manager.removeListener('event', checkEvent)
+      }
+
+      const finish = (result: 'completed' | 'interrupted'): void => {
+        cleanup()
+        resolve(result)
+      }
+
+      const fail = (error: Error): void => {
+        cleanup()
+        reject(error)
+      }
+
+      onAbort = () => {
+        finish('interrupted')
+      }
+
       const startTimer = () => {
         clearTimer()
         timerStartedAt = Date.now()
         timer = setTimeout(() => {
-          cleanup()
-          reject(new Error('Turn timed out'))
+          fail(new Error('Turn timed out'))
         }, remainingMs)
       }
 
@@ -2183,11 +2534,22 @@ export class CodexImplementer implements AgentSdkImplementer, AgentRuntimeAdapte
       }
 
       const checkEvent = (event: CodexManagerEvent) => {
-        if (event.threadId !== session.threadId) return
+        if (!this.eventMatchesActiveRun(session, runId, event)) return
 
         if (event.method === 'turn/completed') {
-          cleanup()
-          resolve()
+          const payload = event.payload as Record<string, unknown> | undefined
+          const turnObj = payload?.turn as Record<string, unknown> | undefined
+          const status = (turnObj?.status as string) ?? (payload?.state as string)
+          if (status === 'interrupted') {
+            finish('interrupted')
+            return
+          }
+          finish('completed')
+          return
+        }
+
+        if (event.method === 'turn/interrupted') {
+          finish('interrupted')
           return
         }
 
@@ -2201,8 +2563,7 @@ export class CodexImplementer implements AgentSdkImplementer, AgentRuntimeAdapte
           event.method === 'session/closed'
 
         if (isFatalError) {
-          cleanup()
-          reject(new Error(event.message ?? 'Codex process error'))
+          fail(new Error(event.message ?? 'Codex process error'))
           return
         }
 
@@ -2217,8 +2578,8 @@ export class CodexImplementer implements AgentSdkImplementer, AgentRuntimeAdapte
             (payload?.error as string) ??
             event.message ??
             'Session entered error state'
-          cleanup()
-          reject(new Error(reason))
+          fail(new Error(reason))
+          return
         }
 
         if (event.kind === 'request') {
@@ -2238,11 +2599,9 @@ export class CodexImplementer implements AgentSdkImplementer, AgentRuntimeAdapte
         }
       }
 
-      const cleanup = () => {
-        clearTimer()
-        this.manager.removeListener('event', checkEvent)
+      if (onAbort) {
+        signal?.addEventListener('abort', onAbort, { once: true })
       }
-
       this.manager.on('event', checkEvent)
       if (!hasPendingHitlForThread()) {
         startTimer()
@@ -2250,8 +2609,7 @@ export class CodexImplementer implements AgentSdkImplementer, AgentRuntimeAdapte
 
       // Check again in case it completed between the start and listener setup
       if (isComplete()) {
-        cleanup()
-        resolve()
+        finish('completed')
       }
     })
   }
@@ -2351,12 +2709,14 @@ export class CodexImplementer implements AgentSdkImplementer, AgentRuntimeAdapte
         status: this.mapProviderStatus(providerSession.status),
         messages: [],
         liveAssistantDraft: null,
+        activeRun: null,
+        settledRunIds: new Set(),
         revertMessageID: null,
         revertDiff: null,
         titleGenerated: true,
         titleGenerationStarted: true,
         mapperState: createCodexMapperState(),
-      itemTimestampsByTurn: new Map()
+        itemTimestampsByTurn: new Map()
       }
 
       this.sessions.set(this.getSessionKey(worktreePath, threadId), recovered)
@@ -2538,9 +2898,7 @@ export class CodexImplementer implements AgentSdkImplementer, AgentRuntimeAdapte
       // at `createdAt` / `updatedAt`, so items often fell back to read time and
       // sorted after synthetic activity emitted during the same turn.
       const startedAtSec = asNumber(turnObj.startedAt)
-      const turnStartIso = startedAtSec
-        ? new Date(startedAtSec * 1000).toISOString()
-        : undefined
+      const turnStartIso = startedAtSec ? new Date(startedAtSec * 1000).toISOString() : undefined
       const turnTimestamp =
         turnStartIso ?? asString(turnObj.createdAt) ?? asString(turnObj.updatedAt)
       const items = turnObj.items as unknown[] | undefined
@@ -2574,8 +2932,7 @@ export class CodexImplementer implements AgentSdkImplementer, AgentRuntimeAdapte
         // the turn because codex's thread/read renumbers item ids. Falls back
         // to turnTimestamp (turn startedAt) when the streaming list is too
         // short — happens for past turns we never streamed.
-        const turnPositionalTimestamps =
-          turnId ? (itemTimestampsByTurn?.get(turnId) ?? []) : []
+        const turnPositionalTimestamps = turnId ? (itemTimestampsByTurn?.get(turnId) ?? []) : []
         let itemPositionInTurn = 0
 
         for (const item of items) {
@@ -2585,8 +2942,7 @@ export class CodexImplementer implements AgentSdkImplementer, AgentRuntimeAdapte
           const itemType = asString(itemObj.type)
           const itemId = asString(itemObj.id)
           const positionalTs = turnPositionalTimestamps[itemPositionInTurn]
-          const itemTimestamp =
-            positionalTs ?? turnTimestamp ?? new Date().toISOString()
+          const itemTimestamp = positionalTs ?? turnTimestamp ?? new Date().toISOString()
           itemPositionInTurn += 1
 
           if (itemType === 'userMessage') {
@@ -2768,10 +3124,7 @@ export class CodexImplementer implements AgentSdkImplementer, AgentRuntimeAdapte
    * Codex tool lifecycle items are `commandExecution` (Bash) and `fileChange`
    * (apply_patch); anything else is ignored by `isToolLifecycleItem`.
    */
-  private emitAgentToolField(
-    session: CodexSessionState,
-    event: CodexManagerEvent
-  ): void {
+  private emitAgentToolField(session: CodexSessionState, event: CodexManagerEvent): void {
     if (!this.dbService) return
 
     const payload = asObject(event.payload)

--- a/src/renderer/src/components/session-hq/SessionShell.tsx
+++ b/src/renderer/src/components/session-hq/SessionShell.tsx
@@ -913,16 +913,12 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
     ;(async () => {
       try {
         if (opcSessionId) {
-          console.log('[SessionShell] reconnecting', { sessionId, opcSessionId, worktreePath })
           const result = await window.agentOps.reconnect(worktreePath, opcSessionId, sessionId)
-          console.log('[SessionShell] reconnect result', result)
           if (!cancelled && result.success) {
             setDroidSessionId(opcSessionId)
           }
         } else {
-          console.log('[SessionShell] connecting (new)', { sessionId, worktreePath })
           const result = await window.agentOps.connect(worktreePath, sessionId)
-          console.log('[SessionShell] connect result', result)
           if (!cancelled && result.success && result.sessionId) {
             setDroidSessionId(result.sessionId)
             useSessionStore.getState().setOpenCodeSessionId(sessionId, result.sessionId)

--- a/src/renderer/src/components/session-hq/SessionShell.tsx
+++ b/src/renderer/src/components/session-hq/SessionShell.tsx
@@ -368,6 +368,45 @@ function useStreamingMirror(sessionId: string) {
   )
 }
 
+function waitForSessionIdleAfterAbort(sessionId: string, timeoutMs = 2500): Promise<void> {
+  const isReady = (): boolean => {
+    const lifecycle = useSessionRuntimeStore.getState().getSession(sessionId).lifecycle
+    return lifecycle === 'idle' || lifecycle === 'error'
+  }
+
+  if (isReady()) {
+    return Promise.resolve()
+  }
+
+  return new Promise((resolve) => {
+    let settled = false
+    let timer: ReturnType<typeof window.setTimeout> | null = null
+    let unsubscribe: (() => void) | null = null
+
+    const settle = (): void => {
+      if (settled) return
+      settled = true
+      unsubscribe?.()
+      if (timer !== null) window.clearTimeout(timer)
+      resolve()
+    }
+
+    unsubscribe = useSessionRuntimeStore.subscribe(() => {
+      if (isReady()) settle()
+    })
+
+    // Close the small race where the idle transition lands between the first
+    // read and subscription registration.
+    if (isReady()) {
+      settle()
+      return
+    }
+
+    // Deadlock guard only: the normal path resolves on the lifecycle event.
+    timer = window.setTimeout(settle, timeoutMs)
+  })
+}
+
 // ---------------------------------------------------------------------------
 // SessionShell
 // ---------------------------------------------------------------------------
@@ -1323,8 +1362,11 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
       )
       const contentToSend = diffCommentContext + content
 
-      if (action === 'send' || action === 'stop_and_send' || action === 'steer') {
+      if (action === 'send' || action === 'stop_and_send') {
         resetLiveOverlay(true)
+      }
+
+      if (action === 'send' || action === 'stop_and_send' || action === 'steer') {
         // Lock provider/model selectors immediately. Main process also stamps
         // first_message_at via createSessionMessage / upsertSessionActivity,
         // but the UI shouldn't wait for the round-trip.
@@ -1363,6 +1405,7 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
         const consumed = await executeSendAction(action, contentToSend, attachments, {
           worktreePath,
           sessionId: droidSessionId,
+          queueSessionId: sessionId,
           prompt: async (wp, sid, c) => {
             let messageParts: MessagePart[] | undefined
             if (attachments.length > 0) {
@@ -1372,6 +1415,7 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
           },
           steer: (wp, sid, c) => window.agentOps.steer(wp, sid, c, requestModel),
           abort: (wp, sid) => window.agentOps.abort(wp, sid),
+          waitForAbortReady: () => waitForSessionIdleAfterAbort(sessionId),
           queueMessage: (sid, msg) => useSessionRuntimeStore.getState().queueMessage(sid, msg)
         })
 
@@ -1405,7 +1449,9 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
           setSuccessCriteria(previousSuccessCriteria)
         }
         toast.error(err instanceof Error ? err.message : 'Failed to send message')
-        resetLiveOverlay(false)
+        if (action === 'send' || action === 'stop_and_send') {
+          resetLiveOverlay(false)
+        }
         return false
       }
     },
@@ -1483,6 +1529,7 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
         const consumed = await executeSendAction('send', contentToSend, [], {
           worktreePath,
           sessionId: droidSessionId,
+          queueSessionId: sessionId,
           prompt: (wp, sid, content) =>
             window.agentOps.prompt(wp, sid, content, requestModel, promptOptions),
           abort: (wp, sid) => window.agentOps.abort(wp, sid),
@@ -1502,6 +1549,7 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
       editingContent,
       worktreePath,
       droidSessionId,
+      sessionId,
       timelineMessages,
       setMessages,
       appendOptimistic,
@@ -1673,6 +1721,7 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
       await executeSendAction('send', implementPrompt, [], {
         worktreePath,
         sessionId: droidSessionId,
+        queueSessionId: sessionId,
         prompt: (wp, sid, c) => window.agentOps.prompt(wp, sid, c, requestModel, promptOptions),
         abort: (wp, sid) => window.agentOps.abort(wp, sid),
         queueMessage: (sid, msg) => useSessionRuntimeStore.getState().queueMessage(sid, msg)

--- a/src/renderer/src/hooks/usePRDetection.ts
+++ b/src/renderer/src/hooks/usePRDetection.ts
@@ -1,17 +1,21 @@
 import { useEffect, useRef } from 'react'
 import { useGitStore } from '@/stores/useGitStore'
 import { useSessionStore } from '@/stores/useSessionStore'
+import { useSessionRuntimeStore } from '@/stores/useSessionRuntimeStore'
 import { useWorktreeStore } from '@/stores/useWorktreeStore'
 
 export const PR_URL_PATTERN = /https:\/\/github\.com\/[^/]+\/[^/]+\/pull\/(\d+)/
 
 /**
- * Watches stream events for a PR session and detects when a GitHub PR URL
- * appears in assistant output. Transitions from creating → attached (DB-persisted).
+ * Watches accepted session runtime events for a PR session and detects when a
+ * GitHub PR URL appears in assistant output. Transitions from creating →
+ * attached (DB-persisted).
  *
- * Stream detection is scoped to the specific Hive session that started PR
- * creation (event.sessionId === prCreation.sessionId). This prevents concurrent PR
- * workflows in sibling worktrees from leaking state into each other.
+ * Raw stream ingress is owned by useAgentEventBridge. This hook subscribes to
+ * the runtime store's per-session accepted-event channel scoped to the specific
+ * Hive session that started PR creation. This prevents concurrent PR workflows
+ * in sibling worktrees from leaking state into each other and keeps stale
+ * run/turn events behind the bridge guard.
  *
  * We scan both text content AND tool output (the `gh pr create` command output
  * typically contains the PR URL before the assistant's text summary does).
@@ -53,87 +57,93 @@ export function usePRDetection(worktreeId: string | null): void {
 
   useEffect(() => {
     // Only monitor when actively creating
-    if (!worktreeId || !prCreation || !prCreation.creating) return
+    if (!worktreeId || !prCreation || !prCreation.creating || !prCreation.sessionId) return
 
     // Reset accumulated text
     accumulatedTextRef.current = ''
+    const sessionId = prCreation.sessionId
 
     const checkForPrUrl = (text: string): void => {
       const match = text.match(PR_URL_PATTERN)
       if (match) {
         const currentCreation = prCreationRef.current
         const currentWorktreeId = worktreeIdRef.current
-        if (currentCreation && currentWorktreeId && currentCreation.creating) {
+        if (
+          currentCreation &&
+          currentWorktreeId &&
+          currentCreation.creating &&
+          currentCreation.sessionId === sessionId
+        ) {
           const prNumber = parseInt(match[1], 10)
           // Persist to DB + optimistic cache
-          attachPR(currentWorktreeId, prNumber, match[0])
+          void attachPR(currentWorktreeId, prNumber, match[0])
           // Clear ephemeral creation state
           setPrCreation(currentWorktreeId, null)
+          prCreationRef.current = undefined
         }
       }
     }
 
-    const unsubscribe = window.agentOps?.onStream
-      ? window.agentOps.onStream((event) => {
-          const currentCreation = prCreationRef.current
-          if (
-            !currentCreation ||
-            !currentCreation.creating ||
-            !currentCreation.sessionId
-          ) {
+    const unsubscribe = useSessionRuntimeStore
+      .getState()
+      .subscribeToSessionEvents(sessionId, (event) => {
+        const currentCreation = prCreationRef.current
+        if (
+          !currentCreation ||
+          !currentCreation.creating ||
+          currentCreation.sessionId !== sessionId ||
+          event.sessionId !== sessionId
+        ) {
+          return
+        }
+
+        // Primary path: message part updates (SDK streams text/tool deltas here)
+        if (event.type === 'message.part.updated') {
+          const payload = event.data
+          const part = payload?.part ?? payload
+          if (!part) return
+
+          // Check text content (assistant prose)
+          if (part.type === 'text') {
+            const delta = payload?.delta
+            if (typeof delta === 'string' && delta.length > 0) {
+              accumulatedTextRef.current += delta
+            } else if (typeof part.text === 'string' && part.text.length > 0) {
+              accumulatedTextRef.current = part.text
+            }
+            checkForPrUrl(accumulatedTextRef.current)
             return
           }
 
-          if (event.sessionId !== currentCreation.sessionId) return
-
-          // Primary path: message part updates (SDK streams text/tool deltas here)
-          if (event.type === 'message.part.updated') {
-            const payload = event.data
-            const part = payload?.part ?? payload
-            if (!part) return
-
-            // Check text content (assistant prose)
-            if (part.type === 'text') {
-              const delta = payload?.delta
-              if (typeof delta === 'string' && delta.length > 0) {
-                accumulatedTextRef.current += delta
-              } else if (typeof part.text === 'string' && part.text.length > 0) {
-                accumulatedTextRef.current = part.text
-              }
-              checkForPrUrl(accumulatedTextRef.current)
-              return
-            }
-
-            // Check tool output (gh pr create output often contains the PR URL)
-            if (part.type === 'tool') {
-              const output = part.state?.output ?? part.output
-              if (typeof output === 'string') {
-                checkForPrUrl(output)
-              } else if (output !== undefined && output !== null) {
-                try {
-                  checkForPrUrl(JSON.stringify(output))
-                } catch {
-                  // ignore non-serializable tool outputs
-                }
+          // Check tool output (gh pr create output often contains the PR URL)
+          if (part.type === 'tool') {
+            const output = part.state?.output ?? part.output
+            if (typeof output === 'string') {
+              checkForPrUrl(output)
+            } else if (output !== undefined && output !== null) {
+              try {
+                checkForPrUrl(JSON.stringify(output))
+              } catch {
+                // ignore non-serializable tool outputs
               }
             }
-
-            return
           }
 
-          // Fallback path: some providers may emit URL on message.updated
-          if (event.type === 'message.updated') {
-            const messageText =
-              event.data?.message?.content ?? event.data?.content ?? event.data?.info?.content
-            if (typeof messageText === 'string') {
-              checkForPrUrl(messageText)
-            }
+          return
+        }
+
+        // Fallback path: some providers may emit URL on message.updated
+        if (event.type === 'message.updated') {
+          const messageText =
+            event.data?.message?.content ?? event.data?.content ?? event.data?.info?.content
+          if (typeof messageText === 'string') {
+            checkForPrUrl(messageText)
           }
-        })
-      : () => {}
+        }
+      })
 
     return unsubscribe
-  }, [worktreeId, prCreation, opencodeSessionId, worktreePath, setPrCreation, attachPR])
+  }, [worktreeId, prCreation, setPrCreation, attachPR])
 
   // Backstop: poll transcript while creating in case stream event payload shapes vary.
   useEffect(() => {
@@ -164,9 +174,10 @@ export function usePRDetection(worktreeId: string | null): void {
 
         const prNumber = parseInt(match[1], 10)
         // Persist to DB + optimistic cache
-        attachPR(currentWorktreeId, prNumber, match[0])
+        void attachPR(currentWorktreeId, prNumber, match[0])
         // Clear ephemeral creation state
         setPrCreation(currentWorktreeId, null)
+        prCreationRef.current = undefined
       } catch {
         // Non-fatal: next poll tick will retry
       }

--- a/src/renderer/src/lib/session-send-actions.ts
+++ b/src/renderer/src/lib/session-send-actions.ts
@@ -186,7 +186,10 @@ export function _resetPendingIdCounter(): void {
  */
 export interface SendContext {
   worktreePath: string
+  /** Agent session id used for prompt/abort/steer IPC calls. */
   sessionId: string
+  /** Optional store/session id used for queued-message bookkeeping. */
+  queueSessionId?: string
   /** IPC: send a prompt to the agent */
   prompt: (
     worktreePath: string,
@@ -194,7 +197,7 @@ export interface SendContext {
     content: string
   ) => Promise<{ success: boolean; error?: string }>
   /** IPC: steer the active turn */
-  steer: (
+  steer?: (
     worktreePath: string,
     sessionId: string,
     content: string
@@ -204,6 +207,8 @@ export interface SendContext {
     worktreePath: string,
     sessionId: string
   ) => Promise<{ success: boolean; error?: string }>
+  /** Optional wait gate used after abort so the next prompt lands on a clean turn boundary. */
+  waitForAbortReady?: () => Promise<void>
   /** Store: enqueue a pending message */
   queueMessage: (sessionId: string, message: PendingMessage) => void
 }
@@ -245,11 +250,15 @@ export async function executeSendAction(
 
     case 'queue': {
       const msg = createPendingMessage(content, attachments)
-      ctx.queueMessage(ctx.sessionId, msg)
+      ctx.queueMessage(ctx.queueSessionId ?? ctx.sessionId, msg)
       return true
     }
 
     case 'steer': {
+      if (!ctx.steer) {
+        throw new Error('Steer is not available for this session')
+      }
+
       if (attachments.length > 0) {
         throw new Error('Steer only supports text messages')
       }
@@ -266,8 +275,7 @@ export async function executeSendAction(
         ctx.abort(ctx.worktreePath, ctx.sessionId),
         'Failed to stop active turn'
       )
-      // Brief delay so the abort propagates before the new prompt
-      await new Promise((r) => setTimeout(r, 100))
+      await ctx.waitForAbortReady?.()
       await ensureSuccess(
         ctx.prompt(ctx.worktreePath, ctx.sessionId, content),
         'Failed to send message after stopping active turn'

--- a/src/renderer/src/stores/useSessionRuntimeStore.ts
+++ b/src/renderer/src/stores/useSessionRuntimeStore.ts
@@ -63,6 +63,8 @@ export const DEFAULT_SESSION_STATE: Readonly<SessionRuntimeState> = {
   retryInfo: null
 }
 
+export const ACTIVITY_TOUCH_THROTTLE_MS = 1000
+
 // ---------------------------------------------------------------------------
 // Per-session event callback registry (module-level, NOT reactive state)
 // ---------------------------------------------------------------------------
@@ -822,9 +824,19 @@ export const useSessionRuntimeStore = create<SessionRuntimeStore>()((set, get) =
 
   touchActivity(sessionId) {
     set((state) => {
+      const now = Date.now()
+      const hasSession = state.sessions.has(sessionId)
+      const existing = ensureSession(state.sessions, sessionId)
+      if (
+        hasSession &&
+        now >= existing.lastActivityAt &&
+        now - existing.lastActivityAt < ACTIVITY_TOUCH_THROTTLE_MS
+      ) {
+        return state
+      }
+
       const sessions = new Map(state.sessions)
-      const existing = ensureSession(sessions, sessionId)
-      sessions.set(sessionId, { ...existing, lastActivityAt: Date.now() })
+      sessions.set(sessionId, { ...existing, lastActivityAt: now })
       return { sessions }
     })
   },

--- a/test/phase-20/session-10/pr-detection-session-scope.test.ts
+++ b/test/phase-20/session-10/pr-detection-session-scope.test.ts
@@ -2,20 +2,27 @@ import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { act, cleanup, renderHook } from '@testing-library/react'
 import { usePRDetection } from '../../../src/renderer/src/hooks/usePRDetection'
 import { useGitStore } from '../../../src/renderer/src/stores/useGitStore'
+import { useSessionRuntimeStore } from '../../../src/renderer/src/stores/useSessionRuntimeStore'
+import type { CanonicalAgentEvent } from '../../../src/shared/types/agent-protocol'
 
-let streamCallback: ((event: Record<string, unknown>) => void) | null = null
+const mockOnStream = vi.fn(() => () => {})
+const mockGetMessages = vi.fn()
+const mockAttachPR = vi.fn()
 
-const mockOnStream = vi.fn((cb: (event: Record<string, unknown>) => void) => {
-  streamCallback = cb
-  return () => {
-    streamCallback = null
+Object.defineProperty(window, 'agentOps', {
+  writable: true,
+  value: {
+    onStream: mockOnStream,
+    getMessages: mockGetMessages
   }
 })
 
-Object.defineProperty(window, 'opencodeOps', {
+Object.defineProperty(window, 'db', {
   writable: true,
   value: {
-    onStream: mockOnStream
+    worktree: {
+      attachPR: mockAttachPR
+    }
   }
 })
 
@@ -31,7 +38,7 @@ const mockSessionState: {
   sessionsByWorktree: new Map()
 }
 
-vi.mock('../../../src/renderer/src/stores/useWorktreeStore', () => ({
+vi.mock('@/stores/useWorktreeStore', () => ({
   useWorktreeStore: Object.assign(
     <T>(selector: (state: typeof mockWorktreeState) => T): T => selector(mockWorktreeState),
     {
@@ -40,7 +47,7 @@ vi.mock('../../../src/renderer/src/stores/useWorktreeStore', () => ({
   )
 }))
 
-vi.mock('../../../src/renderer/src/stores/useSessionStore', () => ({
+vi.mock('@/stores/useSessionStore', () => ({
   useSessionStore: Object.assign(
     <T>(selector: (state: typeof mockSessionState) => T): T => selector(mockSessionState),
     {
@@ -49,10 +56,33 @@ vi.mock('../../../src/renderer/src/stores/useSessionStore', () => ({
   )
 }))
 
+function makeTextDeltaEvent(
+  sessionId: string,
+  delta: string,
+  sequence: number
+): CanonicalAgentEvent {
+  return {
+    type: 'message.part.updated',
+    sessionId,
+    runEpoch: 1,
+    sessionSequence: sequence,
+    eventId: `${sessionId}-${sequence}`,
+    sourceChannel: 'agent:stream',
+    data: {
+      part: {
+        type: 'text',
+        text: delta
+      },
+      delta
+    }
+  } as CanonicalAgentEvent
+}
+
 describe('Session 10: PR detection session scoping', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    streamCallback = null
+    mockAttachPR.mockResolvedValue({ success: true })
+    mockGetMessages.mockResolvedValue({ success: true, messages: [] })
 
     mockWorktreeState.worktreesByProject = new Map([
       [
@@ -86,14 +116,17 @@ describe('Session 10: PR detection session scoping', () => {
     ])
 
     useGitStore.setState({
-      prInfo: new Map(),
+      prCreation: new Map(),
+      attachedPR: new Map(),
       fileStatusesByWorktree: new Map(),
       branchInfoByWorktree: new Map(),
       conflictsByWorktree: {},
       remoteInfo: new Map(),
       prTargetBranch: new Map(),
+      reviewTargetBranch: new Map(),
       defaultMergeBranch: new Map(),
       selectedMergeBranch: new Map(),
+      selectedDiffBranch: new Map(),
       mergeSelectionVersion: 0,
       isLoading: false,
       error: null,
@@ -101,63 +134,86 @@ describe('Session 10: PR detection session scoping', () => {
       isPushing: false,
       isPulling: false
     })
+
+    useSessionRuntimeStore.getState().clearSession('session-1')
+    useSessionRuntimeStore.getState().clearSession('session-2')
   })
 
   afterEach(() => {
     cleanup()
   })
 
-  test('ignores PR URL stream events from other sessions/worktrees', () => {
+  test('consumes accepted runtime events without subscribing to the raw stream', () => {
     act(() => {
-      useGitStore.getState().setPrState('wt-1', {
-        state: 'creating',
-        sessionId: 'session-1',
-        targetBranch: 'origin/main'
+      useGitStore.getState().setPrCreation('wt-1', {
+        creating: true,
+        sessionId: 'session-1'
       })
-      useGitStore.getState().setPrState('wt-2', {
-        state: 'creating',
-        sessionId: 'session-2',
-        targetBranch: 'origin/main'
+      useGitStore.getState().setPrCreation('wt-2', {
+        creating: true,
+        sessionId: 'session-2'
       })
     })
 
     renderHook(() => usePRDetection('wt-1'))
-    expect(streamCallback).not.toBeNull()
+    expect(mockOnStream).not.toHaveBeenCalled()
 
     act(() => {
-      streamCallback?.({
-        type: 'message.part.updated',
-        sessionId: 'session-2',
-        data: {
-          part: {
-            type: 'text',
-            text: 'https://github.com/org/repo/pull/22'
-          },
-          delta: 'https://github.com/org/repo/pull/22'
-        }
+      useSessionRuntimeStore
+        .getState()
+        .dispatchToSession(
+          'session-2',
+          makeTextDeltaEvent('session-2', 'https://github.com/org/repo/pull/22', 1)
+        )
+    })
+
+    expect(useGitStore.getState().prCreation.get('wt-1')?.creating).toBe(true)
+    expect(useGitStore.getState().prCreation.get('wt-2')?.creating).toBe(true)
+    expect(useGitStore.getState().attachedPR.get('wt-1')).toBeUndefined()
+
+    act(() => {
+      useSessionRuntimeStore
+        .getState()
+        .dispatchToSession(
+          'session-1',
+          makeTextDeltaEvent('session-1', 'https://github.com/org/repo/pull/11', 2)
+        )
+    })
+
+    expect(useGitStore.getState().prCreation.get('wt-1')).toBeUndefined()
+    expect(useGitStore.getState().attachedPR.get('wt-1')).toEqual({
+      number: 11,
+      url: 'https://github.com/org/repo/pull/11'
+    })
+    expect(mockAttachPR).toHaveBeenCalledWith('wt-1', 11, 'https://github.com/org/repo/pull/11')
+    expect(mockGetMessages).not.toHaveBeenCalled()
+  })
+
+  test('detects a PR URL split across accepted runtime text deltas', () => {
+    act(() => {
+      useGitStore.getState().setPrCreation('wt-1', {
+        creating: true,
+        sessionId: 'session-1'
       })
     })
 
-    expect(useGitStore.getState().prInfo.get('wt-1')?.state).toBe('creating')
-    expect(useGitStore.getState().prInfo.get('wt-2')?.state).toBe('creating')
+    renderHook(() => usePRDetection('wt-1'))
 
     act(() => {
-      streamCallback?.({
-        type: 'message.part.updated',
-        sessionId: 'session-1',
-        data: {
-          part: {
-            type: 'text',
-            text: 'https://github.com/org/repo/pull/11'
-          },
-          delta: 'https://github.com/org/repo/pull/11'
-        }
-      })
+      const runtime = useSessionRuntimeStore.getState()
+      runtime.dispatchToSession('session-1', makeTextDeltaEvent('session-1', 'Created at ', 1))
+      runtime.dispatchToSession(
+        'session-1',
+        makeTextDeltaEvent('session-1', 'https://github.com/', 2)
+      )
+      runtime.dispatchToSession('session-1', makeTextDeltaEvent('session-1', 'org/repo/pull/', 3))
+      runtime.dispatchToSession('session-1', makeTextDeltaEvent('session-1', '77', 4))
     })
 
-    const wt1Pr = useGitStore.getState().prInfo.get('wt-1')
-    expect(wt1Pr?.state).toBe('created')
-    expect(wt1Pr?.prNumber).toBe(11)
-    expect(wt1Pr?.prUrl).toBe('https://github.com/org/repo/pull/11')
+    expect(useGitStore.getState().prCreation.get('wt-1')).toBeUndefined()
+    expect(useGitStore.getState().attachedPR.get('wt-1')).toEqual({
+      number: 77,
+      url: 'https://github.com/org/repo/pull/77'
+    })
   })
 })

--- a/test/phase-20/session-2/pr-lifecycle-store.test.ts
+++ b/test/phase-20/session-2/pr-lifecycle-store.test.ts
@@ -13,94 +13,95 @@ vi.mock('../../../src/renderer/src/stores/useWorktreeStore', () => ({
 describe('Session 2: PR Lifecycle Store State', () => {
   beforeEach(() => {
     useGitStore.setState({
-      prInfo: new Map()
+      prCreation: new Map(),
+      attachedPR: new Map()
     })
   })
 
-  test('prInfo starts as an empty map', () => {
+  test('PR lifecycle maps start empty', () => {
     const state = useGitStore.getState()
-    expect(state.prInfo).toBeInstanceOf(Map)
-    expect(state.prInfo.size).toBe(0)
+    expect(state.prCreation).toBeInstanceOf(Map)
+    expect(state.attachedPR).toBeInstanceOf(Map)
+    expect(state.prCreation.size).toBe(0)
+    expect(state.attachedPR.size).toBe(0)
   })
 
-  test('setPrState adds a new PR info entry', () => {
-    useGitStore.getState().setPrState('wt-1', {
-      state: 'creating',
-      sessionId: 'session-123',
-      targetBranch: 'origin/main'
-    })
-    const info = useGitStore.getState().prInfo.get('wt-1')
-    expect(info).toBeDefined()
-    expect(info?.state).toBe('creating')
-    expect(info?.sessionId).toBe('session-123')
-    expect(info?.targetBranch).toBe('origin/main')
-  })
-
-  test('setPrState updates existing entry', () => {
-    useGitStore.getState().setPrState('wt-1', { state: 'creating' })
-    useGitStore.getState().setPrState('wt-1', {
-      state: 'created',
-      prNumber: 42,
-      prUrl: 'https://github.com/org/repo/pull/42'
-    })
-    const info = useGitStore.getState().prInfo.get('wt-1')
-    expect(info?.state).toBe('created')
-    expect(info?.prNumber).toBe(42)
-    expect(info?.prUrl).toBe('https://github.com/org/repo/pull/42')
-  })
-
-  test('different worktrees have independent PR states', () => {
-    useGitStore.getState().setPrState('wt-1', { state: 'created', prNumber: 1 })
-    useGitStore.getState().setPrState('wt-2', { state: 'merged', prNumber: 2 })
-    expect(useGitStore.getState().prInfo.get('wt-1')?.state).toBe('created')
-    expect(useGitStore.getState().prInfo.get('wt-1')?.prNumber).toBe(1)
-    expect(useGitStore.getState().prInfo.get('wt-2')?.state).toBe('merged')
-    expect(useGitStore.getState().prInfo.get('wt-2')?.prNumber).toBe(2)
-  })
-
-  test('setPrState does not affect other worktree entries', () => {
-    useGitStore.getState().setPrState('wt-1', { state: 'creating', sessionId: 's1' })
-    useGitStore.getState().setPrState('wt-2', { state: 'none' })
-
-    // Update only wt-1
-    useGitStore.getState().setPrState('wt-1', {
-      state: 'created',
-      prNumber: 99,
-      prUrl: 'https://github.com/org/repo/pull/99'
+  test('setPrCreation adds an active PR creation entry', () => {
+    useGitStore.getState().setPrCreation('wt-1', {
+      creating: true,
+      sessionId: 'session-123'
     })
 
-    // wt-2 should be unchanged
-    const wt2Info = useGitStore.getState().prInfo.get('wt-2')
-    expect(wt2Info?.state).toBe('none')
-  })
-
-  test('prInfo supports all valid states', () => {
-    const states = ['none', 'creating', 'created', 'merged'] as const
-    for (const state of states) {
-      useGitStore.getState().setPrState('wt-test', { state })
-      expect(useGitStore.getState().prInfo.get('wt-test')?.state).toBe(state)
-    }
-  })
-
-  test('setPrState preserves optional fields when provided', () => {
-    useGitStore.getState().setPrState('wt-1', {
-      state: 'created',
-      prNumber: 42,
-      prUrl: 'https://github.com/org/repo/pull/42',
-      targetBranch: 'main',
-      sessionId: 'session-abc'
+    const creation = useGitStore.getState().prCreation.get('wt-1')
+    expect(creation).toEqual({
+      creating: true,
+      sessionId: 'session-123'
     })
-    const info = useGitStore.getState().prInfo.get('wt-1')
-    expect(info?.prNumber).toBe(42)
-    expect(info?.prUrl).toBe('https://github.com/org/repo/pull/42')
-    expect(info?.targetBranch).toBe('main')
-    expect(info?.sessionId).toBe('session-abc')
   })
 
-  test('prInfo is in-memory only (no persistence key)', () => {
-    // The store should not persist prInfo -- it resets on app restart
-    // Verify initial state is empty (no persisted data loaded)
+  test('setPrCreation updates and clears an existing entry', () => {
+    useGitStore.getState().setPrCreation('wt-1', {
+      creating: true,
+      sessionId: 'session-1'
+    })
+    useGitStore.getState().setPrCreation('wt-1', {
+      creating: true,
+      sessionId: 'session-2'
+    })
+
+    expect(useGitStore.getState().prCreation.get('wt-1')?.sessionId).toBe('session-2')
+
+    useGitStore.getState().setPrCreation('wt-1', null)
+    expect(useGitStore.getState().prCreation.get('wt-1')).toBeUndefined()
+  })
+
+  test('setAttachedPR tracks a persisted PR attachment', () => {
+    useGitStore.getState().setAttachedPR('wt-1', {
+      number: 42,
+      url: 'https://github.com/org/repo/pull/42'
+    })
+
+    expect(useGitStore.getState().attachedPR.get('wt-1')).toEqual({
+      number: 42,
+      url: 'https://github.com/org/repo/pull/42'
+    })
+  })
+
+  test('different worktrees have independent PR lifecycle state', () => {
+    useGitStore.getState().setPrCreation('wt-1', {
+      creating: true,
+      sessionId: 'session-1'
+    })
+    useGitStore.getState().setAttachedPR('wt-2', {
+      number: 2,
+      url: 'https://github.com/org/repo/pull/2'
+    })
+
+    expect(useGitStore.getState().prCreation.get('wt-1')?.sessionId).toBe('session-1')
+    expect(useGitStore.getState().attachedPR.get('wt-1')).toBeUndefined()
+    expect(useGitStore.getState().prCreation.get('wt-2')).toBeUndefined()
+    expect(useGitStore.getState().attachedPR.get('wt-2')?.number).toBe(2)
+  })
+
+  test('setAttachedPR clears an attachment without affecting creation state', () => {
+    useGitStore.getState().setPrCreation('wt-1', {
+      creating: true,
+      sessionId: 'session-1'
+    })
+    useGitStore.getState().setAttachedPR('wt-1', {
+      number: 42,
+      url: 'https://github.com/org/repo/pull/42'
+    })
+
+    useGitStore.getState().setAttachedPR('wt-1', null)
+
+    expect(useGitStore.getState().attachedPR.get('wt-1')).toBeUndefined()
+    expect(useGitStore.getState().prCreation.get('wt-1')?.creating).toBe(true)
+  })
+
+  test('PR lifecycle state is in-memory only', () => {
     const freshState = useGitStore.getState()
-    expect(freshState.prInfo.size).toBe(0)
+    expect(freshState.prCreation.size).toBe(0)
+    expect(freshState.attachedPR.size).toBe(0)
   })
 })

--- a/test/phase-20/session-4/pr-detection-hook.test.ts
+++ b/test/phase-20/session-4/pr-detection-hook.test.ts
@@ -11,10 +11,23 @@ vi.mock('../../../src/renderer/src/stores/useWorktreeStore', () => ({
   }
 }))
 
+function attachDetectedPr(worktreeId: string, text: string): void {
+  const creation = useGitStore.getState().prCreation.get(worktreeId)
+  const match = text.match(PR_URL_PATTERN)
+  if (!creation?.creating || !match) return
+
+  useGitStore.getState().setAttachedPR(worktreeId, {
+    number: parseInt(match[1], 10),
+    url: match[0]
+  })
+  useGitStore.getState().setPrCreation(worktreeId, null)
+}
+
 describe('Session 4: PR Detection Hook', () => {
   beforeEach(() => {
     useGitStore.setState({
-      prInfo: new Map()
+      prCreation: new Map(),
+      attachedPR: new Map()
     })
   })
 
@@ -64,183 +77,80 @@ describe('Session 4: PR Detection Hook', () => {
     })
   })
 
-  describe('PR state transition logic', () => {
-    test('transitions from creating to created when PR URL is detected', () => {
-      // Set initial state to 'creating'
-      useGitStore.getState().setPrState('wt-1', {
-        state: 'creating',
-        sessionId: 'session-1',
-        targetBranch: 'origin/main'
-      })
-
-      // Simulate what the hook does when a PR URL is found
-      const prInfo = useGitStore.getState().prInfo.get('wt-1')
-      expect(prInfo?.state).toBe('creating')
-
-      const text = 'I created a pull request: https://github.com/org/repo/pull/42'
-      const match = text.match(PR_URL_PATTERN)
-      expect(match).not.toBeNull()
-
-      if (match && prInfo && prInfo.state === 'creating') {
-        const prNumber = parseInt(match[1], 10)
-        useGitStore.getState().setPrState('wt-1', {
-          ...prInfo,
-          state: 'created',
-          prNumber,
-          prUrl: match[0]
-        })
-      }
-
-      // Verify transition
-      const updatedInfo = useGitStore.getState().prInfo.get('wt-1')
-      expect(updatedInfo?.state).toBe('created')
-      expect(updatedInfo?.prNumber).toBe(42)
-      expect(updatedInfo?.prUrl).toBe('https://github.com/org/repo/pull/42')
-      // Original fields preserved
-      expect(updatedInfo?.sessionId).toBe('session-1')
-      expect(updatedInfo?.targetBranch).toBe('origin/main')
-    })
-
-    test('does not transition when state is not creating', () => {
-      useGitStore.getState().setPrState('wt-1', {
-        state: 'created',
-        prNumber: 10,
-        prUrl: 'https://github.com/org/repo/pull/10'
-      })
-
-      const prInfo = useGitStore.getState().prInfo.get('wt-1')
-
-      // Hook would check state before transitioning
-      if (prInfo && prInfo.state === 'creating') {
-        // This should NOT execute
-        useGitStore.getState().setPrState('wt-1', {
-          ...prInfo,
-          state: 'created',
-          prNumber: 99
-        })
-      }
-
-      // State should be unchanged
-      const info = useGitStore.getState().prInfo.get('wt-1')
-      expect(info?.state).toBe('created')
-      expect(info?.prNumber).toBe(10)
-    })
-
-    test('does not transition when state is none', () => {
-      useGitStore.getState().setPrState('wt-1', { state: 'none' })
-
-      const prInfo = useGitStore.getState().prInfo.get('wt-1')
-      if (prInfo && prInfo.state === 'creating') {
-        useGitStore.getState().setPrState('wt-1', {
-          ...prInfo,
-          state: 'created',
-          prNumber: 99
-        })
-      }
-
-      expect(useGitStore.getState().prInfo.get('wt-1')?.state).toBe('none')
-    })
-
-    test('does not transition when state is merged', () => {
-      useGitStore.getState().setPrState('wt-1', { state: 'merged', prNumber: 5 })
-
-      const prInfo = useGitStore.getState().prInfo.get('wt-1')
-      if (prInfo && prInfo.state === 'creating') {
-        useGitStore.getState().setPrState('wt-1', {
-          ...prInfo,
-          state: 'created',
-          prNumber: 99
-        })
-      }
-
-      expect(useGitStore.getState().prInfo.get('wt-1')?.state).toBe('merged')
-    })
-
-    test('does not transition when no PR URL found in text', () => {
-      useGitStore.getState().setPrState('wt-1', {
-        state: 'creating',
+  describe('PR detection lifecycle side effects', () => {
+    test('moves from creating to attached when a PR URL is detected', () => {
+      useGitStore.getState().setPrCreation('wt-1', {
+        creating: true,
         sessionId: 'session-1'
       })
 
-      const text = 'I am working on creating the pull request now...'
-      const match = text.match(PR_URL_PATTERN)
-      expect(match).toBeNull()
+      attachDetectedPr('wt-1', 'I created a pull request: https://github.com/org/repo/pull/42')
 
-      // No transition should occur
-      const info = useGitStore.getState().prInfo.get('wt-1')
-      expect(info?.state).toBe('creating')
+      expect(useGitStore.getState().prCreation.get('wt-1')).toBeUndefined()
+      expect(useGitStore.getState().attachedPR.get('wt-1')).toEqual({
+        number: 42,
+        url: 'https://github.com/org/repo/pull/42'
+      })
     })
 
-    test('detects PR URL in tool output (gh pr create command)', () => {
-      useGitStore.getState().setPrState('wt-1', {
-        state: 'creating',
+    test('does not attach when PR creation is not active', () => {
+      attachDetectedPr('wt-1', 'Created PR: https://github.com/org/repo/pull/99')
+
+      expect(useGitStore.getState().prCreation.get('wt-1')).toBeUndefined()
+      expect(useGitStore.getState().attachedPR.get('wt-1')).toBeUndefined()
+    })
+
+    test('does not attach when no PR URL is found in text', () => {
+      useGitStore.getState().setPrCreation('wt-1', {
+        creating: true,
         sessionId: 'session-1'
       })
 
-      // Simulate tool output from gh pr create
-      const toolOutput =
+      attachDetectedPr('wt-1', 'I am working on creating the pull request now...')
+
+      expect(useGitStore.getState().prCreation.get('wt-1')?.creating).toBe(true)
+      expect(useGitStore.getState().attachedPR.get('wt-1')).toBeUndefined()
+    })
+
+    test('detects PR URL in tool output from gh pr create', () => {
+      useGitStore.getState().setPrCreation('wt-1', {
+        creating: true,
+        sessionId: 'session-1'
+      })
+
+      attachDetectedPr(
+        'wt-1',
         'Creating pull request for feature-branch into main\nhttps://github.com/org/repo/pull/55'
-      const match = toolOutput.match(PR_URL_PATTERN)
-      expect(match).not.toBeNull()
+      )
 
-      if (match) {
-        const prInfo = useGitStore.getState().prInfo.get('wt-1')
-        if (prInfo && prInfo.state === 'creating') {
-          const prNumber = parseInt(match[1], 10)
-          useGitStore.getState().setPrState('wt-1', {
-            ...prInfo,
-            state: 'created',
-            prNumber,
-            prUrl: match[0]
-          })
-        }
-      }
-
-      const info = useGitStore.getState().prInfo.get('wt-1')
-      expect(info?.state).toBe('created')
-      expect(info?.prNumber).toBe(55)
+      expect(useGitStore.getState().attachedPR.get('wt-1')).toEqual({
+        number: 55,
+        url: 'https://github.com/org/repo/pull/55'
+      })
     })
 
-    test('detects PR URL across accumulated text (simulating streaming deltas)', () => {
-      useGitStore.getState().setPrState('wt-1', {
-        state: 'creating',
+    test('detects PR URL across accumulated streaming deltas', () => {
+      useGitStore.getState().setPrCreation('wt-1', {
+        creating: true,
         sessionId: 'session-1'
       })
 
-      // Simulate incremental text accumulation as stream deltas arrive
       let accumulated = ''
-      const deltas = [
+      for (const delta of [
         'I created the PR at ',
         'https://github.com/',
         'org/repo/pull/',
         '123',
         ' successfully!'
-      ]
-
-      let detected = false
-      for (const delta of deltas) {
+      ]) {
         accumulated += delta
-        const match = accumulated.match(PR_URL_PATTERN)
-        if (match && !detected) {
-          detected = true
-          const prInfo = useGitStore.getState().prInfo.get('wt-1')
-          if (prInfo && prInfo.state === 'creating') {
-            const prNumber = parseInt(match[1], 10)
-            useGitStore.getState().setPrState('wt-1', {
-              ...prInfo,
-              state: 'created',
-              prNumber,
-              prUrl: match[0]
-            })
-          }
-        }
+        attachDetectedPr('wt-1', accumulated)
       }
 
-      expect(detected).toBe(true)
-      const info = useGitStore.getState().prInfo.get('wt-1')
-      expect(info?.state).toBe('created')
-      expect(info?.prNumber).toBe(123)
-      expect(info?.prUrl).toBe('https://github.com/org/repo/pull/123')
+      expect(useGitStore.getState().attachedPR.get('wt-1')).toEqual({
+        number: 123,
+        url: 'https://github.com/org/repo/pull/123'
+      })
     })
   })
 })

--- a/test/phase-22/session-4/codex-lifecycle.test.ts
+++ b/test/phase-22/session-4/codex-lifecycle.test.ts
@@ -78,10 +78,12 @@ describe('CodexImplementer lifecycle', () => {
 
       await impl.connect('/test/project', 'hive-session-1')
 
-      expect(mockManager.startSession).toHaveBeenCalledWith({
-        cwd: '/test/project',
-        model: CODEX_DEFAULT_MODEL
-      })
+      expect(mockManager.startSession).toHaveBeenCalledWith(
+        expect.objectContaining({
+          cwd: '/test/project',
+          model: CODEX_DEFAULT_MODEL
+        })
+      )
     })
 
     it('uses selected model when set', async () => {
@@ -101,10 +103,12 @@ describe('CodexImplementer lifecycle', () => {
 
       await impl.connect('/test', 'hive-1')
 
-      expect(mockManager.startSession).toHaveBeenCalledWith({
-        cwd: '/test',
-        model: 'gpt-5.3-codex'
-      })
+      expect(mockManager.startSession).toHaveBeenCalledWith(
+        expect.objectContaining({
+          cwd: '/test',
+          model: 'gpt-5.3-codex'
+        })
+      )
     })
 
     it('stores session state in local map', async () => {
@@ -147,9 +151,7 @@ describe('CodexImplementer lifecycle', () => {
         updatedAt: new Date().toISOString()
       })
 
-      await expect(impl.connect('/test', 'hive-1')).rejects.toThrow(
-        'no thread ID was returned'
-      )
+      await expect(impl.connect('/test', 'hive-1')).rejects.toThrow('no thread ID was returned')
     })
 
     it('sends session.materialized event to renderer', async () => {
@@ -173,11 +175,14 @@ describe('CodexImplementer lifecycle', () => {
 
       await impl.connect('/test', 'hive-session-3')
 
-      expect(mockWindow.webContents.send).toHaveBeenCalledWith('agent:stream', {
-        type: 'session.materialized',
-        sessionId: 'hive-session-3',
-        data: { newSessionId: 'thread-mat', wasFork: false }
-      })
+      expect(mockWindow.webContents.send).toHaveBeenCalledWith(
+        'agent:stream',
+        expect.objectContaining({
+          type: 'session.materialized',
+          sessionId: 'hive-session-3',
+          data: { newSessionId: 'thread-mat', wasFork: false }
+        })
+      )
     })
   })
 
@@ -240,11 +245,13 @@ describe('CodexImplementer lifecycle', () => {
       expect(result.sessionStatus).toBe('idle')
 
       // Verify manager was called with resume
-      expect(mockManager.startSession).toHaveBeenCalledWith({
-        cwd: '/test',
-        model: CODEX_DEFAULT_MODEL,
-        resumeThreadId: 'thread-old'
-      })
+      expect(mockManager.startSession).toHaveBeenCalledWith(
+        expect.objectContaining({
+          cwd: '/test',
+          model: CODEX_DEFAULT_MODEL,
+          resumeThreadId: 'thread-old'
+        })
+      )
     })
 
     it('stores the new session state', async () => {
@@ -444,9 +451,7 @@ describe('CodexImplementer lifecycle', () => {
 
   describe('implemented methods behavior', () => {
     it('prompt throws when session not found', async () => {
-      await expect(impl.prompt('/test', 'session-1', 'hello')).rejects.toThrow(
-        'session not found'
-      )
+      await expect(impl.prompt('/test', 'session-1', 'hello')).rejects.toThrow('session not found')
     })
 
     it('abort returns false for unknown session', async () => {

--- a/test/phase-22/session-5/codex-prompt-streaming.test.ts
+++ b/test/phase-22/session-5/codex-prompt-streaming.test.ts
@@ -52,6 +52,7 @@ vi.mock('../../../src/main/services/codex-app-server-manager', () => {
     listSessions: vi.fn().mockReturnValue([]),
     setThreadGoal: vi.fn(),
     sendTurn: vi.fn(),
+    readThread: vi.fn(),
     on: vi.fn().mockImplementation((_event: string, handler: any) => {
       eventListeners.push(handler)
     }),
@@ -121,6 +122,12 @@ describe('CodexImplementer.prompt()', () => {
       }, 5)
       return { turnId: 'turn-1', threadId: 'thread-1' }
     })
+  }
+
+  function emitManagerEvent(event: any) {
+    for (const listener of [...eventListeners]) {
+      listener(event)
+    }
   }
 
   // ── Basic prompt flow ───────────────────────────────────────
@@ -654,6 +661,159 @@ describe('CodexImplementer.prompt()', () => {
     await impl.prompt('/test/project', 'thread-1', 'test')
 
     expect(session.status).toBe('error')
+  })
+
+  // ── Run / turn isolation ─────────────────────────────────────
+
+  it('does not resolve the current prompt from a different turn completion', async () => {
+    const session = seedSession()
+    mockManager.sendTurn.mockResolvedValue({ turnId: 'turn-b', threadId: 'thread-1' })
+
+    let settled = false
+    const promptPromise = impl.prompt('/test/project', 'thread-1', 'Current prompt').then(() => {
+      settled = true
+    })
+
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(mockManager.sendTurn).toHaveBeenCalled()
+
+    emitManagerEvent({
+      id: 'wrong-turn',
+      kind: 'notification',
+      provider: 'codex',
+      threadId: 'thread-1',
+      turnId: 'turn-a',
+      createdAt: new Date().toISOString(),
+      method: 'turn/completed',
+      payload: { turn: { id: 'turn-a', status: 'completed' } }
+    })
+
+    await new Promise((resolve) => setTimeout(resolve, 10))
+    expect(settled).toBe(false)
+    expect(session.status).toBe('running')
+
+    emitManagerEvent({
+      id: 'right-turn',
+      kind: 'notification',
+      provider: 'codex',
+      threadId: 'thread-1',
+      turnId: 'turn-b',
+      createdAt: new Date().toISOString(),
+      method: 'turn/completed',
+      payload: { turn: { id: 'turn-b', status: 'completed' } }
+    })
+
+    await promptPromise
+    expect(settled).toBe(true)
+    expect(session.status).toBe('ready')
+  })
+
+  it('settles an interrupted turn without waiting for timeout', async () => {
+    const session = seedSession()
+    mockManager.sendTurn.mockResolvedValue({ turnId: 'turn-stop', threadId: 'thread-1' })
+
+    const promptPromise = impl.prompt('/test/project', 'thread-1', 'Stop me')
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    emitManagerEvent({
+      id: 'interrupted',
+      kind: 'session',
+      provider: 'codex',
+      threadId: 'thread-1',
+      turnId: 'turn-stop',
+      createdAt: new Date().toISOString(),
+      method: 'turn/interrupted',
+      message: 'Turn interrupted'
+    })
+
+    await promptPromise
+    expect(session.status).toBe('ready')
+    expect(session.activeRun).toBeNull()
+  })
+
+  it('ignores a stale thread/read snapshot after a newer prompt has completed', async () => {
+    const session = seedSession()
+    let sendCount = 0
+    let resolveReadA: ((value: unknown) => void) | null = null
+
+    mockManager.sendTurn.mockImplementation(async () => {
+      sendCount += 1
+      return { turnId: sendCount === 1 ? 'turn-a' : 'turn-b', threadId: 'thread-1' }
+    })
+
+    mockManager.readThread
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveReadA = resolve
+          })
+      )
+      .mockResolvedValueOnce({
+        thread: {
+          id: 'thread-1',
+          turns: [
+            {
+              id: 'turn-a',
+              input: [{ type: 'text', text: 'Prompt A' }],
+              outputText: 'Reply A'
+            },
+            {
+              id: 'turn-b',
+              input: [{ type: 'text', text: 'Prompt B' }],
+              outputText: 'Reply B'
+            }
+          ]
+        }
+      })
+
+    const promptA = impl.prompt('/test/project', 'thread-1', 'Prompt A')
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    emitManagerEvent({
+      id: 'a-complete',
+      kind: 'notification',
+      provider: 'codex',
+      threadId: 'thread-1',
+      turnId: 'turn-a',
+      createdAt: new Date().toISOString(),
+      method: 'turn/completed',
+      payload: { turn: { id: 'turn-a', status: 'completed' } }
+    })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    const promptB = impl.prompt('/test/project', 'thread-1', 'Prompt B')
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    emitManagerEvent({
+      id: 'b-complete',
+      kind: 'notification',
+      provider: 'codex',
+      threadId: 'thread-1',
+      turnId: 'turn-b',
+      createdAt: new Date().toISOString(),
+      method: 'turn/completed',
+      payload: { turn: { id: 'turn-b', status: 'completed' } }
+    })
+    await promptB
+
+    resolveReadA?.({
+      thread: {
+        id: 'thread-1',
+        turns: [
+          {
+            id: 'turn-a',
+            input: [{ type: 'text', text: 'Prompt A' }],
+            outputText: 'Stale Reply A'
+          }
+        ]
+      }
+    })
+    await promptA
+
+    const texts = session.messages.flatMap((message: any) =>
+      (message.parts ?? []).map((part: any) => part.text).filter(Boolean)
+    )
+    expect(texts).toContain('Prompt B')
+    expect(texts).toContain('Reply B')
+    expect(texts).not.toContain('Stale Reply A')
   })
 
   // ── Session not found ───────────────────────────────────────

--- a/test/phase-22/session-6/codex-abort-getmessages.test.ts
+++ b/test/phase-22/session-6/codex-abort-getmessages.test.ts
@@ -373,6 +373,76 @@ describe('Codex Abort & getMessages', () => {
       const result = await impl.abort('/test', 'thread-abort-1')
       expect(result).toBe(true) // Still succeeds
     })
+
+    it('materializes live assistant draft before clearing an aborted run', async () => {
+      const { CodexImplementer } = await import('../../../src/main/services/codex-implementer')
+      const impl = new CodexImplementer()
+      const internalManager = impl.getManager() as any
+      const mockWindow = {
+        isDestroyed: () => false,
+        webContents: { send: vi.fn() }
+      }
+      impl.setMainWindow(mockWindow as any)
+
+      const session = {
+        threadId: 'thread-abort-1',
+        hiveSessionId: 'hive-abort-1',
+        worktreePath: '/test',
+        status: 'running' as const,
+        messages: [],
+        liveAssistantDraft: {
+          id: 'codex-live-thread-abort-1',
+          timestamp: '2026-01-01T00:00:00.000Z',
+          parts: [
+            { type: 'text', text: 'Partial answer', timestamp: '2026-01-01T00:00:00.000Z' },
+            {
+              type: 'tool',
+              callID: 'tool-1',
+              tool: 'Bash',
+              state: {
+                status: 'running',
+                input: { command: 'pnpm test' },
+                output: 'running...'
+              }
+            }
+          ],
+          toolIndexById: new Map([['tool-1', 1]])
+        },
+        activeRun: {
+          runId: 'run-abort-1',
+          expectedTurnId: 'turn-live-1',
+          state: 'running' as const,
+          startedAt: Date.now(),
+          abortController: new AbortController()
+        },
+        settledRunIds: new Set<string>(),
+        revertMessageID: null,
+        revertDiff: null,
+        titleGenerated: false,
+        titleGenerationStarted: false
+      }
+      impl.getSessions().set('/test::thread-abort-1', session)
+
+      internalManager.interruptTurn = vi.fn().mockResolvedValue(undefined)
+
+      const result = await impl.abort('/test', 'thread-abort-1')
+
+      expect(result).toBe(true)
+      expect(internalManager.interruptTurn).toHaveBeenCalledWith('thread-abort-1', 'turn-live-1')
+      expect(session.liveAssistantDraft).toBeNull()
+      expect(session.activeRun).toBeNull()
+
+      const assistant = session.messages[0] as any
+      expect(assistant.role).toBe('assistant')
+      expect(assistant.aborted).toBe(true)
+      expect(assistant.parts[0].text).toBe('Partial answer')
+      expect(assistant.parts[1].state.status).toBe('cancelled')
+      expect(assistant.parts[1].state.output).toBe('running...')
+
+      const messages = await impl.getMessages('/test', 'thread-abort-1')
+      expect(messages).toHaveLength(1)
+      expect((messages[0] as any).aborted).toBe(true)
+    })
   })
 
   // ── CodexImplementer.getMessages ────────────────────────────────
@@ -556,11 +626,13 @@ describe('Codex Abort & getMessages', () => {
 
       const messages = await impl.getMessages('/test', 'thread-msg-1')
 
-      expect(internalManager.startSession).toHaveBeenCalledWith({
-        cwd: '/test',
-        model: impl.getSelectedModel(),
-        resumeThreadId: 'thread-msg-1'
-      })
+      expect(internalManager.startSession).toHaveBeenCalledWith(
+        expect.objectContaining({
+          cwd: '/test',
+          model: impl.getSelectedModel(),
+          resumeThreadId: 'thread-msg-1'
+        })
+      )
       expect(internalManager.readThread).toHaveBeenCalledWith('thread-msg-1')
       expect(messages).toHaveLength(2)
       expect((messages[0] as any).parts[0].text).toBe('Recovered question')

--- a/test/phase-23/session-send-actions.test.ts
+++ b/test/phase-23/session-send-actions.test.ts
@@ -272,6 +272,16 @@ describe('executeSendAction', () => {
     expect(ctx.prompt).not.toHaveBeenCalled()
   })
 
+  it('queue: uses queueSessionId for runtime store bookkeeping when provided', async () => {
+    const ctx = makeSendContext({ queueSessionId: 'db-sess-1' })
+    const result = await executeSendAction('queue', 'later', [], ctx)
+
+    expect(result).toBe(true)
+    expect(ctx.queueMessage).toHaveBeenCalledWith('db-sess-1', expect.objectContaining({
+      content: 'later'
+    }))
+  })
+
   it('steer: calls steer IPC (sends while busy)', async () => {
     const ctx = makeSendContext()
     const result = await executeSendAction('steer', 'change direction', [], ctx)
@@ -302,11 +312,15 @@ describe('executeSendAction', () => {
       callOrder.push('prompt')
       return { success: true }
     })
+    ctx.waitForAbortReady = vi.fn(async () => {
+      callOrder.push('wait')
+    })
 
     const result = await executeSendAction('stop_and_send', 'new task', [], ctx)
     expect(result).toBe(true)
-    expect(callOrder).toEqual(['abort', 'prompt'])
+    expect(callOrder).toEqual(['abort', 'wait', 'prompt'])
     expect(ctx.abort).toHaveBeenCalledWith('/test/path', 'sess-1')
+    expect(ctx.waitForAbortReady).toHaveBeenCalledTimes(1)
     expect(ctx.prompt).toHaveBeenCalledWith('/test/path', 'sess-1', 'new task')
   })
 

--- a/test/phase-23/session-shell-plan-implement-source.test.ts
+++ b/test/phase-23/session-shell-plan-implement-source.test.ts
@@ -95,4 +95,18 @@ describe('SessionShell plan implement flow (source verification)', () => {
     expect(source).toContain('setGoalMode(false)')
     expect(source).toContain("setSuccessCriteria('')")
   })
+
+  test('composer queue and stop-and-send use runtime boundaries, not guessed sleeps', async () => {
+    const fs = await import('fs')
+    const path = await import('path')
+    const source = fs.readFileSync(
+      path.resolve(__dirname, '../../src/renderer/src/components/session-hq/SessionShell.tsx'),
+      'utf-8'
+    )
+
+    expect(source).toContain('function waitForSessionIdleAfterAbort')
+    expect(source).toContain('queueSessionId: sessionId')
+    expect(source).toContain('waitForAbortReady: () => waitForSessionIdleAfterAbort(sessionId)')
+    expect(source).toContain("if (action === 'send' || action === 'stop_and_send') {")
+  })
 })

--- a/test/phase-23/session-shell-thread-status-source.test.ts
+++ b/test/phase-23/session-shell-thread-status-source.test.ts
@@ -43,7 +43,7 @@ describe('SessionShell thread status flow (source verification)', () => {
     expect(source).toContain('hasDurableCompactionMessage')
   })
 
-  test('clears active overlays in finally while preserving compaction chips', async () => {
+  test('keeps completed overlays readable after idle instead of clearing them in finally', async () => {
     const fs = await import('fs')
     const path = await import('path')
     const source = fs.readFileSync(
@@ -56,8 +56,9 @@ describe('SessionShell thread status flow (source verification)', () => {
 
     expect(source).toContain('void refresh()')
     expect(source).toContain('.finally(() => {')
-    expect(source).toContain('clearStreamingBufferOverlay(sessionId, {')
-    expect(source).toContain('preserveCompactionState: true')
+    expect(source).toContain('do NOT clearStreamingBufferOverlay here')
+    expect(source).toContain('already set isStreaming=false')
+    expect(source).toContain('next user message will')
   })
 
   test('wires new UI user-message edit and fork flows into AgentTimeline', async () => {

--- a/test/phase-23/use-session-runtime-store.test.ts
+++ b/test/phase-23/use-session-runtime-store.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import {
+  ACTIVITY_TOUCH_THROTTLE_MS,
   clearStreamingBuffer,
   clearStreamingBufferOverlay,
   getStreamingBufferSnapshot,
@@ -28,6 +29,10 @@ beforeEach(() => {
   for (const sessionId of state.dismissedGoalSignatures.keys()) {
     state.clearSession(sessionId)
   }
+})
+
+afterEach(() => {
+  vi.useRealTimers()
 })
 
 describe('useSessionRuntimeStore', () => {
@@ -102,6 +107,35 @@ describe('useSessionRuntimeStore', () => {
       useSessionRuntimeStore.getState().touchActivity('sess-1')
       const state = useSessionRuntimeStore.getState().getSession('sess-1')
       expect(state.lastActivityAt).toBeGreaterThanOrEqual(before)
+    })
+
+    it('throttles repeated activity touches within the window', () => {
+      vi.useFakeTimers()
+      vi.setSystemTime(1_000_000)
+
+      let notificationCount = 0
+      const unsubscribe = useSessionRuntimeStore.subscribe(() => {
+        notificationCount += 1
+      })
+
+      useSessionRuntimeStore.getState().touchActivity('sess-1')
+      const initialState = useSessionRuntimeStore.getState().getSession('sess-1')
+      expect(initialState.lastActivityAt).toBe(1_000_000)
+      expect(notificationCount).toBe(1)
+
+      vi.setSystemTime(1_000_000 + ACTIVITY_TOUCH_THROTTLE_MS - 1)
+      useSessionRuntimeStore.getState().touchActivity('sess-1')
+      const throttledState = useSessionRuntimeStore.getState().getSession('sess-1')
+      expect(throttledState.lastActivityAt).toBe(1_000_000)
+      expect(notificationCount).toBe(1)
+
+      vi.setSystemTime(1_000_000 + ACTIVITY_TOUCH_THROTTLE_MS)
+      useSessionRuntimeStore.getState().touchActivity('sess-1')
+      const updatedState = useSessionRuntimeStore.getState().getSession('sess-1')
+      expect(updatedState.lastActivityAt).toBe(1_000_000 + ACTIVITY_TOUCH_THROTTLE_MS)
+      expect(notificationCount).toBe(2)
+
+      unsubscribe()
     })
   })
 


### PR DESCRIPTION
## Summary
- harden Codex turn lifecycle and stale completion guards
- route renderer-side PR detection through runtime events
- reduce Session HQ hot-path churn around runtime state
- add 1.4.9 infra stability planning docs

## Stack
Base layer of the infra stack.

## Verification
Verified on top of the full stack before splitting:
- pnpm vitest run test/context-panel/context-panel-host-tabs.test.tsx test/xfp/audit.test.ts test/xfp/agent-prompt-xfp-policy.test.ts test/xfp/claude-mcp-server.test.ts test/phase-21/field-events/field-handlers.test.ts test/phase-21/session-4/claude-prompt-streaming.test.ts test/phase-22/session-5/codex-prompt-streaming.test.ts
- pnpm vitest run test/xfp
- pnpm lint
- git diff --check
- pnpm build