### PR TITLE
fix(hub): stabilize mobile runtime streaming

### DIFF
--- a/docs/architecture/hub.md
+++ b/docs/architecture/hub.md
@@ -39,7 +39,7 @@
 
 1. **零侵入** — Claude/Codex/OpenCode 的 implementer 文件未修改。fan-out 完全在 `wrapBrowserWindow` Proxy 里：拦截 `webContents.send(channel, ...)`，只对 `channel==='agent:stream'` 分流给 HubBridge。
 2. **loopback-only 监听** — `HubServer` 只 bind `127.0.0.1`（v6 fallback `::1`）。公网暴露必须走 `cloudflared` 子进程，从设计上杜绝误操作。
-3. **桌面端二次确认不可由移动端跳过** — `HubBridge.handleClientMessage` 对 `prompt` frame 强制走 `PromptConfirmer.confirm()`，30s 超时返回 `CONFIRM_TIMEOUT`。
+3. **prompt 直达 runtime** — 移动端通过 Hub 鉴权和 Origin 校验后，`HubBridge.handleClientMessage` 会把 `prompt` 直接路由到 owning runtime。这里不再有 per-prompt approval gate；公网场景应使用强密码或 Cloudflare Access。
 4. **消息幂等** — 每个 ServerMsg 都带单调 `seq`（per-session `SeqCounter`）；reconnect 用 `resume{lastSeq}` 从 `MessageRingBuffer` 重播（容量 500 帧）。buffer 被挤出就回 `NEED_FULL_RELOAD`，客户端走 REST `/api/sessions/:id/history` 全量回填。
 
 ## 文件地图
@@ -77,11 +77,13 @@ ClaudeCodeImplementer.emitAgentEvent
                     (every subscriber WebSocket gets JSON)
 ```
 
-**翻译策略（loose, lossless）：**
+**翻译策略（loose, best-effort）：**
 - `session.status` → `status` frame (filter: idle/busy/retry/error)
 - `permission.asked` → `permission/request` frame
 - `question.asked` → `question/request` frame
-- 其他 CanonicalAgentEvent → `message/append` 带单个 `UnknownPart{raw:event}`（保证不丢数据）
+- `plan.ready` / `command_approval.requested` → 对应交互卡
+- 常见 `message.updated` / `message.part.updated` → 文本、工具调用和工具结果 frame
+- 其他未建模 CanonicalAgentEvent 可能暂时跳过；不要把 Hub live stream 当成完整 lossless event log
 
 ### 手机 → 桌面（inbound）
 
@@ -93,10 +95,7 @@ HubServer WS route → bridge.handleClientMessage(ws, hiveSessionId, raw)
   │
   ├─ ClientMsgSchema.parse (zod)
   │
-  ├─ 'prompt' → PromptConfirmer.confirm{confirmId, preview}
-  │      │    ├─ resolve{approved:true}  → runtime.prompt(wt, sid, text)
-  │      │    └─ resolve{approved:false} → error BAD_REQUEST 'rejected'
-  │      │    └─ 30s timeout              → error CONFIRM_TIMEOUT
+  ├─ 'prompt' → routingResolver / cached routing → runtime.prompt(wt, sid, text)
   │
   ├─ 'interrupt' → runtime.abort(wt, sid)
   │
@@ -117,7 +116,7 @@ Schema v17 (`src/main/db/schema.ts` 第 445-500 行)。五张表：
 | `hub_tokens` | M2 agent/PWA token；prefix 索引 + sha256 哈希 |
 | `hub_cookie_sessions` | UI 7 天 Cookie；expires 索引 |
 | `hub_devices` | M2 多设备；M1 只填本机一条 |
-| `hub_settings` | 键值存储：auth_mode、require_desktop_confirm、cf_access_emails (JSON)、tunnel_url |
+| `hub_settings` | 键值存储：auth_mode、cf_access_emails (JSON)、tunnel_url |
 
 ## 鉴权矩阵
 
@@ -140,7 +139,7 @@ Origin 检查：允许 `http://127.0.0.1:<port>` + `http://[::1]:<port>` + `http
 | `test/server/hub-auth.test.ts` | scrypt 盐哈希往返、rate limiter 滑窗、CF Access header / Origin check | 14 tests |
 | `test/server/hub-protocol.test.ts` | zod schema 正/反例、RingBuffer 驱逐 + NEED_FULL_RELOAD、SeqCounter 单调 | 18 tests |
 | `test/server/hub-registry.test.ts` | 订阅/取消、broadcast 丢失 WS 清理、status 传递 | 9 tests |
-| `test/server/hub-bridge.test.ts` | Proxy 拦截、runtimeId 过滤、翻译、CONFIRM_TIMEOUT、resume 回放 | 11 tests |
+| `test/server/hub-bridge.test.ts` | Proxy 拦截、多 runtime 翻译、prompt 直达 runtime、resume 回放 | 11 tests |
 | `test/server/hub-server.test.ts` | 集成（真 fetch）：setup/login/me/logout、四种鉴权、Origin、路由 404 | 22 tests |
 | `test/server/tunnel-service.test.ts` | 假 spawn：启动/URL 解析、无二进制、退避链、reset、手动 stop | 8 tests |
 
@@ -163,7 +162,7 @@ Origin 检查：允许 `http://127.0.0.1:<port>` + `http://[::1]:<port>` + `http
 
 ## 已知折中
 
-- **UnknownPart 回退**：代价是手机消息流里很多事件是 `agent activity` 折叠 JSON；好处是任何未来的 CanonicalAgentEvent 都不会掉。M1.5 会把常见 `message.updated` / `tool.called` 专门翻译。
+- **live event 保真度**：Hub 已经专门翻译常见 status / permission / question / plan / command approval / message / tool 输出事件，但未建模事件不是完整兜底。需要继续补专用 frame 或移动端活动展示，而不是假设所有 CanonicalAgentEvent 都能无损到达手机。
 - **Ring buffer 容量 500**：长会话或慢 reconnect 会触发 `NEED_FULL_RELOAD`。mobile 已经实现 fallback 路径，但用户体验是"白屏一秒后满血"。调大容量的代价是内存。
 - **Mobile bundle 92KB gzip**：没有 react-markdown / qrcode 等大库。代价是 MiniMarkdown 能力弱（仅 fence / inline / bold）。
 - **CSRF 靠 Origin/Referer**：没发 CSRF token（loopback + SameSite=Lax 已经挡住 80% 场景）。M2 加 CSRF token。

--- a/docs/architecture/hub.md
+++ b/docs/architecture/hub.md
@@ -81,8 +81,9 @@ ClaudeCodeImplementer.emitAgentEvent
 - `session.status` → `status` frame (filter: idle/busy/retry/error)
 - `permission.asked` → `permission/request` frame
 - `question.asked` → `question/request` frame
-- `plan.ready` / `command_approval.requested` → 对应交互卡
+- `plan.ready` / `command.approval_needed` → 对应交互卡
 - 常见 `message.updated` / `message.part.updated` → 文本、工具调用和工具结果 frame
+- `session.turn_diff` → 可更新的 `diff` 卡；同一 turn 的累计 diff 用 `replacePart` 更新，避免刷屏
 - 其他未建模 CanonicalAgentEvent 可能暂时跳过；不要把 Hub live stream 当成完整 lossless event log
 
 ### 手机 → 桌面（inbound）
@@ -162,7 +163,7 @@ Origin 检查：允许 `http://127.0.0.1:<port>` + `http://[::1]:<port>` + `http
 
 ## 已知折中
 
-- **live event 保真度**：Hub 已经专门翻译常见 status / permission / question / plan / command approval / message / tool 输出事件，但未建模事件不是完整兜底。需要继续补专用 frame 或移动端活动展示，而不是假设所有 CanonicalAgentEvent 都能无损到达手机。
+- **live event 保真度**：Hub 已经专门翻译常见 status / permission / question / plan / command approval / message / tool 输出 / turn diff 事件，但未建模事件不是完整兜底。需要继续补专用 frame 或移动端活动展示，而不是假设所有 CanonicalAgentEvent 都能无损到达手机。
 - **Ring buffer 容量 500**：长会话或慢 reconnect 会触发 `NEED_FULL_RELOAD`。mobile 已经实现 fallback 路径，但用户体验是"白屏一秒后满血"。调大容量的代价是内存。
 - **Mobile bundle 92KB gzip**：没有 react-markdown / qrcode 等大库。代价是 MiniMarkdown 能力弱（仅 fence / inline / bold）。
 - **CSRF 靠 Origin/Referer**：没发 CSRF token（loopback + SameSite=Lax 已经挡住 80% 场景）。M2 加 CSRF token。

--- a/docs/hub-e2e-checklist.md
+++ b/docs/hub-e2e-checklist.md
@@ -51,19 +51,16 @@ pnpm dev
 - [ ] 登录 → 看到设备 → 选会话
 - [ ] curl 桌面 `https://xxx.trycloudflare.com/health` → `{"ok":true}`
 
-## 4. 桌面端二次确认
+## 4. Prompt 直达 runtime
 
-- [ ] tunnel 开启状态下，**确认面板里「桌面端二次确认」开关变灰且强制 ON**
 - [ ] 手机端在 PromptComposer 输入「ls」点发送
-- [ ] 桌面端右下角弹 sonner toast「手机请求执行 prompt: ls」+ 批准/拒绝
-- [ ] 桌面点「批准」→ 手机看到 user bubble + claude 开始流式回复
-- [ ] 重新发一条 prompt，桌面 30 秒不点 → 手机收到 `CONFIRM_TIMEOUT` 错误条
-- [ ] 关 tunnel，再关「二次确认」开关 → 此时手机 prompt 直接执行无 toast
+- [ ] 手机立即看到 user bubble，桌面端不出现 approval toast
+- [ ] 对应 Claude Code / Codex / OpenCode session 开始流式回复
+- [ ] 错误路径：断开桌面 runtime 或使用不存在的 session → 手机收到明确错误条，而不是静默卡住
 
 ## 5. 中断长任务
 
 - [ ] 发一条会跑很久的 prompt（如「写一个完整的 React 项目脚手架」）
-- [ ] 桌面批准
 - [ ] 手机「发送」按钮变成红色「中断」
 - [ ] 点「中断」→ runtime.abort 触发，桌面端 claude 进程立刻停
 - [ ] 手机端 status 变回 idle
@@ -84,7 +81,7 @@ pnpm dev
 - [ ] 手机连接条变红「已断开，尝试重连中」
 - [ ] 5-10 秒（指数退避 1s/2s/4s）后变绿
 - [ ] 在断线期间桌面继续产生的消息 **应该被回放出来**（来自 ringBuffer.replayAfter(lastSeq)）
-- [ ] 极端：让 server 停 60 秒以上 + 期间产生 > 500 帧 → 收到 `NEED_FULL_RELOAD` 错误条，**手动刷新页面**应能从 REST `/api/sessions/:id/history` 拉到完整历史
+- [ ] 极端：让 server 停 60 秒以上 + 期间产生 > 500 帧 → 收到 `NEED_FULL_RELOAD` 后，手机端应自动 REST reload `/api/sessions/:id/history` 并恢复完整历史
 
 ## 8. Rate Limit
 
@@ -135,8 +132,7 @@ pnpm dev
 
 | Symptom | 状态 |
 | :-- | :-- |
-| Codex / OpenCode 会话在手机端不可见 | M1.5 |
-| 消息流大量 `agent activity` JSON 折叠卡 | M1.5 翻译常见类型 |
+| 少量未建模 runtime event 只有简化活动展示 | 继续补专用卡片 |
 | 没有文件附件上传 | M2 |
 | Hub 状态栏没有 PWA 图标提示 | M2 |
 | 无 Service Worker 离线壳 | M2 |
@@ -145,6 +141,6 @@ pnpm dev
 
 ## 路线
 
-- **M1.5**：Codex + OpenCode；消息流富渲染（MarkDown / Diff）；附件 base64 上传
+- **M1.5**：消息流富渲染（Markdown / Diff）；附件 base64 上传；更多 runtime 事件专用卡片
 - **M2**：xuanpu-agent (其他电脑 → 你的 Hub) ；Token 鉴权；PWA Service Worker；CSRF Token
 - **M3**：端到端加密；DHT / 无中心 relay

--- a/docs/hub-mobile.md
+++ b/docs/hub-mobile.md
@@ -1,6 +1,6 @@
 # Hub 模式：手机远程访问（M1）
 
-> 让手机或平板通过浏览器远程查看、控制你的 Claude Code 会话。  
+> 让手机或平板通过浏览器远程查看、控制你的 Claude Code / Codex / OpenCode 会话。
 > 无需账号、无需额外工具，桌面端一次开关即用。
 
 ## 快速开始
@@ -25,11 +25,11 @@ Xuanpu Hub 默认只接受 **loopback（127.0.0.1 / ::1）** 连接。公网暴�
 | **cf_access** | 公网暴露 **推荐** | 使用 Cloudflare Access 前置，信任 `CF-Access-Authenticated-User-Email` + 白名单 |
 | **hybrid** | 过渡切换 | 以上任一方式通过即放行 |
 
-### 桌面端二次确认
+### Prompt 执行策略
 
-默认开启：手机发起的每条 prompt，都会在桌面端弹 Toast 让你 **批准 / 拒绝**，30 秒超时视为拒绝。
+移动端 prompt 在 Hub 鉴权和 Origin 校验通过后会直接进入对应 runtime。Xuanpu 目前不再提供每条 prompt 的 desktop approval gate。
 
-> **公网访问开启时此开关强制为 ON，无法关闭**。这是 Xuanpu 防止 Hub URL 泄漏后被滥用的最后一道闸门。
+公网访问建议使用 Cloudflare Access，并在 Hub 面板里切到 `cf_access` 或 `hybrid` 模式；不要把只靠密码的 trycloudflare URL 长期公开给不可信网络。
 
 ### 登录限流
 
@@ -71,23 +71,19 @@ Xuanpu Hub 默认只接受 **loopback（127.0.0.1 / ::1）** 连接。公网暴�
 
 ### 手机 prompt 发出后卡住
 
-- 桌面端 Toast 被你忽略了 → 30 秒后会返回 `CONFIRM_TIMEOUT` 错误
-- 关掉二次确认开关（仅内网建议）
-
-### 二次确认开关是灰的
-
-公网隧道开启时会强制 ON。先关 tunnel 再改。
+- 会话正在等待 permission / question / plan / command approval，先在手机端处理对应卡片
+- runtime 本身仍在 busy，等待当前 turn 结束或点「中断」
+- WebSocket 断线后会自动 resume；如果 ring buffer gap 被挤出，客户端会自动通过 REST history reload 回填
 
 ## 已知限制（M1）
 
-- **仅 Claude Code**：Codex / OpenCode 会话在手机端不可见（M1.5）
 - **不支持文件附件上传**：手机端只能发文本 prompt
-- **消息流是"agent activity"JSON dump**：复杂工具调用目前没有专用 UI（M2 补）
+- **部分复杂事件仍是简化渲染**：常见 status / permission / question / plan / command approval / tool 输出已翻译，少数未建模事件可能只显示为简化活动
 - **没有深色/浅色切换**：手机端固定深色
 - **没有 PWA 离线壳**：刷新需要网络（M2 加 Service Worker）
 
 ## 后续路线
 
-- **M1.5**：Codex + OpenCode 接入、消息流富渲染（MarkDown/Diff）
+- **M1.5**：消息流富渲染（Markdown / Diff）、更多 runtime 事件专用卡片
 - **M2**：Agent 模式（装 xuanpu-agent 的其他电脑汇报给 Hub）、Token 鉴权、PWA 离线壳
 - **M3**：端到端加密、无中心（DHT）

--- a/docs/plans/2026-05-17-v1.4.9-stability-closure.md
+++ b/docs/plans/2026-05-17-v1.4.9-stability-closure.md
@@ -124,10 +124,11 @@ Codex 的稳定性更依赖 main-process 里的 canonical 化：
 - prompt policy 已统一为直达 runtime；旧桌面确认设置的死 helper、设置注释、Hub 架构文档、mobile 文档和 E2E checklist 已清理成单口径
 - `NEED_FULL_RELOAD` 已从“普通错误条”升级为 mobile 自动 REST reload `/api/sessions/:id/history`，并在 reload 后推进 WebSocket `lastSeq`
 - Hub reconnect 关键行为已有测试锁住：`test/mobile/hub-websocket.test.ts` 覆盖 close → reconnect → open 后带 `resume{lastSeq}`；`test/server/hub-bridge.test.ts` 覆盖 replay gap 被挤出时返回 `NEED_FULL_RELOAD`
+- Codex `session.turn_diff` 已通过 Hub 转成 mobile `diff` 卡；同一 turn 的累计 diff 用 `replacePart` 更新，避免每次 diff update 都追加新卡
 
 仍有一个明显问题：
 
-- Hub live stream 不是完整 lossless：`message.part.updated`、status、permission/question/plan/command approval 等常见事件有专门翻译，部分未建模 live event 会被跳过；`UnknownPart` 主要还体现在协议能力和部分历史映射，不应当把它描述成所有 live event 的兜底
+- Hub live stream 不是完整 lossless：`message.part.updated`、status、permission/question/plan/command approval、turn diff 等常见事件有专门翻译，部分未建模 live event 会被跳过；`UnknownPart` 主要还体现在协议能力和部分历史映射，不应当把它描述成所有 live event 的兜底
 - 这意味着远程控制的“运行时合同”和 prompt policy 已经统一，但 live event 信息保真度还需要继续补
 
 这不是“小差异”，这是远程控制从“能操作”走向“可回放、可解释”的剩余缺口。
@@ -167,7 +168,7 @@ Codex 的稳定性更依赖 main-process 里的 canonical 化：
 | Run guard | `sessionSequence` + `runEpoch` 已存在 | 行为合同主要靠 store 守卫，缺少端到端验收 | 乱序 / 晚到事件可能只在边界条件暴露 | P1 |
 | Hub replay | `seq` / `resume` / ring buffer 已实现；mobile `HubWebSocket` reconnect 会带上最新 `lastSeq` | 还缺不依赖本地 SQLite native ABI 的真 server WS 集成测试 | 断线恢复核心客户端/bridge 语义已有防回归，真 socket 路径仍需补 | P1 |
 | Hub full reload | server 能发 `NEED_FULL_RELOAD`，mobile 会自动 REST 拉 `/api/sessions/:id/history` 并推进 `lastSeq`；bridge gap-evicted 分支已有测试 | 还缺真 server WS + REST reload 组合测试 | 长断线恢复需要继续防回归 | P1 |
-| Hub live translation | 常见 live event 已翻译 | 未建模 live event 不是全量 `UnknownPart` 兜底 | 手机端可能丢状态或只看到不完整过程 | P1 |
+| Hub live translation | 常见 live event 已翻译，Codex `session.turn_diff` 已转成可更新 diff 卡 | 未建模 live event 不是全量 `UnknownPart` 兜底 | 手机端可能丢状态或只看到不完整过程 | P1 |
 | Hub prompt policy | 代码和文档都已统一为直通 runtime | 需要继续靠测试防止桌面 confirm gate 误回归 | 配置语义已收敛，剩防回归 | P2 |
 | Hub product copy | 文档、设置页和 checklist 已改成多 runtime | 少量未来路线仍需跟随真实能力更新 | 用户预期基本收敛 | P2 |
 | Source tests | 有一些 source-verification 测试 | 不是行为测试，只能证明“代码里写了什么” | 容易把字符串当验收 | P1 |

--- a/docs/plans/2026-05-17-v1.4.9-stability-closure.md
+++ b/docs/plans/2026-05-17-v1.4.9-stability-closure.md
@@ -119,15 +119,17 @@ Codex 的稳定性更依赖 main-process 里的 canonical 化：
 - `snapshot + live frame` 模式已经成型
 - `prompt / interrupt / permission / question / plan / command_approval` 都有 inbound/outbound 合同
 
-但有一个明显问题：
+当前已收敛的部分：
 
-- 当前代码已经是 prompt 直达 runtime；文档和 checklist 也已开始统一这个口径
-- 但 `require_desktop_confirm` 仍留在设置层，设置面板/注释里还有历史遗留说法
-- `NEED_FULL_RELOAD` 在 server / protocol 层已经存在，但 mobile hook 当前只是把它当普通 error 渲染，还没有自动 REST history reload
+- prompt policy 已统一为直达 runtime；旧桌面确认设置的死 helper、设置注释、Hub 架构文档、mobile 文档和 E2E checklist 已清理成单口径
+- `NEED_FULL_RELOAD` 已从“普通错误条”升级为 mobile 自动 REST reload `/api/sessions/:id/history`，并在 reload 后推进 WebSocket `lastSeq`
+
+仍有一个明显问题：
+
 - Hub live stream 不是完整 lossless：`message.part.updated`、status、permission/question/plan/command approval 等常见事件有专门翻译，部分未建模 live event 会被跳过；`UnknownPart` 主要还体现在协议能力和部分历史映射，不应当把它描述成所有 live event 的兜底
-- 这意味着远程控制的“运行时合同”已经统一，但“配置/UI 语义”还需要一次清理
+- 这意味着远程控制的“运行时合同”和 prompt policy 已经统一，但 live event 信息保真度还需要继续补
 
-这不是“小差异”，这是远程控制的产品契约不一致。
+这不是“小差异”，这是远程控制从“能操作”走向“可回放、可解释”的剩余缺口。
 
 ---
 
@@ -163,10 +165,10 @@ Codex 的稳定性更依赖 main-process 里的 canonical 化：
 | Codex turn shape | main 里已经 canonical 化不少 | durable transcript / live draft / timeline backfill 还没彻底单源化 | tool / plan / assistant bubble 重复风险仍在 | P0 |
 | Run guard | `sessionSequence` + `runEpoch` 已存在 | 行为合同主要靠 store 守卫，缺少端到端验收 | 乱序 / 晚到事件可能只在边界条件暴露 | P1 |
 | Hub replay | `seq` / `resume` / ring buffer 已实现 | 只有 API / bridge 级测试，缺少完整 ws 恢复行为验证 | 断线恢复体验不稳 | P0 |
-| Hub full reload | server 能发 `NEED_FULL_RELOAD` | mobile 还不会自动 REST 拉 `/api/sessions/:id/history` | 长断线后用户只能看到错误 / 手动刷新 | P0 |
+| Hub full reload | server 能发 `NEED_FULL_RELOAD`，mobile 会自动 REST 拉 `/api/sessions/:id/history` 并推进 `lastSeq` | 还缺完整 WS 行为级恢复测试 | 长断线恢复需要防回归 | P1 |
 | Hub live translation | 常见 live event 已翻译 | 未建模 live event 不是全量 `UnknownPart` 兜底 | 手机端可能丢状态或只看到不完整过程 | P1 |
-| Hub prompt policy | 代码直通 runtime | `require_desktop_confirm` 的历史设置/注释还没清完 | 配置语义和真实行为仍有残留不一致 | P1 |
-| Hub product copy | 文档已改成多 runtime | 部分 UI / checklist 仍有 Claude-only 或 M1.5 旧口径 | 用户会误判 Codex / OpenCode 能力边界 | P1 |
+| Hub prompt policy | 代码和文档都已统一为直通 runtime | 需要继续靠测试防止桌面 confirm gate 误回归 | 配置语义已收敛，剩防回归 | P2 |
+| Hub product copy | 文档、设置页和 checklist 已改成多 runtime | 少量未来路线仍需跟随真实能力更新 | 用户预期基本收敛 | P2 |
 | Source tests | 有一些 source-verification 测试 | 不是行为测试，只能证明“代码里写了什么” | 容易把字符串当验收 | P1 |
 
 ---
@@ -186,9 +188,9 @@ Codex 的稳定性更依赖 main-process 里的 canonical 化：
 
 ### 4.2 Hub 远程控制 P0
 
-1. mobile `NEED_FULL_RELOAD` 自动 REST 回填或至少有明确的“一键重新加载历史”路径。
+1. mobile `NEED_FULL_RELOAD` 自动 REST 回填或至少有明确的“一键重新加载历史”路径。已完成：mobile 会拉 `/api/sessions/:id/history`，优先使用 `hubMessages`，并忽略跨 session 的 stale reload 结果。
 2. 增加 WebSocket 断线重连行为测试：连接、收 frame、断开、断线期间广播、重连 resume、只补缺失帧。
-3. prompt policy 单口径：1.4.9 如果继续采用直达 runtime，就清理所有二次确认 UI / 文档 / checklist 残留。
+3. prompt policy 单口径：1.4.9 如果继续采用直达 runtime，就清理所有旧确认 UI / 文档 / checklist 残留。已完成：代码死 helper 和文档/checklist 残留已清理。
 4. mobile 状态清空行为测试：permission / question / plan / command approval response 后卡片必定清空，失败路径可见。
 
 ---

--- a/docs/plans/2026-05-17-v1.4.9-stability-closure.md
+++ b/docs/plans/2026-05-17-v1.4.9-stability-closure.md
@@ -193,7 +193,7 @@ Codex 的稳定性更依赖 main-process 里的 canonical 化：
 1. mobile `NEED_FULL_RELOAD` 自动 REST 回填或至少有明确的“一键重新加载历史”路径。已完成：mobile 会拉 `/api/sessions/:id/history`，优先使用 `hubMessages`，并忽略跨 session 的 stale reload 结果。
 2. 增加 WebSocket 断线重连行为测试：连接、收 frame、断开、断线期间广播、重连 resume、只补缺失帧。已完成核心客户端/bridge 测试；真 server WS 集成测试仍待拆掉 `hub-server.test.ts` 对本地 `better-sqlite3` ABI 的依赖后补。
 3. prompt policy 单口径：1.4.9 如果继续采用直达 runtime，就清理所有旧确认 UI / 文档 / checklist 残留。已完成：代码死 helper 和文档/checklist 残留已清理。
-4. mobile 状态清空行为测试：permission / question / plan / command approval response 后卡片必定清空，失败路径可见。
+4. mobile 状态清空行为测试：permission / question / plan / command approval response 后卡片必定清空，失败路径可见。已完成：发送成功才清卡，WebSocket send 失败时保留卡片并显示 `SEND_FAILED`。
 
 ---
 

--- a/docs/plans/2026-05-17-v1.4.9-stability-closure.md
+++ b/docs/plans/2026-05-17-v1.4.9-stability-closure.md
@@ -123,6 +123,7 @@ Codex 的稳定性更依赖 main-process 里的 canonical 化：
 
 - prompt policy 已统一为直达 runtime；旧桌面确认设置的死 helper、设置注释、Hub 架构文档、mobile 文档和 E2E checklist 已清理成单口径
 - `NEED_FULL_RELOAD` 已从“普通错误条”升级为 mobile 自动 REST reload `/api/sessions/:id/history`，并在 reload 后推进 WebSocket `lastSeq`
+- Hub reconnect 关键行为已有测试锁住：`test/mobile/hub-websocket.test.ts` 覆盖 close → reconnect → open 后带 `resume{lastSeq}`；`test/server/hub-bridge.test.ts` 覆盖 replay gap 被挤出时返回 `NEED_FULL_RELOAD`
 
 仍有一个明显问题：
 
@@ -164,8 +165,8 @@ Codex 的稳定性更依赖 main-process 里的 canonical 化：
 | SessionShell vs SessionView | SessionShell 已经更接近稳定路径 | `SessionView` 仍是复杂兼容层 | 默认路径之外仍有不稳定面 | P0 |
 | Codex turn shape | main 里已经 canonical 化不少 | durable transcript / live draft / timeline backfill 还没彻底单源化 | tool / plan / assistant bubble 重复风险仍在 | P0 |
 | Run guard | `sessionSequence` + `runEpoch` 已存在 | 行为合同主要靠 store 守卫，缺少端到端验收 | 乱序 / 晚到事件可能只在边界条件暴露 | P1 |
-| Hub replay | `seq` / `resume` / ring buffer 已实现 | 只有 API / bridge 级测试，缺少完整 ws 恢复行为验证 | 断线恢复体验不稳 | P0 |
-| Hub full reload | server 能发 `NEED_FULL_RELOAD`，mobile 会自动 REST 拉 `/api/sessions/:id/history` 并推进 `lastSeq` | 还缺完整 WS 行为级恢复测试 | 长断线恢复需要防回归 | P1 |
+| Hub replay | `seq` / `resume` / ring buffer 已实现；mobile `HubWebSocket` reconnect 会带上最新 `lastSeq` | 还缺不依赖本地 SQLite native ABI 的真 server WS 集成测试 | 断线恢复核心客户端/bridge 语义已有防回归，真 socket 路径仍需补 | P1 |
+| Hub full reload | server 能发 `NEED_FULL_RELOAD`，mobile 会自动 REST 拉 `/api/sessions/:id/history` 并推进 `lastSeq`；bridge gap-evicted 分支已有测试 | 还缺真 server WS + REST reload 组合测试 | 长断线恢复需要继续防回归 | P1 |
 | Hub live translation | 常见 live event 已翻译 | 未建模 live event 不是全量 `UnknownPart` 兜底 | 手机端可能丢状态或只看到不完整过程 | P1 |
 | Hub prompt policy | 代码和文档都已统一为直通 runtime | 需要继续靠测试防止桌面 confirm gate 误回归 | 配置语义已收敛，剩防回归 | P2 |
 | Hub product copy | 文档、设置页和 checklist 已改成多 runtime | 少量未来路线仍需跟随真实能力更新 | 用户预期基本收敛 | P2 |
@@ -189,7 +190,7 @@ Codex 的稳定性更依赖 main-process 里的 canonical 化：
 ### 4.2 Hub 远程控制 P0
 
 1. mobile `NEED_FULL_RELOAD` 自动 REST 回填或至少有明确的“一键重新加载历史”路径。已完成：mobile 会拉 `/api/sessions/:id/history`，优先使用 `hubMessages`，并忽略跨 session 的 stale reload 结果。
-2. 增加 WebSocket 断线重连行为测试：连接、收 frame、断开、断线期间广播、重连 resume、只补缺失帧。
+2. 增加 WebSocket 断线重连行为测试：连接、收 frame、断开、断线期间广播、重连 resume、只补缺失帧。已完成核心客户端/bridge 测试；真 server WS 集成测试仍待拆掉 `hub-server.test.ts` 对本地 `better-sqlite3` ABI 的依赖后补。
 3. prompt policy 单口径：1.4.9 如果继续采用直达 runtime，就清理所有旧确认 UI / 文档 / checklist 残留。已完成：代码死 helper 和文档/checklist 残留已清理。
 4. mobile 状态清空行为测试：permission / question / plan / command approval response 后卡片必定清空，失败路径可见。
 

--- a/mobile/src/api/ws.ts
+++ b/mobile/src/api/ws.ts
@@ -115,6 +115,12 @@ export class HubWebSocket {
     }
   }
 
+  markFullReloadComplete(lastSeq: number): void {
+    if (Number.isFinite(lastSeq) && lastSeq > this.lastSeq) {
+      this.lastSeq = lastSeq
+    }
+  }
+
   destroy(): void {
     this.destroyed = true
     if (this.retryTimer) {

--- a/mobile/src/hooks/useSessionStream.ts
+++ b/mobile/src/hooks/useSessionStream.ts
@@ -113,6 +113,7 @@ type Action =
       status?: HubSessionStatus
     }
   | { type: 'historyReloadFailed'; message: string }
+  | { type: 'sendFailed'; message: string }
   | { type: 'clearPermission' }
   | { type: 'clearQuestion' }
   | { type: 'clearPlan' }
@@ -140,6 +141,10 @@ function applyPatch(message: HubMessage, op: MessageUpdateOp): HubMessage {
     }
   }
   return { ...message, parts }
+}
+
+function clearSendFailedError(state: State): State['error'] {
+  return state.error?.code === 'SEND_FAILED' ? null : state.error
 }
 
 function reducer(state: State, action: Action): State {
@@ -170,17 +175,26 @@ function reducer(state: State, action: Action): State {
       }
     }
   }
+  if (action.type === 'sendFailed') {
+    return {
+      ...state,
+      error: {
+        code: 'SEND_FAILED',
+        message: action.message
+      }
+    }
+  }
   if (action.type === 'clearPermission') {
-    return { ...state, permission: null }
+    return { ...state, permission: null, error: clearSendFailedError(state) }
   }
   if (action.type === 'clearQuestion') {
-    return { ...state, question: null }
+    return { ...state, question: null, error: clearSendFailedError(state) }
   }
   if (action.type === 'clearPlan') {
-    return { ...state, plan: null }
+    return { ...state, plan: null, error: clearSendFailedError(state) }
   }
   if (action.type === 'clearCommandApproval') {
-    return { ...state, commandApproval: null }
+    return { ...state, commandApproval: null, error: clearSendFailedError(state) }
   }
   if (action.type === 'dismissNotice') {
     return { ...state, notices: state.notices.filter((n) => n.seq !== action.seq) }
@@ -316,6 +330,12 @@ export function useSessionStream(deviceId: string, hiveId: string): SessionStrea
   const wsRef = useRef<HubWebSocket | null>(null)
   const streamEpochRef = useRef(0)
   const reloadInFlightRef = useRef<number | null>(null)
+  const dispatchSendFailed = (): void => {
+    dispatch({
+      type: 'sendFailed',
+      message: 'Connection is not open. Please retry.'
+    })
+  }
 
   useEffect(() => {
     const streamEpoch = streamEpochRef.current + 1
@@ -409,28 +429,33 @@ export function useSessionStream(deviceId: string, hiveId: string): SessionStrea
     send({ type: 'interrupt' })
   }
 
-  const respondPermission = (
-    decision: 'once' | 'always' | 'reject',
-    message?: string
-  ): void => {
+  const respondPermission = (decision: 'once' | 'always' | 'reject', message?: string): void => {
     if (!state.permission) return
-    send({
+    const sent = send({
       type: 'permission/respond',
       requestId: state.permission.requestId,
       decision,
       message
     })
-    dispatch({ type: 'clearPermission' })
+    if (sent) {
+      dispatch({ type: 'clearPermission' })
+    } else {
+      dispatchSendFailed()
+    }
   }
 
   const respondQuestion = (answers: string[][]): void => {
     if (!state.question) return
-    send({
+    const sent = send({
       type: 'question/respond',
       requestId: state.question.requestId,
       answers
     })
-    dispatch({ type: 'clearQuestion' })
+    if (sent) {
+      dispatch({ type: 'clearQuestion' })
+    } else {
+      dispatchSendFailed()
+    }
   }
 
   const dismissPermission = (): void => {
@@ -442,8 +467,12 @@ export function useSessionStream(deviceId: string, hiveId: string): SessionStrea
 
   const respondPlan = (decision: 'approve' | 'reject', feedback?: string): void => {
     if (!state.plan) return
-    send({ type: 'plan/respond', requestId: state.plan.requestId, decision, feedback })
-    dispatch({ type: 'clearPlan' })
+    const sent = send({ type: 'plan/respond', requestId: state.plan.requestId, decision, feedback })
+    if (sent) {
+      dispatch({ type: 'clearPlan' })
+    } else {
+      dispatchSendFailed()
+    }
   }
 
   const respondCommandApproval = (
@@ -451,13 +480,17 @@ export function useSessionStream(deviceId: string, hiveId: string): SessionStrea
     message?: string
   ): void => {
     if (!state.commandApproval) return
-    send({
+    const sent = send({
       type: 'command_approval/respond',
       requestId: state.commandApproval.requestId,
       decision,
       message
     })
-    dispatch({ type: 'clearCommandApproval' })
+    if (sent) {
+      dispatch({ type: 'clearCommandApproval' })
+    } else {
+      dispatchSendFailed()
+    }
   }
 
   const dismissNotice = (seq: number): void => {

--- a/mobile/src/hooks/useSessionStream.ts
+++ b/mobile/src/hooks/useSessionStream.ts
@@ -15,6 +15,7 @@
  */
 
 import { useEffect, useReducer, useRef } from 'react'
+import { api } from '../api/client'
 import { HubWebSocket, type ConnectionState } from '../api/ws'
 import type {
   ClientMsg,
@@ -87,9 +88,31 @@ const INITIAL: State = {
   connection: 'connecting'
 }
 
+interface HistoryMessageRow {
+  id: string
+  role: string
+  content: string
+  created_at: string
+}
+
+interface HistoryResponse {
+  hiveId: string
+  status?: HubSessionStatus
+  lastSeq?: number
+  hubMessages?: HubMessage[]
+  messages?: HistoryMessageRow[]
+}
+
 type Action =
+  | { type: 'reset' }
   | { type: 'frame'; frame: ServerMsg }
   | { type: 'connection'; value: ConnectionState }
+  | {
+      type: 'historyReloaded'
+      messages: HubMessage[]
+      status?: HubSessionStatus
+    }
+  | { type: 'historyReloadFailed'; message: string }
   | { type: 'clearPermission' }
   | { type: 'clearQuestion' }
   | { type: 'clearPlan' }
@@ -120,8 +143,32 @@ function applyPatch(message: HubMessage, op: MessageUpdateOp): HubMessage {
 }
 
 function reducer(state: State, action: Action): State {
+  if (action.type === 'reset') {
+    return INITIAL
+  }
   if (action.type === 'connection') {
     return { ...state, connection: action.value }
+  }
+  if (action.type === 'historyReloaded') {
+    return {
+      ...state,
+      status: action.status ?? state.status,
+      messages: action.messages,
+      permission: null,
+      question: null,
+      plan: null,
+      commandApproval: null,
+      error: null
+    }
+  }
+  if (action.type === 'historyReloadFailed') {
+    return {
+      ...state,
+      error: {
+        code: 'NEED_FULL_RELOAD',
+        message: action.message
+      }
+    }
   }
   if (action.type === 'clearPermission') {
     return { ...state, permission: null }
@@ -223,6 +270,28 @@ function reducer(state: State, action: Action): State {
   }
 }
 
+function normalizeHistoryRole(role: string): HubMessage['role'] {
+  if (role === 'user' || role === 'assistant' || role === 'system') return role
+  return 'system'
+}
+
+function mapHistoryMessages(messages: HistoryMessageRow[] = []): HubMessage[] {
+  return messages.map((message, index) => ({
+    id: message.id,
+    role: normalizeHistoryRole(message.role),
+    ts: Date.parse(message.created_at) || Date.now(),
+    seq: index + 1,
+    parts: message.content ? [{ type: 'text', text: message.content }] : []
+  }))
+}
+
+function getReloadedMessages(history: HistoryResponse): HubMessage[] {
+  if (Array.isArray(history.hubMessages) && history.hubMessages.length > 0) {
+    return history.hubMessages
+  }
+  return mapHistoryMessages(history.messages)
+}
+
 export interface SessionStream {
   state: State
   send: (msg: ClientMsg) => boolean
@@ -245,18 +314,70 @@ export interface SessionStream {
 export function useSessionStream(deviceId: string, hiveId: string): SessionStream {
   const [state, dispatch] = useReducer(reducer, INITIAL)
   const wsRef = useRef<HubWebSocket | null>(null)
+  const streamEpochRef = useRef(0)
+  const reloadInFlightRef = useRef<number | null>(null)
 
   useEffect(() => {
+    const streamEpoch = streamEpochRef.current + 1
+    streamEpochRef.current = streamEpoch
     const ws = new HubWebSocket(deviceId, hiveId)
     wsRef.current = ws
-    const offFrame = ws.onFrame((f) => dispatch({ type: 'frame', frame: f as ServerMsg }))
+    dispatch({ type: 'reset' })
+    let reloadAbortController: AbortController | null = null
+    const isCurrentStream = (): boolean => {
+      return streamEpochRef.current === streamEpoch && wsRef.current === ws
+    }
+    const reloadHistory = async (): Promise<void> => {
+      if (reloadInFlightRef.current === streamEpoch) return
+      const abortController = new AbortController()
+      reloadAbortController = abortController
+      reloadInFlightRef.current = streamEpoch
+      try {
+        const history = await api<HistoryResponse>(
+          `/api/sessions/${encodeURIComponent(hiveId)}/history`,
+          { signal: abortController.signal }
+        )
+        if (!isCurrentStream() || history.hiveId !== hiveId) return
+        ws.markFullReloadComplete(history.lastSeq ?? 0)
+        dispatch({
+          type: 'historyReloaded',
+          messages: getReloadedMessages(history),
+          status: history.status
+        })
+      } catch (error) {
+        if (!isCurrentStream()) return
+        if (error instanceof DOMException && error.name === 'AbortError') return
+        dispatch({
+          type: 'historyReloadFailed',
+          message: error instanceof Error ? error.message : String(error)
+        })
+      } finally {
+        if (reloadInFlightRef.current === streamEpoch) {
+          reloadInFlightRef.current = null
+        }
+        if (reloadAbortController === abortController) {
+          reloadAbortController = null
+        }
+      }
+    }
+    const offFrame = ws.onFrame((f) => {
+      const frame = f as ServerMsg
+      dispatch({ type: 'frame', frame })
+      if (frame.type === 'error' && frame.code === 'NEED_FULL_RELOAD') {
+        void reloadHistory()
+      }
+    })
     const offState = ws.onState((s) => dispatch({ type: 'connection', value: s }))
     ws.connect()
     return () => {
       offFrame()
       offState()
+      reloadAbortController?.abort()
       ws.destroy()
       wsRef.current = null
+      if (reloadInFlightRef.current === streamEpoch) {
+        reloadInFlightRef.current = null
+      }
     }
   }, [deviceId, hiveId])
 

--- a/src/main/services/hub/hub-bridge.ts
+++ b/src/main/services/hub/hub-bridge.ts
@@ -182,6 +182,12 @@ export class HubBridge {
     { hubMsgId: string; partIdx: Map<string, number>; nextPartIdx: number }
   >()
   /**
+   * Codex emits turn-cumulative diffs as `session.turn_diff`. Keep one mobile
+   * diff card per `(session, turn)` and replace it as the cumulative patch
+   * changes instead of appending a new card for every update.
+   */
+  private readonly turnDiffMsgs = new Map<string, { hubMsgId: string }>()
+  /**
    * Last emit timestamp (ms) per `${sessionId}:${noticeCategory}`. Lets us
    * throttle high-frequency notices like `context_usage` so mobile doesn't get
    * a notice every assistant tick.
@@ -215,6 +221,10 @@ export class HubBridge {
     this.worktreePaths.delete(hiveSessionId)
     this.agentSessionIds.delete(hiveSessionId)
     this.runtimeIds.delete(hiveSessionId)
+    this.streamingMsgs.delete(hiveSessionId)
+    for (const key of Array.from(this.turnDiffMsgs.keys())) {
+      if (key.startsWith(`${hiveSessionId}:`)) this.turnDiffMsgs.delete(key)
+    }
   }
 
   /**
@@ -569,13 +579,49 @@ export class HubBridge {
           }
         ]
       }
+      case 'session.turn_diff': {
+        const d = ev.data as { turnId?: string; diff?: string }
+        if (!d.turnId || !d.diff) return []
+        const key = `${ev.sessionId}:${d.turnId}`
+        const part: HubPart = {
+          type: 'diff',
+          filePath: `turn:${d.turnId}`,
+          patch: d.diff
+        }
+        const existing = this.turnDiffMsgs.get(key)
+        if (existing) {
+          return [
+            {
+              type: 'message/update',
+              seq: 0,
+              messageId: existing.hubMsgId,
+              patch: { op: 'replacePart', partIdx: 0, value: part }
+            }
+          ]
+        }
+
+        const hubMsgId = `diff-${ev.sessionId}-${d.turnId}`
+        this.turnDiffMsgs.set(key, { hubMsgId })
+        return [
+          {
+            type: 'message/append',
+            seq: 0,
+            message: {
+              id: hubMsgId,
+              role: 'assistant',
+              ts: this.now(),
+              seq: 0,
+              parts: [part]
+            }
+          }
+        ]
+      }
       case 'message.updated':
       case 'session.idle':
       case 'session.materialized':
       case 'session.updated':
       case 'session.commands_available':
       case 'session.model_limits':
-      case 'session.turn_diff':
       case 'permission.replied':
       case 'question.replied':
       case 'question.rejected':

--- a/src/main/services/hub/hub-bridge.ts
+++ b/src/main/services/hub/hub-bridge.ts
@@ -12,9 +12,9 @@
  * 2. The bridge routes incoming `agent:stream` envelopes (CanonicalAgentEvent)
  *    to a HubRegistry session keyed by `(localDeviceId, hiveSessionId)`, using
  *    a best-effort translation to the agent-agnostic `ServerMsg` protocol. We
- *    deliberately keep the translation lossy-but-lossless: anything we don't
- *    model yet is wrapped as a HubMessage with a single `UnknownPart{ raw }`,
- *    so the mobile client can render the raw payload and we never drop data.
+ *    translate common status, interaction, message, and tool events. Unknown
+ *    live events may be skipped until the mobile protocol grows a dedicated
+ *    frame for them.
  *
  * 3. Reverse path (ClientMsg → runtime) lives in `handleClientMessage`.
  *    Mobile-originated `prompt` is dispatched directly to the runtime — there

--- a/src/main/services/hub/hub-server.ts
+++ b/src/main/services/hub/hub-server.ts
@@ -857,7 +857,17 @@ class HubServerImpl implements HubServer {
       created_at: string
     }>
 
-    sendJson(res, 200, { hiveId, messages, activities })
+    const activeSession = this.registry.getSession(this.registry.localDeviceId, hiveId)
+    const hubMessages = this.bridge?.getHistorySnapshot(hiveId) ?? []
+
+    sendJson(res, 200, {
+      hiveId,
+      status: activeSession?.status ?? 'idle',
+      lastSeq: activeSession?.seq.current() ?? 0,
+      messages,
+      activities,
+      hubMessages
+    })
   }
 
   // ─── static ──────────────────────────────────────────────────────────────

--- a/src/main/services/hub/hub-server.ts
+++ b/src/main/services/hub/hub-server.ts
@@ -81,7 +81,6 @@ const DEFAULT_AUTH_MODE: HubAuthMode = 'password'
 
 const SETTING_KEYS = {
   authMode: 'auth_mode',
-  requireDesktopConfirm: 'require_desktop_confirm',
   cfAccessEmails: 'cf_access_emails',
   tunnelUrl: 'tunnel_url'
 } as const
@@ -1071,10 +1070,6 @@ export function setHubAuthMode(db: Database, mode: HubAuthMode): void {
 
 export function setHubCfAccessEmails(db: Database, emails: readonly string[]): void {
   setSetting(db, SETTING_KEYS.cfAccessEmails, JSON.stringify(emails))
-}
-
-export function setHubRequireDesktopConfirm(db: Database, value: boolean): void {
-  setSetting(db, SETTING_KEYS.requireDesktopConfirm, value ? '1' : '0')
 }
 
 export function setHubTunnelUrl(db: Database, url: string | null): void {

--- a/src/renderer/src/components/settings/HubSection.tsx
+++ b/src/renderer/src/components/settings/HubSection.tsx
@@ -6,10 +6,7 @@
  *  2. Local hub on/off + URL
  *  3. Public access via cloudflared
  *  4. Auth mode (password / cf_access / hybrid)
- *  5. Security (desktop confirm + change password)
- *
- * The desktop二次确认 toast lives in `HubConfirmationToasts` (mounted higher
- * up so it survives panel close).
+ *  5. Security (change password)
  */
 
 import { useEffect, useState, type FormEvent } from 'react'
@@ -62,7 +59,7 @@ export function HubSection(): React.JSX.Element {
       <header>
         <h2 className="text-lg font-semibold">远程访问 (Hub)</h2>
         <p className="text-sm text-muted-foreground mt-1">
-          在本机开启 Hub 服务，让手机或平板远程查看与控制你的 Claude Code 会话。
+          在本机开启 Hub 服务，让手机或平板远程查看与控制你的 AI coding 会话。
           公网访问通过 Cloudflare 临时隧道实现。
         </p>
       </header>

--- a/test/mobile/hub-websocket.test.ts
+++ b/test/mobile/hub-websocket.test.ts
@@ -1,0 +1,118 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { HubWebSocket, type ConnectionState, type ServerFrame } from '../../mobile/src/api/ws'
+
+class MockBrowserWebSocket {
+  static readonly CONNECTING = 0
+  static readonly OPEN = 1
+  static readonly CLOSING = 2
+  static readonly CLOSED = 3
+
+  readonly sent: unknown[] = []
+  readyState = MockBrowserWebSocket.CONNECTING
+  onopen: (() => void) | null = null
+  onmessage: ((event: { data: string }) => void) | null = null
+  onerror: (() => void) | null = null
+  onclose: (() => void) | null = null
+
+  constructor(readonly url: string) {
+    sockets.push(this)
+  }
+
+  send(data: string): void {
+    this.sent.push(JSON.parse(data) as unknown)
+  }
+
+  close(): void {
+    this.readyState = MockBrowserWebSocket.CLOSED
+  }
+
+  open(): void {
+    this.readyState = MockBrowserWebSocket.OPEN
+    this.onopen?.()
+  }
+
+  message(frame: ServerFrame): void {
+    this.onmessage?.({ data: JSON.stringify(frame) })
+  }
+
+  closeFromServer(): void {
+    this.readyState = MockBrowserWebSocket.CLOSED
+    this.onclose?.()
+  }
+}
+
+let sockets: MockBrowserWebSocket[] = []
+
+describe('HubWebSocket reconnect resume', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    sockets = []
+    vi.stubGlobal('WebSocket', MockBrowserWebSocket)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
+  })
+
+  it('reconnects with the latest received seq as resume cursor', async () => {
+    const frames: ServerFrame[] = []
+    const states: ConnectionState[] = []
+    const ws = new HubWebSocket('device-1', 'hive-1')
+    ws.onFrame((frame) => frames.push(frame))
+    ws.onState((state) => states.push(state))
+
+    ws.connect()
+
+    expect(sockets).toHaveLength(1)
+    expect(sockets[0]?.url).toContain('/ws/ui/device-1/hive-1')
+    sockets[0]?.open()
+    expect(sockets[0]?.sent).toEqual([])
+
+    sockets[0]?.message({ type: 'status', seq: 1, status: 'busy' })
+    sockets[0]?.message({ type: 'status', seq: 2, status: 'idle' })
+    sockets[0]?.closeFromServer()
+
+    expect(states.at(-1)).toBe('closed')
+
+    await vi.advanceTimersByTimeAsync(1000)
+
+    expect(sockets).toHaveLength(2)
+    sockets[1]?.open()
+    expect(sockets[1]?.sent).toEqual([{ type: 'resume', lastSeq: 2 }])
+
+    sockets[1]?.message({ type: 'status', seq: 3, status: 'busy' })
+    sockets[1]?.closeFromServer()
+
+    await vi.advanceTimersByTimeAsync(1000)
+
+    expect(sockets).toHaveLength(3)
+    sockets[2]?.open()
+    expect(sockets[2]?.sent).toEqual([{ type: 'resume', lastSeq: 3 }])
+    expect(frames.map((frame) => frame.seq)).toEqual([1, 2, 3])
+
+    ws.destroy()
+  })
+
+  it('uses the REST full-reload seq as the next resume cursor', async () => {
+    const ws = new HubWebSocket('device-1', 'hive-1')
+    ws.connect()
+
+    expect(sockets).toHaveLength(1)
+    sockets[0]?.open()
+    sockets[0]?.message({ type: 'status', seq: 5, status: 'busy' })
+
+    ws.markFullReloadComplete(42)
+    ws.markFullReloadComplete(7)
+    sockets[0]?.closeFromServer()
+
+    await vi.advanceTimersByTimeAsync(1000)
+
+    expect(sockets).toHaveLength(2)
+    sockets[1]?.open()
+    expect(sockets[1]?.sent).toEqual([{ type: 'resume', lastSeq: 42 }])
+
+    ws.destroy()
+  })
+})

--- a/test/mobile/use-session-stream.test.ts
+++ b/test/mobile/use-session-stream.test.ts
@@ -1,14 +1,21 @@
-import { act, renderHook } from '@testing-library/react'
+import { act, renderHook, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const apiMock = vi.hoisted(() => ({
+  api: vi.fn()
+}))
 
 const wsMock = vi.hoisted(() => {
   let latestSocket: {
     emitFrame: (frame: unknown) => void
+    markFullReloadComplete: (lastSeq: number) => void
+    getLastSeq: () => number
   } | null = null
 
   class MockHubWebSocket {
     private frameListeners = new Set<(frame: unknown) => void>()
     private stateListeners = new Set<(state: 'connecting' | 'open' | 'closed') => void>()
+    private lastSeq = 0
 
     constructor(
       _deviceId: string,
@@ -26,6 +33,14 @@ const wsMock = vi.hoisted(() => {
 
     send(): boolean {
       return true
+    }
+
+    markFullReloadComplete(lastSeq: number): void {
+      this.lastSeq = Math.max(this.lastSeq, lastSeq)
+    }
+
+    getLastSeq(): number {
+      return this.lastSeq
     }
 
     onFrame(cb: (frame: unknown) => void): () => void {
@@ -61,11 +76,16 @@ vi.mock('../../mobile/src/api/ws', () => ({
   HubWebSocket: wsMock.MockHubWebSocket
 }))
 
+vi.mock('../../mobile/src/api/client', () => ({
+  api: apiMock.api
+}))
+
 import { useSessionStream } from '../../mobile/src/hooks/useSessionStream'
 
 describe('useSessionStream', () => {
   beforeEach(() => {
     wsMock.reset()
+    apiMock.api.mockReset()
   })
 
   it('clears pending plan and command approval cards on session snapshot', () => {
@@ -103,5 +123,113 @@ describe('useSessionStream', () => {
 
     expect(result.current.state.plan).toBeNull()
     expect(result.current.state.commandApproval).toBeNull()
+  })
+
+  it('reloads history when the server asks for a full reload', async () => {
+    apiMock.api.mockResolvedValue({
+      hiveId: 'hive-1',
+      status: 'busy',
+      lastSeq: 42,
+      hubMessages: [
+        {
+          id: 'm-1',
+          role: 'assistant',
+          ts: 123,
+          seq: 1,
+          parts: [{ type: 'text', text: 'Recovered message' }]
+        }
+      ]
+    })
+
+    const { result } = renderHook(() => useSessionStream('device-1', 'hive-1'))
+    const latestSocket = wsMock.getLatestSocket()
+    expect(latestSocket).not.toBeNull()
+
+    await act(async () => {
+      latestSocket?.emitFrame({
+        type: 'error',
+        code: 'NEED_FULL_RELOAD',
+        message: 'gap evicted'
+      })
+    })
+
+    await waitFor(() => {
+      expect(result.current.state.messages).toHaveLength(1)
+    })
+
+    expect(apiMock.api).toHaveBeenCalledWith(
+      '/api/sessions/hive-1/history',
+      expect.objectContaining({
+        signal: expect.any(Object)
+      })
+    )
+    expect(latestSocket?.getLastSeq()).toBe(42)
+    expect(result.current.state.status).toBe('busy')
+    expect(result.current.state.error).toBeNull()
+    expect(result.current.state.messages[0]).toMatchObject({
+      id: 'm-1',
+      role: 'assistant'
+    })
+    expect(result.current.state.messages[0]?.parts).toEqual([
+      { type: 'text', text: 'Recovered message' }
+    ])
+  })
+
+  it('drops stale full reload results after switching sessions', async () => {
+    let resolveHistory: (value: unknown) => void = () => {}
+    const pendingHistory = new Promise((resolve) => {
+      resolveHistory = resolve
+    })
+    apiMock.api.mockReturnValueOnce(pendingHistory)
+
+    const { result, rerender } = renderHook(
+      ({ hiveId }) => useSessionStream('device-1', hiveId),
+      { initialProps: { hiveId: 'hive-1' } }
+    )
+
+    const oldSocket = wsMock.getLatestSocket()
+    expect(oldSocket).not.toBeNull()
+
+    await act(async () => {
+      oldSocket?.emitFrame({
+        type: 'error',
+        code: 'NEED_FULL_RELOAD',
+        message: 'gap evicted'
+      })
+    })
+
+    expect(apiMock.api).toHaveBeenCalledTimes(1)
+    expect(apiMock.api).toHaveBeenCalledWith(
+      '/api/sessions/hive-1/history',
+      expect.objectContaining({
+        signal: expect.any(Object)
+      })
+    )
+
+    await act(async () => {
+      rerender({ hiveId: 'hive-2' })
+    })
+
+    await act(async () => {
+      resolveHistory({
+        hiveId: 'hive-1',
+        status: 'busy',
+        lastSeq: 99,
+        hubMessages: [
+          {
+            id: 'stale-1',
+            role: 'assistant',
+            ts: 321,
+            seq: 1,
+            parts: [{ type: 'text', text: 'Stale recovery' }]
+          }
+        ]
+      })
+      await Promise.resolve()
+    })
+
+    expect(result.current.state.messages).toEqual([])
+    expect(result.current.state.error).toBeNull()
+    expect(result.current.state.status).toBe('idle')
   })
 })

--- a/test/mobile/use-session-stream.test.ts
+++ b/test/mobile/use-session-stream.test.ts
@@ -6,6 +6,8 @@ const apiMock = vi.hoisted(() => ({
 }))
 
 const wsMock = vi.hoisted(() => {
+  let sendResult = true
+  let sentFrames: unknown[] = []
   let latestSocket: {
     emitFrame: (frame: unknown) => void
     markFullReloadComplete: (lastSeq: number) => void
@@ -17,10 +19,7 @@ const wsMock = vi.hoisted(() => {
     private stateListeners = new Set<(state: 'connecting' | 'open' | 'closed') => void>()
     private lastSeq = 0
 
-    constructor(
-      _deviceId: string,
-      _hiveSessionId: string
-    ) {
+    constructor(_deviceId: string, _hiveSessionId: string) {
       // eslint-disable-next-line @typescript-eslint/no-this-alias
       latestSocket = this
     }
@@ -31,8 +30,11 @@ const wsMock = vi.hoisted(() => {
 
     destroy(): void {}
 
-    send(): boolean {
-      return true
+    send(frame: unknown): boolean {
+      if (sendResult) {
+        sentFrames.push(frame)
+      }
+      return sendResult
     }
 
     markFullReloadComplete(lastSeq: number): void {
@@ -65,7 +67,13 @@ const wsMock = vi.hoisted(() => {
 
   return {
     getLatestSocket: () => latestSocket,
+    getSentFrames: () => sentFrames,
+    setSendResult: (value: boolean) => {
+      sendResult = value
+    },
     reset: () => {
+      sendResult = true
+      sentFrames = []
       latestSocket = null
     },
     MockHubWebSocket
@@ -86,6 +94,137 @@ describe('useSessionStream', () => {
   beforeEach(() => {
     wsMock.reset()
     apiMock.api.mockReset()
+  })
+
+  it('keeps permission card and shows send error when permission response cannot be sent', () => {
+    const { result } = renderHook(() => useSessionStream('device-1', 'hive-1'))
+    const latestSocket = wsMock.getLatestSocket()
+    expect(latestSocket).not.toBeNull()
+
+    act(() => {
+      latestSocket?.emitFrame({
+        type: 'permission/request',
+        seq: 1,
+        requestId: 'perm-1',
+        toolName: 'Bash'
+      })
+    })
+
+    expect(result.current.state.permission?.requestId).toBe('perm-1')
+
+    wsMock.setSendResult(false)
+    act(() => {
+      result.current.respondPermission('once')
+    })
+
+    expect(result.current.state.permission?.requestId).toBe('perm-1')
+    expect(result.current.state.error).toMatchObject({
+      code: 'SEND_FAILED',
+      message: 'Connection is not open. Please retry.'
+    })
+    expect(wsMock.getSentFrames()).toEqual([])
+
+    wsMock.setSendResult(true)
+    act(() => {
+      result.current.respondPermission('once')
+    })
+
+    expect(result.current.state.permission).toBeNull()
+    expect(result.current.state.error).toBeNull()
+    expect(wsMock.getSentFrames()).toEqual([
+      expect.objectContaining({ type: 'permission/respond', requestId: 'perm-1' })
+    ])
+  })
+
+  it('keeps question, plan, and command approval cards when responses cannot be sent', () => {
+    const { result } = renderHook(() => useSessionStream('device-1', 'hive-1'))
+    const latestSocket = wsMock.getLatestSocket()
+    expect(latestSocket).not.toBeNull()
+
+    act(() => {
+      latestSocket?.emitFrame({
+        type: 'question/request',
+        seq: 1,
+        requestId: 'question-1',
+        question: 'Pick one'
+      })
+      latestSocket?.emitFrame({
+        type: 'plan/request',
+        seq: 2,
+        requestId: 'plan-1',
+        planText: 'Do the thing'
+      })
+      latestSocket?.emitFrame({
+        type: 'command_approval/request',
+        seq: 3,
+        requestId: 'cmd-1',
+        command: 'pnpm test'
+      })
+    })
+
+    wsMock.setSendResult(false)
+    act(() => {
+      result.current.respondQuestion([['A']])
+      result.current.respondPlan('approve')
+      result.current.respondCommandApproval('approve_once')
+    })
+
+    expect(result.current.state.question?.requestId).toBe('question-1')
+    expect(result.current.state.plan?.requestId).toBe('plan-1')
+    expect(result.current.state.commandApproval?.requestId).toBe('cmd-1')
+    expect(result.current.state.error?.code).toBe('SEND_FAILED')
+    expect(wsMock.getSentFrames()).toEqual([])
+  })
+
+  it('clears interactive cards after responses are sent', () => {
+    const { result } = renderHook(() => useSessionStream('device-1', 'hive-1'))
+    const latestSocket = wsMock.getLatestSocket()
+    expect(latestSocket).not.toBeNull()
+
+    act(() => {
+      latestSocket?.emitFrame({
+        type: 'permission/request',
+        seq: 1,
+        requestId: 'perm-1',
+        toolName: 'Bash'
+      })
+      latestSocket?.emitFrame({
+        type: 'question/request',
+        seq: 2,
+        requestId: 'question-1',
+        question: 'Pick one'
+      })
+      latestSocket?.emitFrame({
+        type: 'plan/request',
+        seq: 3,
+        requestId: 'plan-1',
+        planText: 'Do the thing'
+      })
+      latestSocket?.emitFrame({
+        type: 'command_approval/request',
+        seq: 4,
+        requestId: 'cmd-1',
+        command: 'pnpm test'
+      })
+    })
+
+    act(() => {
+      result.current.respondPermission('always')
+      result.current.respondQuestion([['A']])
+      result.current.respondPlan('approve')
+      result.current.respondCommandApproval('approve_once')
+    })
+
+    expect(result.current.state.permission).toBeNull()
+    expect(result.current.state.question).toBeNull()
+    expect(result.current.state.plan).toBeNull()
+    expect(result.current.state.commandApproval).toBeNull()
+    expect(wsMock.getSentFrames()).toEqual([
+      expect.objectContaining({ type: 'permission/respond', requestId: 'perm-1' }),
+      expect.objectContaining({ type: 'question/respond', requestId: 'question-1' }),
+      expect.objectContaining({ type: 'plan/respond', requestId: 'plan-1' }),
+      expect.objectContaining({ type: 'command_approval/respond', requestId: 'cmd-1' })
+    ])
   })
 
   it('clears pending plan and command approval cards on session snapshot', () => {
@@ -182,10 +321,9 @@ describe('useSessionStream', () => {
     })
     apiMock.api.mockReturnValueOnce(pendingHistory)
 
-    const { result, rerender } = renderHook(
-      ({ hiveId }) => useSessionStream('device-1', hiveId),
-      { initialProps: { hiveId: 'hive-1' } }
-    )
+    const { result, rerender } = renderHook(({ hiveId }) => useSessionStream('device-1', hiveId), {
+      initialProps: { hiveId: 'hive-1' }
+    })
 
     const oldSocket = wsMock.getLatestSocket()
     expect(oldSocket).not.toBeNull()

--- a/test/server/hub-bridge.test.ts
+++ b/test/server/hub-bridge.test.ts
@@ -441,6 +441,35 @@ describe('hub-bridge: inbound client messages', () => {
     await bridge.handleClientMessage(ws, 's1', { type: 'resume', lastSeq: 1 })
     expect(ws.sent.map((f) => (f as { seq: number }).seq)).toEqual([2, 3])
   })
+
+  it('resume returns NEED_FULL_RELOAD when the replay gap has been evicted', async () => {
+    const registry = new HubRegistry({ localDeviceId: 'd' })
+    const { manager } = makeRuntimeStub()
+    const bridge = new HubBridge({
+      registry,
+      runtimeManager: manager
+    })
+
+    for (let i = 0; i < 502; i += 1) {
+      bridge.onIpcEvent(AGENT_STREAM_CHANNEL, [
+        envelope({
+          eventId: `evt-${i}`,
+          sessionSequence: i + 1,
+          type: 'session.status',
+          sessionId: 's1',
+          data: { status: { type: i % 2 === 0 ? 'busy' : 'idle' } },
+          statusPayload: { type: i % 2 === 0 ? 'busy' : 'idle' }
+        })
+      ])
+    }
+
+    const ws = makeWs()
+    await bridge.handleClientMessage(ws, 's1', { type: 'resume', lastSeq: 1 })
+
+    expect(ws.sent).toEqual([
+      { type: 'error', code: 'NEED_FULL_RELOAD', message: 'gap evicted' }
+    ])
+  })
 })
 
 describe('hub-bridge: routingResolver lazy fallback', () => {

--- a/test/server/hub-bridge.test.ts
+++ b/test/server/hub-bridge.test.ts
@@ -366,6 +366,67 @@ describe('hub-bridge: outbound translation', () => {
     expect(resultFrame.patch.value.output.length).toBeLessThan(4500)
     expect(resultFrame.patch.value.output).toContain('truncated')
   })
+
+  it('renders Codex turn diffs as a single replaceable diff card', () => {
+    const ws = makeWs()
+    registry.subscribe(ws, 'd', 's1')
+
+    bridge.onIpcEvent(AGENT_STREAM_CHANNEL, [
+      envelope({
+        type: 'session.turn_diff',
+        sessionId: 's1',
+        runtimeId: 'codex',
+        data: {
+          turnId: 'turn-1',
+          diff: 'diff --git a/a.ts b/a.ts\n+first\n'
+        }
+      })
+    ])
+
+    expect(ws.sent).toHaveLength(1)
+    const append = ws.sent[0] as {
+      type: string
+      seq: number
+      message: { id: string; role: string; parts: Array<Record<string, unknown>> }
+    }
+    expect(append.type).toBe('message/append')
+    expect(append.seq).toBe(1)
+    expect(append.message.id).toBe('diff-s1-turn-1')
+    expect(append.message.role).toBe('assistant')
+    expect(append.message.parts[0]).toMatchObject({
+      type: 'diff',
+      filePath: 'turn:turn-1',
+      patch: expect.stringContaining('+first')
+    })
+
+    bridge.onIpcEvent(AGENT_STREAM_CHANNEL, [
+      envelope({
+        type: 'session.turn_diff',
+        sessionId: 's1',
+        runtimeId: 'codex',
+        data: {
+          turnId: 'turn-1',
+          diff: 'diff --git a/a.ts b/a.ts\n+second\n'
+        }
+      })
+    ])
+
+    expect(ws.sent).toHaveLength(2)
+    expect(ws.sent[1]).toMatchObject({
+      type: 'message/update',
+      seq: 2,
+      messageId: 'diff-s1-turn-1',
+      patch: {
+        op: 'replacePart',
+        partIdx: 0,
+        value: {
+          type: 'diff',
+          filePath: 'turn:turn-1',
+          patch: expect.stringContaining('+second')
+        }
+      }
+    })
+  })
 })
 
 describe('hub-bridge: inbound client messages', () => {

--- a/test/server/hub-server.test.ts
+++ b/test/server/hub-server.test.ts
@@ -393,12 +393,18 @@ describe('hub-server: protected routes', () => {
     expect(r.status).toBe(200)
     const body = r.body as {
       hiveId: string
+      status: string
+      lastSeq: number
       messages: Array<{ id: string }>
       activities: Array<{ id: string }>
+      hubMessages: Array<{ id: string }>
     }
     expect(body.hiveId).toBe('sess-1')
+    expect(body.status).toBe('idle')
+    expect(body.lastSeq).toBe(0)
     expect(body.messages.map((m) => m.id)).toEqual(['m1'])
     expect(body.activities.map((a) => a.id)).toEqual(['a1'])
+    expect(body.hubMessages).toEqual([])
   })
 
   it('all protected routes refuse missing auth', async () => {


### PR DESCRIPTION
## Summary
- recover mobile streams after full reload and websocket resume
- surface Codex turn diffs through the Hub mobile path
- keep mobile approvals available on send failure
- align prompt policy docs for Hub behavior

## Stack
Stacked on #62. Review this PR against `infra/session-queue-reliability`.

## Verification
Verified on top of the full stack before splitting:
- pnpm vitest run test/context-panel/context-panel-host-tabs.test.tsx test/xfp/audit.test.ts test/xfp/agent-prompt-xfp-policy.test.ts test/xfp/claude-mcp-server.test.ts test/phase-21/field-events/field-handlers.test.ts test/phase-21/session-4/claude-prompt-streaming.test.ts test/phase-22/session-5/codex-prompt-streaming.test.ts
- pnpm vitest run test/xfp
- pnpm lint
- git diff --check
- pnpm build