### PR TITLE
feat(layout): add right context workbench panels

### DIFF
--- a/docs/plans/2026-05-17-v1.4.9-stability-closure.md
+++ b/docs/plans/2026-05-17-v1.4.9-stability-closure.md
@@ -185,6 +185,7 @@ Codex 的稳定性更依赖 main-process 里的 canonical 化：
    - 新 `runEpoch` 清 live overlay，但保留 optimistic user message / compaction chip
    - `session.status idle`、`session.idle`、refresh、remount 顺序互换后不出双 assistant bubble
    - Claude Code / Codex 都走同一组用例
+   - 已完成第一批：`runEpoch + sessionSequence + eventId` 三层 guard，避免同一 event replay 用更高 sequence 二次写入 live overlay 或重复分发给 `SessionShell`。
 3. 只允许 durable timeline 作为完成态真相源，live overlay 只负责 transient。
 4. 把 `SessionView` 的 duplicate/fallback 逻辑压到 legacy 兼容边界，不能继续复制到新链路。
 

--- a/src/main/services/voice/funasr-client.ts
+++ b/src/main/services/voice/funasr-client.ts
@@ -14,6 +14,7 @@ import { createLogger } from '../logger'
 
 const log = createLogger({ component: 'FunAsrClient' })
 const TRANSCRIPTION_CONNECT_TIMEOUT_MS = 10000
+export const FUNASR_WEBSOCKET_SUBPROTOCOL = 'binary'
 
 type AudioChunk = ArrayBuffer | ArrayBufferView
 
@@ -65,7 +66,7 @@ export class FunAsrClient {
 
   async healthCheck(wsUrl: string, timeoutMs = 5000): Promise<boolean> {
     return new Promise((resolve) => {
-      const ws = new WebSocket(wsUrl)
+      const ws = new WebSocket(wsUrl, FUNASR_WEBSOCKET_SUBPROTOCOL)
       let settled = false
       const finish = (ready: boolean): void => {
         if (settled) return
@@ -95,7 +96,7 @@ export class FunAsrClient {
     const id = randomUUID()
 
     return new Promise((resolve, reject) => {
-      const ws = new WebSocket(options.wsUrl)
+      const ws = new WebSocket(options.wsUrl, FUNASR_WEBSOCKET_SUBPROTOCOL)
       let connected = false
       let rejected = false
 

--- a/src/main/services/voice/managed-funasr-runtime.ts
+++ b/src/main/services/voice/managed-funasr-runtime.ts
@@ -27,10 +27,30 @@ const log = createLogger({ component: 'ManagedFunAsrRuntime' })
 
 const FUNASR_REPO_URL = 'https://github.com/modelscope/FunASR.git'
 const FUNASR_REPO_REF = 'b842ff8107e1da950947ada0d11ae3c008baeb54'
-const PINNED_PYTHON_PACKAGES = ['modelscope==1.37.0', 'funasr==1.3.1'] as const
-const INSTALL_MARKER = 'xuanpu-managed-runtime-v2'
+export const MANAGED_FUNASR_REQUIRED_PYTHON_PACKAGES = [
+  'torch==2.11.0',
+  'torchaudio==2.11.0',
+  'modelscope==1.37.0',
+  'funasr==1.3.1'
+] as const
+const REQUIRED_PYTHON_MODULES = ['torch', 'torchaudio', 'funasr', 'websockets'] as const
+const INSTALL_MARKER = 'xuanpu-managed-runtime-v3'
 const LOCAL_PROXY_PORT = 6244
 const LOCAL_PROXY_URL = `http://127.0.0.1:${LOCAL_PROXY_PORT}`
+const SUPPORTED_PYTHON_COMMANDS = [
+  '/opt/homebrew/bin/python3.11',
+  '/usr/local/bin/python3.11',
+  'python3.11',
+  '/opt/homebrew/bin/python3.12',
+  '/usr/local/bin/python3.12',
+  'python3.12',
+  '/opt/homebrew/bin/python3.10',
+  '/usr/local/bin/python3.10',
+  'python3.10',
+  'python3',
+  '/usr/bin/python3',
+  '/opt/homebrew/bin/python3'
+] as const
 
 interface RunResult {
   stdout: string
@@ -51,8 +71,39 @@ interface RuntimeInstallManifest {
   pythonPackages: string[]
 }
 
+export interface PythonVersion {
+  major: number
+  minor: number
+  patch: number
+}
+
 function normalizeCommandText(value: string): string {
   return value.replace(/\\/g, '/')
+}
+
+export function parsePythonVersionOutput(output: string): PythonVersion | null {
+  const match = output.match(/Python\s+(\d+)\.(\d+)(?:\.(\d+))?/)
+  if (!match) return null
+  return {
+    major: Number(match[1]),
+    minor: Number(match[2]),
+    patch: Number(match[3] ?? 0)
+  }
+}
+
+export function isSupportedFunAsrPythonVersion(version: PythonVersion | null): boolean {
+  if (!version) return false
+  if (version.major !== 3) return false
+
+  // FunASR's Python server imports PyTorch at module load. PyTorch macOS arm64
+  // wheels are reliable for 3.10-3.12; newer Homebrew `python3` may point to
+  // 3.14 and create a venv that cannot install torch/torchaudio.
+  return version.minor >= 10 && version.minor <= 12
+}
+
+function formatPythonVersion(version: PythonVersion | null): string {
+  if (!version) return 'unknown'
+  return `${version.major}.${version.minor}.${version.patch}`
 }
 
 export function isManagedFunAsrCommandLine(
@@ -112,7 +163,8 @@ export class ManagedFunAsrRuntime {
     if (!(await this.findPythonCommand())) {
       return {
         status: 'python_missing',
-        message: 'Python 3 is required to prepare the local FunASR runtime'
+        message: 'Python 3.10-3.12 is required to prepare the local FunASR runtime',
+        detail: 'PyTorch wheels are not available for newer Python versions such as 3.14'
       }
     }
 
@@ -157,7 +209,10 @@ export class ManagedFunAsrRuntime {
 
     const python = await this.findPythonCommand()
     if (!python) {
-      throw new Error('Python 3 is required to prepare the local FunASR runtime')
+      throw new Error(
+        'Python 3.10-3.12 is required to prepare the local FunASR runtime. ' +
+          'Install Python 3.11 or 3.12 so PyTorch wheels are available.'
+      )
     }
 
     if (!existsSync(getFunAsrSourceDir()) || !this.isRuntimeInstalled()) {
@@ -169,19 +224,14 @@ export class ManagedFunAsrRuntime {
       await this.ensureFunAsrSource(git, onProgress)
     }
 
-    if (!existsSync(this.venvPython())) {
-      onProgress({
-        status: 'installing_runtime',
-        message: 'Creating local Python runtime',
-        detail: getFunAsrVenvDir()
-      })
-      await this.run(python, ['-m', 'venv', getFunAsrVenvDir()], {
-        timeoutMs: 5 * 60 * 1000,
-        onOutput: (chunk) => appendRuntimeLog(chunk.trimEnd())
-      })
+    await this.ensureCompatibleVenv(python, onProgress)
+
+    let needsDependencyInstall = !this.isRuntimeInstalled()
+    if (!needsDependencyInstall) {
+      needsDependencyInstall = !(await this.hasRequiredRuntimeModules())
     }
 
-    if (!this.isRuntimeInstalled()) {
+    if (needsDependencyInstall) {
       onProgress({
         status: 'installing_runtime',
         message: 'Installing FunASR runtime dependencies',
@@ -201,7 +251,7 @@ export class ManagedFunAsrRuntime {
       })
       await this.run(
         this.venvPython(),
-        ['-m', 'pip', 'install', '--upgrade', ...PINNED_PYTHON_PACKAGES],
+        ['-m', 'pip', 'install', '--upgrade', ...MANAGED_FUNASR_REQUIRED_PYTHON_PACKAGES],
         {
           timeoutMs: 30 * 60 * 1000,
           onOutput: (chunk) => {
@@ -235,6 +285,7 @@ export class ManagedFunAsrRuntime {
       this.writeInstallManifest()
     }
 
+    await this.verifyRequiredRuntimeModules()
     await this.start(runtime, onProgress)
   }
 
@@ -400,7 +451,7 @@ export class ManagedFunAsrRuntime {
       marker: INSTALL_MARKER,
       funasrRepoUrl: FUNASR_REPO_URL,
       funasrRepoRef: FUNASR_REPO_REF,
-      pythonPackages: [...PINNED_PYTHON_PACKAGES]
+      pythonPackages: [...MANAGED_FUNASR_REQUIRED_PYTHON_PACKAGES]
     }
   }
 
@@ -437,15 +488,101 @@ export class ManagedFunAsrRuntime {
   }
 
   private async findPythonCommand(): Promise<string | null> {
-    for (const command of ['python3', '/usr/bin/python3', '/opt/homebrew/bin/python3']) {
+    const attempted: Array<{ command: string; version?: string; supported?: boolean }> = []
+    for (const command of Array.from(new Set(SUPPORTED_PYTHON_COMMANDS))) {
       try {
-        const result = await this.run(command, ['--version'], { timeoutMs: 5000 })
-        if (result.code === 0) return command
+        const version = await this.getPythonVersion(command)
+        const supported = isSupportedFunAsrPythonVersion(version)
+        attempted.push({ command, version: formatPythonVersion(version), supported })
+        if (supported) {
+          log.info('Selected Python for managed FunASR runtime', {
+            command,
+            version: formatPythonVersion(version)
+          })
+          return command
+        }
       } catch {
         // Try the next common Python location.
       }
     }
+    log.warn('No supported Python found for managed FunASR runtime', { attempted })
     return null
+  }
+
+  private async getPythonVersion(command: string): Promise<PythonVersion | null> {
+    const result = await this.run(command, ['--version'], { timeoutMs: 5000 })
+    return parsePythonVersionOutput(`${result.stdout}\n${result.stderr}`)
+  }
+
+  private async ensureCompatibleVenv(
+    python: string,
+    onProgress: (progress: VoiceRuntimeProgress) => void
+  ): Promise<void> {
+    if (existsSync(this.venvPython())) {
+      let version: PythonVersion | null = null
+      try {
+        version = await this.getPythonVersion(this.venvPython())
+      } catch {
+        version = null
+      }
+
+      if (!isSupportedFunAsrPythonVersion(version)) {
+        appendRuntimeLog(
+          `Recreating FunASR Python runtime because venv uses unsupported Python ${formatPythonVersion(
+            version
+          )}`
+        )
+        onProgress({
+          status: 'installing_runtime',
+          message: 'Recreating local Python runtime',
+          detail: `Unsupported Python ${formatPythonVersion(version)}`
+        })
+        rmSync(getFunAsrVenvDir(), { force: true, recursive: true })
+      }
+    }
+
+    if (existsSync(this.venvPython())) return
+
+    onProgress({
+      status: 'installing_runtime',
+      message: 'Creating local Python runtime',
+      detail: getFunAsrVenvDir()
+    })
+    await this.run(python, ['-m', 'venv', getFunAsrVenvDir()], {
+      timeoutMs: 5 * 60 * 1000,
+      onOutput: (chunk) => appendRuntimeLog(chunk.trimEnd())
+    })
+  }
+
+  private runtimeModuleProbe(): string {
+    return [
+      'import importlib.util',
+      `modules = ${JSON.stringify(REQUIRED_PYTHON_MODULES)}`,
+      'missing = [name for name in modules if importlib.util.find_spec(name) is None]',
+      'raise SystemExit("Missing runtime Python modules: " + ", ".join(missing) if missing else 0)'
+    ].join('; ')
+  }
+
+  private async hasRequiredRuntimeModules(): Promise<boolean> {
+    if (!existsSync(this.venvPython())) return false
+    try {
+      await this.run(this.venvPython(), ['-c', this.runtimeModuleProbe()], { timeoutMs: 30000 })
+      return true
+    } catch (error) {
+      appendRuntimeLog(
+        `FunASR runtime dependency check failed: ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      )
+      return false
+    }
+  }
+
+  private async verifyRequiredRuntimeModules(): Promise<void> {
+    if (await this.hasRequiredRuntimeModules()) return
+    throw new Error(
+      `Missing required local FunASR Python modules: ${REQUIRED_PYTHON_MODULES.join(', ')}`
+    )
   }
 
   private async findGitCommand(): Promise<string | null> {

--- a/src/renderer/src/components/context-panel/ContextPanelHost.tsx
+++ b/src/renderer/src/components/context-panel/ContextPanelHost.tsx
@@ -17,6 +17,7 @@ import { PrReviewViewer } from '@/components/pr-review/PrReviewViewer'
 import { GoalStatusCard } from '@/components/session-hq/cards/GoalStatusCard'
 import { TodoCard } from '@/components/session-hq/cards/TodoCard'
 import { extractMissionTasks, type SessionTask } from '@/lib/session-tasks'
+import type { UsageAnalyticsSessionSummary } from '@shared/types/usage-analytics'
 
 interface ConnectionMemberInfo {
   worktree_path: string
@@ -56,6 +57,7 @@ const REVIEW_TABS: Array<{ id: RightReviewTab; labelKey: string }> = [
   { id: 'diffs', labelKey: 'fileTree.sidebar.diffs' },
   { id: 'comments', labelKey: 'fileTree.sidebar.comments' }
 ]
+const EMPTY_TASKS: SessionTask[] = []
 
 function formatCompactNumber(value: number): string {
   if (!Number.isFinite(value)) return '0'
@@ -115,8 +117,27 @@ function findSessionById(state: ReturnType<typeof useSessionStore.getState>, ses
   return null
 }
 
+function getGoalSignature(goal: {
+  threadId?: string
+  objective: string
+  successCriteria?: string
+  status: string
+  createdAt?: number | null
+}): string {
+  return [
+    goal.threadId?.trim() ?? '',
+    goal.objective.trim(),
+    goal.successCriteria?.trim() ?? '',
+    goal.status.trim().toLowerCase(),
+    goal.createdAt ?? ''
+  ].join('|')
+}
+
 function useSessionTasks(activeSessionId: string | null): SessionTask[] {
   const [tasks, setTasks] = useState<SessionTask[]>([])
+  const liveTasks = useSessionRuntimeStore((state) =>
+    activeSessionId ? state.getSessionTasks(activeSessionId) : EMPTY_TASKS
+  )
   const activityTick = useSessionRuntimeStore((state) =>
     activeSessionId ? state.getSession(activeSessionId).lastActivityAt : 0
   )
@@ -146,7 +167,7 @@ function useSessionTasks(activeSessionId: string | null): SessionTask[] {
     }
   }, [activeSessionId, activityTick])
 
-  return tasks
+  return liveTasks.length > 0 ? liveTasks : tasks
 }
 
 function OverviewPanel({
@@ -159,6 +180,42 @@ function OverviewPanel({
   usage: SessionContextUsage | null
 }): React.JSX.Element {
   const { t } = useI18n()
+  const [summary, setSummary] = useState<UsageAnalyticsSessionSummary | null>(null)
+  const activityTick = useSessionRuntimeStore((state) =>
+    activeSessionId ? state.getSession(activeSessionId).lastActivityAt : 0
+  )
+
+  useEffect(() => {
+    let cancelled = false
+
+    if (!activeSessionId || !window.usageAnalyticsOps?.fetchSessionSummary) {
+      setSummary(null)
+      return () => {
+        cancelled = true
+      }
+    }
+
+    window.usageAnalyticsOps
+      .fetchSessionSummary(activeSessionId)
+      .then((result) => {
+        if (cancelled) return
+        const nextSummary = result.success && result.data ? result.data : null
+        setSummary(nextSummary)
+        if (nextSummary && nextSummary.total_cost > 0) {
+          const store = useContextStore.getState()
+          if ((store.costBySession[activeSessionId] ?? 0) < nextSummary.total_cost) {
+            store.setSessionCost(activeSessionId, nextSummary.total_cost)
+          }
+        }
+      })
+      .catch(() => {
+        if (!cancelled) setSummary(null)
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [activeSessionId, activityTick])
 
   if (!activeSessionId) {
     return (
@@ -170,13 +227,20 @@ function OverviewPanel({
   }
 
   const tokens = usage?.tokens
-  const totalTokens = tokens
+  const liveTotalTokens = tokens
     ? tokens.input + tokens.output + tokens.reasoning + tokens.cacheRead + tokens.cacheWrite
     : 0
+  const totalCost = Math.max(summary?.total_cost ?? 0, usage?.cost ?? 0)
+  const totalTokens =
+    summary?.total_tokens && summary.total_tokens > 0 ? summary.total_tokens : liveTotalTokens
+  const inputTokens = summary?.input_tokens ?? tokens?.input ?? 0
+  const outputTokens = summary?.output_tokens ?? tokens?.output ?? 0
+  const cacheReadTokens = summary?.cache_read_tokens ?? tokens?.cacheRead ?? 0
+  const cacheWriteTokens = summary?.cache_write_tokens ?? tokens?.cacheWrite ?? 0
   const metrics: ContextMetric[] = [
     {
       label: t('contextPanel.overview.cost'),
-      value: formatCost(usage?.cost ?? 0)
+      value: formatCost(totalCost)
     },
     {
       label: t('contextPanel.overview.tokens'),
@@ -191,13 +255,13 @@ function OverviewPanel({
     },
     {
       label: t('contextPanel.overview.input'),
-      value: formatCompactNumber(tokens?.input ?? 0),
-      muted: `${t('contextPanel.overview.output')} ${formatCompactNumber(tokens?.output ?? 0)}`
+      value: formatCompactNumber(inputTokens),
+      muted: `${t('contextPanel.overview.output')} ${formatCompactNumber(outputTokens)}`
     },
     {
       label: t('contextPanel.overview.cacheRead'),
-      value: formatCompactNumber(tokens?.cacheRead ?? 0),
-      muted: `${t('contextPanel.overview.cacheWrite')} ${formatCompactNumber(tokens?.cacheWrite ?? 0)}`
+      value: formatCompactNumber(cacheReadTokens),
+      muted: `${t('contextPanel.overview.cacheWrite')} ${formatCompactNumber(cacheWriteTokens)}`
     }
   ]
 
@@ -225,6 +289,9 @@ function GoalPanel({ activeSessionId }: { activeSessionId: string | null }): Rea
   const goal = useSessionRuntimeStore((state) =>
     activeSessionId ? (state.goals.get(activeSessionId) ?? null) : null
   )
+  const dismissedGoalSignature = useSessionRuntimeStore((state) =>
+    activeSessionId ? state.getDismissedGoalSignature(activeSessionId) : null
+  )
 
   if (!activeSessionId) {
     return (
@@ -235,7 +302,7 @@ function GoalPanel({ activeSessionId }: { activeSessionId: string | null }): Rea
     )
   }
 
-  if (!goal) {
+  if (!goal || dismissedGoalSignature === getGoalSignature(goal)) {
     return (
       <EmptyPanel
         title={t('contextPanel.goal.emptyTitle')}
@@ -246,7 +313,18 @@ function GoalPanel({ activeSessionId }: { activeSessionId: string | null }): Rea
 
   return (
     <div className="min-h-0 flex-1 overflow-auto p-3" data-testid="context-panel-goal">
-      <GoalStatusCard goal={goal} />
+      <GoalStatusCard
+        goal={goal}
+        onDismiss={
+          goal.status.trim().toLowerCase() === 'completed'
+            ? () => {
+                useSessionRuntimeStore
+                  .getState()
+                  .dismissGoalSignature(activeSessionId, getGoalSignature(goal))
+              }
+            : undefined
+        }
+      />
     </div>
   )
 }

--- a/src/renderer/src/components/context-panel/ContextPanelHost.tsx
+++ b/src/renderer/src/components/context-panel/ContextPanelHost.tsx
@@ -1,43 +1,32 @@
-import React, { useEffect, useMemo, useState } from 'react'
-import { BarChart3, Files, GitPullRequest, ListTodo, Target, X } from 'lucide-react'
+import React, { useEffect, useMemo, useRef, useState } from 'react'
+import { BarChart3, Files, GitPullRequest, ListTodo, SquareTerminal, Target } from 'lucide-react'
+import { useShallow } from 'zustand/react/shallow'
 import { cn } from '@/lib/utils'
 import { useI18n } from '@/i18n/useI18n'
-import { useLayoutStore, type RightContextTab, type RightReviewTab } from '@/stores/useLayoutStore'
+import { useLayoutStore, type RightContextTab } from '@/stores/useLayoutStore'
 import { useSettingsStore } from '@/stores/useSettingsStore'
-import { useWorktreeStore } from '@/stores/useWorktreeStore'
-import { useGitStore } from '@/stores/useGitStore'
 import { useSessionStore } from '@/stores/useSessionStore'
 import { useSessionRuntimeStore } from '@/stores/useSessionRuntimeStore'
-import { useContextStore, type SessionContextUsage } from '@/stores/useContextStore'
+import { useContextStore } from '@/stores/useContextStore'
 import { FileTree } from '@/components/file-tree/FileTree'
-import { ChangesView } from '@/components/file-tree/ChangesView'
-import { BranchDiffView } from '@/components/file-tree/BranchDiffView'
-import { DiffCommentsViewer } from '@/components/diff-comments/DiffCommentsViewer'
-import { PrReviewViewer } from '@/components/pr-review/PrReviewViewer'
+import {
+  ReviewWorkflowPanel,
+  type ConnectionMemberInfo
+} from '@/components/context-panel/ReviewWorkflowPanel'
 import { GoalStatusCard } from '@/components/session-hq/cards/GoalStatusCard'
 import { TodoCard } from '@/components/session-hq/cards/TodoCard'
 import { extractMissionTasks, type SessionTask } from '@/lib/session-tasks'
 import type { UsageAnalyticsSessionSummary } from '@shared/types/usage-analytics'
 
-interface ConnectionMemberInfo {
-  worktree_path: string
-  project_name: string
-  worktree_branch: string
-}
-
 interface ContextPanelHostProps {
   worktreePath: string | null
+  scopeId?: string | null
   isConnectionMode?: boolean
   connectionMembers?: ConnectionMemberInfo[]
   onClose: () => void
   onFileClick: (node: { path: string; name: string; isDirectory: boolean }) => void
+  terminalPanel?: React.ReactNode
   className?: string
-}
-
-interface ContextMetric {
-  label: string
-  value: string
-  muted?: string
 }
 
 const CONTEXT_TABS: Array<{
@@ -49,14 +38,10 @@ const CONTEXT_TABS: Array<{
   { id: 'review', icon: GitPullRequest, labelKey: 'contextPanel.tabs.review' },
   { id: 'files', icon: Files, labelKey: 'contextPanel.tabs.files' },
   { id: 'tasks', icon: ListTodo, labelKey: 'contextPanel.tabs.tasks' },
-  { id: 'goal', icon: Target, labelKey: 'contextPanel.tabs.goal' }
+  { id: 'goal', icon: Target, labelKey: 'contextPanel.tabs.goal' },
+  { id: 'terminal', icon: SquareTerminal, labelKey: 'bottomPanel.tabs.terminal' }
 ]
 
-const REVIEW_TABS: Array<{ id: RightReviewTab; labelKey: string }> = [
-  { id: 'changes', labelKey: 'fileTree.sidebar.changes' },
-  { id: 'diffs', labelKey: 'fileTree.sidebar.diffs' },
-  { id: 'comments', labelKey: 'fileTree.sidebar.comments' }
-]
 const EMPTY_TASKS: SessionTask[] = []
 
 function formatCompactNumber(value: number): string {
@@ -70,6 +55,11 @@ function formatCost(value: number): string {
   if (!Number.isFinite(value) || value <= 0) return '$0'
   if (value < 0.01) return `$${value.toFixed(4)}`
   return `$${value.toFixed(2)}`
+}
+
+function idsEqual(a: string[], b: string[]): boolean {
+  if (a.length !== b.length) return false
+  return a.every((id, index) => id === b[index])
 }
 
 function EmptyPanel({
@@ -89,32 +79,84 @@ function EmptyPanel({
   )
 }
 
-function MetricCard({ metric }: { metric: ContextMetric }): React.JSX.Element {
+function OverviewTokenRow({
+  label,
+  amount,
+  value,
+  max,
+  tone = 'default'
+}: {
+  label: string
+  amount: number
+  value: string
+  max: number
+  tone?: 'mint' | 'lavender' | 'muted'
+}): React.JSX.Element {
+  const percent =
+    max > 0 && Number.isFinite(amount) && amount > 0 ? Math.max(3, (amount / max) * 100) : 0
+
   return (
-    <div className="rounded-lg border border-sidebar-border/70 bg-sidebar-accent/25 px-3 py-2.5">
-      <div className="text-[10px] font-medium uppercase tracking-[0.14em] text-muted-foreground">
-        {metric.label}
+    <div className="space-y-1.5">
+      <div className="flex items-center justify-between gap-2">
+        <div className="min-w-0 truncate text-[11px] font-medium text-muted-foreground">
+          {label}
+        </div>
+        <div
+          className={cn(
+            'shrink-0 font-mono text-xs font-medium tabular-nums',
+            tone === 'muted' ? 'text-muted-foreground/80' : 'text-steel'
+          )}
+        >
+          {value}
+        </div>
       </div>
-      <div className="mt-1 text-lg font-semibold tabular-nums text-sidebar-foreground">
-        {metric.value}
+      <div className="h-1.5 overflow-hidden rounded-full bg-neon-mint-soft/80">
+        <div
+          className={cn(
+            'h-full rounded-full',
+            tone === 'mint'
+              ? 'bg-neon-mint'
+              : tone === 'lavender'
+                ? 'bg-neon-violet/75'
+                : 'bg-steel/25'
+          )}
+          style={{ width: `${Math.min(percent, 100)}%` }}
+        />
       </div>
-      {metric.muted && (
-        <div className="mt-0.5 text-[11px] text-muted-foreground">{metric.muted}</div>
-      )}
     </div>
   )
 }
 
-function findSessionById(state: ReturnType<typeof useSessionStore.getState>, sessionId: string) {
-  for (const sessions of state.sessionsByWorktree.values()) {
-    const match = sessions.find((session) => session.id === sessionId)
-    if (match) return match
-  }
-  for (const sessions of state.sessionsByConnection.values()) {
-    const match = sessions.find((session) => session.id === sessionId)
-    if (match) return match
-  }
-  return null
+function OverviewHeroMetric({
+  label,
+  value,
+  tone = 'default'
+}: {
+  label: string
+  value: string
+  tone?: 'default' | 'cost' | 'tokens'
+}): React.JSX.Element {
+  return (
+    <div className="relative flex min-w-0 flex-col gap-1 overflow-hidden rounded-[10px] border border-sidebar-border bg-agent-card px-3.5 py-2">
+      <div
+        className={cn(
+          'absolute left-0 right-0 top-0 h-0.5',
+          tone === 'cost' ? 'bg-neon-pink' : tone === 'tokens' ? 'bg-neon-mint' : 'bg-tech-blue'
+        )}
+      />
+      <div className="min-w-0 truncate text-[10px] font-semibold uppercase tracking-[0.14em] text-muted-foreground/85">
+        {label}
+      </div>
+      <div
+        className={cn(
+          'shrink-0 whitespace-nowrap font-mono text-[24px] font-semibold leading-none tabular-nums tracking-tight',
+          tone === 'cost' ? 'text-neon-pink' : tone === 'tokens' ? 'text-neon-mint' : 'text-ink'
+        )}
+      >
+        {value}
+      </div>
+    </div>
+  )
 }
 
 function getGoalSignature(goal: {
@@ -171,114 +213,216 @@ function useSessionTasks(activeSessionId: string | null): SessionTask[] {
 }
 
 function OverviewPanel({
-  activeSessionId,
+  sessionIds,
   worktreePath,
-  usage
+  scopeLabel
 }: {
-  activeSessionId: string | null
+  sessionIds: string[]
   worktreePath: string | null
-  usage: SessionContextUsage | null
+  scopeLabel: string
 }): React.JSX.Element {
   const { t } = useI18n()
-  const [summary, setSummary] = useState<UsageAnalyticsSessionSummary | null>(null)
+  const sessionIdsKey = sessionIds.join('|')
+  const [summaryBySession, setSummaryBySession] = useState<
+    Record<string, UsageAnalyticsSessionSummary>
+  >({})
+  const summaryBySessionRef = useRef(summaryBySession)
   const activityTick = useSessionRuntimeStore((state) =>
-    activeSessionId ? state.getSession(activeSessionId).lastActivityAt : 0
+    sessionIds.map((sessionId) => state.sessions.get(sessionId)?.lastActivityAt ?? 0).join('|')
   )
+  const { tokensBySession, costBySession } = useContextStore(
+    useShallow((state) => ({
+      tokensBySession: state.tokensBySession,
+      costBySession: state.costBySession
+    }))
+  )
+
+  useEffect(() => {
+    summaryBySessionRef.current = summaryBySession
+  }, [summaryBySession])
 
   useEffect(() => {
     let cancelled = false
 
-    if (!activeSessionId || !window.usageAnalyticsOps?.fetchSessionSummary) {
-      setSummary(null)
+    if (sessionIds.length === 0 || !window.usageAnalyticsOps?.fetchSessionSummary) {
+      setSummaryBySession({})
       return () => {
         cancelled = true
       }
     }
 
-    window.usageAnalyticsOps
-      .fetchSessionSummary(activeSessionId)
-      .then((result) => {
-        if (cancelled) return
-        const nextSummary = result.success && result.data ? result.data : null
-        setSummary(nextSummary)
-        if (nextSummary && nextSummary.total_cost > 0) {
-          const store = useContextStore.getState()
-          if ((store.costBySession[activeSessionId] ?? 0) < nextSummary.total_cost) {
-            store.setSessionCost(activeSessionId, nextSummary.total_cost)
-          }
+    Promise.all(
+      sessionIds.map(async (sessionId) => {
+        try {
+          const result = await window.usageAnalyticsOps.fetchSessionSummary(sessionId)
+          if (!result.success || !result.data) return null
+          return [sessionId, result.data] as const
+        } catch {
+          return null
         }
       })
+    )
+      .then((entries) => {
+        if (cancelled) return
+
+        const next: Record<string, UsageAnalyticsSessionSummary> = {}
+        const store = useContextStore.getState()
+        for (const entry of entries) {
+          if (!entry) continue
+          const [sessionId, summary] = entry
+          next[sessionId] = summary
+          if (
+            summary.total_cost > 0 &&
+            (store.costBySession[sessionId] ?? 0) < summary.total_cost
+          ) {
+            store.setSessionCost(sessionId, summary.total_cost)
+          }
+        }
+        if (
+          Object.keys(next).length === 0 &&
+          Object.keys(summaryBySessionRef.current).length === 0
+        ) {
+          return
+        }
+        setSummaryBySession(next)
+      })
       .catch(() => {
-        if (!cancelled) setSummary(null)
+        if (!cancelled) setSummaryBySession({})
       })
 
     return () => {
       cancelled = true
     }
-  }, [activeSessionId, activityTick])
+  }, [activityTick, sessionIds, sessionIdsKey])
 
-  if (!activeSessionId) {
+  if (!worktreePath && sessionIds.length === 0) {
     return (
       <EmptyPanel
-        title={t('contextPanel.empty.noSessionTitle')}
+        title={t('contextPanel.empty.noWorktree')}
         description={t('contextPanel.empty.noSessionDescription')}
       />
     )
   }
 
-  const tokens = usage?.tokens
-  const liveTotalTokens = tokens
-    ? tokens.input + tokens.output + tokens.reasoning + tokens.cacheRead + tokens.cacheWrite
-    : 0
-  const totalCost = Math.max(summary?.total_cost ?? 0, usage?.cost ?? 0)
-  const totalTokens =
-    summary?.total_tokens && summary.total_tokens > 0 ? summary.total_tokens : liveTotalTokens
-  const inputTokens = summary?.input_tokens ?? tokens?.input ?? 0
-  const outputTokens = summary?.output_tokens ?? tokens?.output ?? 0
-  const cacheReadTokens = summary?.cache_read_tokens ?? tokens?.cacheRead ?? 0
-  const cacheWriteTokens = summary?.cache_write_tokens ?? tokens?.cacheWrite ?? 0
-  const metrics: ContextMetric[] = [
-    {
-      label: t('contextPanel.overview.cost'),
-      value: formatCost(totalCost)
+  const totals = sessionIds.reduce(
+    (acc, sessionId) => {
+      const summary = summaryBySession[sessionId]
+      const tokens = tokensBySession[sessionId]
+      const liveTotalTokens = tokens
+        ? tokens.input + tokens.output + tokens.reasoning + tokens.cacheRead + tokens.cacheWrite
+        : 0
+
+      acc.totalCost += Math.max(summary?.total_cost ?? 0, costBySession[sessionId] ?? 0)
+      acc.totalTokens += Math.max(summary?.total_tokens ?? 0, liveTotalTokens)
+      acc.inputTokens += Math.max(summary?.input_tokens ?? 0, tokens?.input ?? 0)
+      acc.outputTokens += Math.max(summary?.output_tokens ?? 0, tokens?.output ?? 0)
+      acc.cacheReadTokens += Math.max(summary?.cache_read_tokens ?? 0, tokens?.cacheRead ?? 0)
+      acc.cacheWriteTokens += Math.max(summary?.cache_write_tokens ?? 0, tokens?.cacheWrite ?? 0)
+      return acc
     },
     {
-      label: t('contextPanel.overview.tokens'),
-      value: formatCompactNumber(totalTokens),
-      muted:
-        usage?.limit && usage.limit > 0
-          ? t('contextPanel.overview.contextLimit', {
-              used: formatCompactNumber(usage.used),
-              limit: formatCompactNumber(usage.limit)
-            })
-          : undefined
-    },
+      totalCost: 0,
+      totalTokens: 0,
+      inputTokens: 0,
+      outputTokens: 0,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0
+    }
+  )
+  const maxTokenSlice = Math.max(
+    totals.inputTokens,
+    totals.outputTokens,
+    totals.cacheReadTokens,
+    totals.cacheWriteTokens,
+    1
+  )
+  const tokenRows = [
     {
       label: t('contextPanel.overview.input'),
-      value: formatCompactNumber(inputTokens),
-      muted: `${t('contextPanel.overview.output')} ${formatCompactNumber(outputTokens)}`
+      amount: totals.inputTokens,
+      tone: 'mint' as const
+    },
+    {
+      label: t('contextPanel.overview.output'),
+      amount: totals.outputTokens,
+      tone: 'lavender' as const
     },
     {
       label: t('contextPanel.overview.cacheRead'),
-      value: formatCompactNumber(cacheReadTokens),
-      muted: `${t('contextPanel.overview.cacheWrite')} ${formatCompactNumber(cacheWriteTokens)}`
+      amount: totals.cacheReadTokens,
+      tone: 'muted' as const
+    },
+    {
+      label: t('contextPanel.overview.cacheWrite'),
+      amount: totals.cacheWriteTokens,
+      tone: 'muted' as const
     }
   ]
 
   return (
-    <div className="min-h-0 flex-1 overflow-auto p-3" data-testid="context-panel-overview">
-      <div className="grid grid-cols-2 gap-2">
-        {metrics.map((metric) => (
-          <MetricCard key={metric.label} metric={metric} />
-        ))}
-      </div>
-      <div className="mt-3 rounded-lg border border-sidebar-border/70 bg-sidebar-accent/20 px-3 py-2.5">
-        <div className="text-[10px] font-medium uppercase tracking-[0.14em] text-muted-foreground">
-          {t('contextPanel.overview.worktree')}
-        </div>
-        <div className="mt-1 truncate font-mono text-xs text-sidebar-foreground">
-          {worktreePath ?? t('contextPanel.empty.noWorktree')}
-        </div>
+    <div className="min-h-0 flex-1 overflow-auto px-2.5 py-3" data-testid="context-panel-overview">
+      <div className="space-y-2.5">
+        <section className="crisp-floating-surface relative overflow-hidden rounded-xl p-3">
+          <div className="pointer-events-none absolute -right-12 -top-12 h-28 w-28 rounded-full bg-tech-blue-soft blur-2xl" />
+          <div className="relative min-w-0">
+            <div className="min-w-0">
+              <div className="text-[10px] font-semibold uppercase tracking-[0.16em] text-steel">
+                {scopeLabel} · {t('contextPanel.tabs.overview')}
+              </div>
+              <div className="mt-1.5 truncate text-[11px] text-muted-foreground">
+                {t('contextPanel.overview.sessionCount', {
+                  count: sessionIds.length,
+                  scope: scopeLabel
+                })}
+              </div>
+            </div>
+          </div>
+
+          <div className="relative mt-3 space-y-1.5">
+            <OverviewHeroMetric
+              label={t('contextPanel.overview.cost')}
+              value={formatCost(totals.totalCost)}
+              tone="cost"
+            />
+            <OverviewHeroMetric
+              label={t('contextPanel.overview.tokens')}
+              value={formatCompactNumber(totals.totalTokens)}
+              tone="tokens"
+            />
+          </div>
+        </section>
+
+        <section className="crisp-panel-surface rounded-xl p-3">
+          <div className="mb-2.5 text-[10px] font-semibold uppercase tracking-[0.16em] text-muted-foreground">
+            {t('contextPanel.overview.tokens')}
+          </div>
+          <div className="space-y-2.5">
+            {tokenRows.map((row) => (
+              <OverviewTokenRow
+                key={row.label}
+                label={row.label}
+                amount={row.amount}
+                value={formatCompactNumber(row.amount)}
+                max={maxTokenSlice}
+                tone={row.tone}
+              />
+            ))}
+          </div>
+        </section>
+
+        <section className="rounded-xl border border-sidebar-border bg-agent-card px-3 py-2.5">
+          <div className="flex items-center justify-between gap-2">
+            <div className="text-[10px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">
+              {scopeLabel}
+            </div>
+            <div className="text-[10px] font-medium text-muted-foreground">
+              {t('contextPanel.overview.sessions')}: {formatCompactNumber(sessionIds.length)}
+            </div>
+          </div>
+          <div className="mt-1.5 break-all font-mono text-[11px] leading-relaxed text-steel">
+            {worktreePath ?? t('contextPanel.empty.noWorktree')}
+          </div>
+        </section>
       </div>
     </div>
   )
@@ -358,80 +502,6 @@ function TasksPanel({ activeSessionId }: { activeSessionId: string | null }): Re
   )
 }
 
-function ReviewPanel({
-  worktreePath,
-  isConnectionMode,
-  connectionMembers
-}: Pick<
-  ContextPanelHostProps,
-  'worktreePath' | 'isConnectionMode' | 'connectionMembers'
->): React.JSX.Element {
-  const { t } = useI18n()
-  const selectedWorktreeId = useWorktreeStore((s) => s.selectedWorktreeId)
-  const activeReviewTab = useLayoutStore((s) => s.rightReviewTab)
-  const setRightReviewTab = useLayoutStore((s) => s.setRightReviewTab)
-  const hasAttachedPR = useGitStore(
-    (s) => !!(selectedWorktreeId && s.attachedPR.get(selectedWorktreeId))
-  )
-  const effectiveReviewTab =
-    !selectedWorktreeId && activeReviewTab === 'comments' ? 'changes' : activeReviewTab
-
-  useEffect(() => {
-    if (!selectedWorktreeId && activeReviewTab === 'comments') {
-      setRightReviewTab('changes')
-    }
-  }, [activeReviewTab, selectedWorktreeId, setRightReviewTab])
-
-  return (
-    <div className="flex min-h-0 flex-1 flex-col" data-testid="context-panel-review">
-      <div className="border-b border-sidebar-border/60 px-2.5 py-2">
-        <div className="inline-flex min-w-max items-center gap-1 rounded-lg bg-sidebar-accent/40 p-0.5">
-          {REVIEW_TABS.map((tab) => {
-            if (tab.id === 'comments' && !selectedWorktreeId) return null
-            return (
-              <button
-                key={tab.id}
-                type="button"
-                className={cn(
-                  'shrink-0 rounded-md px-2.5 py-1.5 text-[11px] font-medium transition-colors',
-                  effectiveReviewTab === tab.id
-                    ? 'bg-sidebar-accent text-sidebar-accent-foreground'
-                    : 'text-muted-foreground hover:bg-sidebar-accent/60 hover:text-sidebar-accent-foreground'
-                )}
-                onClick={() => setRightReviewTab(tab.id)}
-                data-testid={`context-panel-review-${tab.id}`}
-              >
-                {t(tab.labelKey)}
-              </button>
-            )
-          })}
-        </div>
-      </div>
-
-      <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
-        {effectiveReviewTab === 'comments' && selectedWorktreeId ? (
-          <div className="flex min-h-0 flex-1 flex-col">
-            <DiffCommentsViewer
-              worktreeId={selectedWorktreeId}
-              worktreePath={worktreePath}
-              compact={hasAttachedPR}
-            />
-            {hasAttachedPR && <PrReviewViewer worktreeId={selectedWorktreeId} />}
-          </div>
-        ) : effectiveReviewTab === 'diffs' ? (
-          <BranchDiffView worktreePath={worktreePath} />
-        ) : (
-          <ChangesView
-            worktreePath={worktreePath}
-            isConnectionMode={isConnectionMode}
-            connectionMembers={connectionMembers}
-          />
-        )}
-      </div>
-    </div>
-  )
-}
-
 function FilesPanel({
   worktreePath,
   isConnectionMode,
@@ -456,10 +526,12 @@ function FilesPanel({
 
 export function ContextPanelHost({
   worktreePath,
+  scopeId,
   isConnectionMode,
   connectionMembers,
   onClose,
   onFileClick,
+  terminalPanel,
   className
 }: ContextPanelHostProps): React.JSX.Element {
   const { t } = useI18n()
@@ -468,18 +540,73 @@ export function ContextPanelHost({
   const setRightReviewTab = useLayoutStore((s) => s.setRightReviewTab)
   const vimModeEnabled = useSettingsStore((s) => s.vimModeEnabled)
   const activeSessionId = useSessionStore((s) => s.inlineConnectionSessionId ?? s.activeSessionId)
-  const activeSession = useSessionStore((s) => {
-    const sessionId = s.inlineConnectionSessionId ?? s.activeSessionId
-    return sessionId ? findSessionById(s, sessionId) : null
-  })
-  const contextState = useContextStore()
-  const usage = activeSessionId
-    ? contextState.getContextUsage(
-        activeSessionId,
-        activeSession?.model_id ?? '',
-        activeSession?.model_provider_id ?? undefined
-      )
-    : null
+  const fallbackOverviewScopeId = useSessionStore((s) =>
+    isConnectionMode ? s.activeConnectionId : s.activeWorktreeId
+  )
+  const overviewScopeId = scopeId ?? fallbackOverviewScopeId
+  const cachedOverviewSessionIds = useSessionStore(
+    useShallow((s) => {
+      const sessions = overviewScopeId
+        ? isConnectionMode
+          ? (s.sessionsByConnection.get(overviewScopeId) ?? [])
+          : (s.sessionsByWorktree.get(overviewScopeId) ?? [])
+        : []
+      const ids = sessions.map((session) => session.id)
+      if (ids.length > 0) return ids
+      return activeSessionId ? [activeSessionId] : []
+    })
+  )
+  const cachedOverviewSessionIdsKey = cachedOverviewSessionIds.join('|')
+  const [overviewSessionIds, setOverviewSessionIds] = useState<string[]>(cachedOverviewSessionIds)
+  const tabs = useMemo(
+    () => (terminalPanel ? CONTEXT_TABS : CONTEXT_TABS.filter((tab) => tab.id !== 'terminal')),
+    [terminalPanel]
+  )
+  const overviewScopeLabel = isConnectionMode
+    ? t('contextPanel.overview.connection')
+    : t('contextPanel.overview.worktree')
+
+  useEffect(() => {
+    let cancelled = false
+
+    setOverviewSessionIds((current) =>
+      idsEqual(current, cachedOverviewSessionIds) ? current : cachedOverviewSessionIds
+    )
+
+    if (!overviewScopeId || !window.db?.session) {
+      return () => {
+        cancelled = true
+      }
+    }
+
+    const loadSessions = isConnectionMode
+      ? window.db.session.getByConnection
+      : window.db.session.getByWorktree
+
+    loadSessions(overviewScopeId)
+      .then((sessions) => {
+        if (cancelled) return
+        const ids = sessions.map((session) => session.id)
+        const nextIds = ids.length > 0 ? ids : cachedOverviewSessionIds
+        setOverviewSessionIds((current) => (idsEqual(current, nextIds) ? current : nextIds))
+      })
+      .catch(() => {
+        if (cancelled) return
+        setOverviewSessionIds((current) =>
+          idsEqual(current, cachedOverviewSessionIds) ? current : cachedOverviewSessionIds
+        )
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [cachedOverviewSessionIds, cachedOverviewSessionIdsKey, isConnectionMode, overviewScopeId])
+
+  useEffect(() => {
+    if (activeTab === 'terminal' && !terminalPanel) {
+      setRightContextTab('overview')
+    }
+  }, [activeTab, setRightContextTab, terminalPanel])
 
   useEffect(() => {
     const handler = (event: Event): void => {
@@ -489,6 +616,10 @@ export function ContextPanelHost({
         setRightContextTab('files')
         return
       }
+      if (tab === 'terminal' && terminalPanel) {
+        setRightContextTab('terminal')
+        return
+      }
       if (tab === 'changes' || tab === 'diffs' || tab === 'comments') {
         setRightContextTab('review')
         setRightReviewTab(tab)
@@ -496,21 +627,23 @@ export function ContextPanelHost({
     }
     window.addEventListener('hive:right-sidebar-tab', handler)
     return () => window.removeEventListener('hive:right-sidebar-tab', handler)
-  }, [setRightContextTab, setRightReviewTab, vimModeEnabled])
+  }, [setRightContextTab, setRightReviewTab, terminalPanel, vimModeEnabled])
 
-  const content = useMemo(() => {
+  const mainContent = useMemo(() => {
     switch (activeTab) {
+      case 'terminal':
+        return null
       case 'overview':
         return (
           <OverviewPanel
-            activeSessionId={activeSessionId}
+            sessionIds={overviewSessionIds}
             worktreePath={worktreePath}
-            usage={usage}
+            scopeLabel={overviewScopeLabel}
           />
         )
       case 'review':
         return (
-          <ReviewPanel
+          <ReviewWorkflowPanel
             worktreePath={worktreePath}
             isConnectionMode={isConnectionMode}
             connectionMembers={connectionMembers}
@@ -537,50 +670,75 @@ export function ContextPanelHost({
     isConnectionMode,
     onClose,
     onFileClick,
-    usage,
+    overviewScopeLabel,
+    overviewSessionIds,
     worktreePath
   ])
 
   return (
-    <div
-      className={cn('flex h-full flex-col bg-transparent', className)}
-      data-testid="context-panel-host"
-    >
-      <div className="flex items-center gap-2 border-b border-sidebar-border/60 px-2.5 py-2">
-        <div className="min-w-0 flex-1 overflow-x-auto">
-          <div className="inline-flex min-w-max items-center gap-1 rounded-lg bg-sidebar-accent/40 p-0.5">
-            {CONTEXT_TABS.map((tab) => {
-              const Icon = tab.icon
-              return (
-                <button
-                  key={tab.id}
-                  type="button"
-                  className={cn(
-                    'inline-flex shrink-0 items-center gap-1.5 rounded-md px-2.5 py-1.5 text-[11px] font-medium transition-colors',
-                    activeTab === tab.id
-                      ? 'bg-sidebar-accent text-sidebar-accent-foreground'
-                      : 'text-muted-foreground hover:bg-sidebar-accent/60 hover:text-sidebar-accent-foreground'
-                  )}
-                  onClick={() => setRightContextTab(tab.id)}
-                  data-testid={`context-panel-tab-${tab.id}`}
-                >
-                  <Icon className="h-3.5 w-3.5" />
-                  {t(tab.labelKey)}
-                </button>
-              )
-            })}
-          </div>
-        </div>
-        <button
-          type="button"
-          onClick={onClose}
-          className="ml-auto rounded-md p-1.5 text-muted-foreground transition-colors hover:bg-sidebar-accent/60 hover:text-sidebar-accent-foreground"
-          aria-label={t('fileTree.sidebar.closeSidebar')}
+    <div className={cn('flex h-full bg-transparent', className)} data-testid="context-panel-host">
+      <div
+        className="flex min-w-0 flex-1 flex-col overflow-hidden bg-transparent"
+        data-testid="context-panel-content"
+      >
+        <div
+          className={cn(
+            'min-h-0 flex-1 flex-col overflow-hidden',
+            activeTab === 'terminal' ? 'hidden' : 'flex'
+          )}
+          data-testid="context-panel-main-content"
+          aria-hidden={activeTab === 'terminal'}
         >
-          <X className="h-3.5 w-3.5" />
-        </button>
+          {mainContent}
+        </div>
+
+        {terminalPanel && (
+          <div
+            className={cn(
+              'min-h-0 flex-1 flex-col overflow-hidden',
+              activeTab === 'terminal' ? 'flex' : 'hidden'
+            )}
+            data-testid="context-panel-terminal-content"
+            aria-hidden={activeTab !== 'terminal'}
+          >
+            {terminalPanel}
+          </div>
+        )}
       </div>
-      <div className="flex min-h-0 flex-1 flex-col overflow-hidden bg-transparent">{content}</div>
+
+      <div
+        className="flex w-12 shrink-0 flex-col items-center border-l border-sidebar-border/35 bg-agent-canvas/45 px-1.5 py-2 backdrop-blur-sm dark:bg-agent-canvas/70"
+        data-testid="context-panel-rail"
+      >
+        <div className="flex flex-col items-center gap-1 rounded-xl border border-sidebar-border/70 bg-agent-card/80 p-1 dark:border-sidebar-border/45 dark:bg-agent-card/40">
+          {tabs.map((tab) => {
+            const Icon = tab.icon
+            const label = t(tab.labelKey)
+            return (
+              <button
+                key={tab.id}
+                type="button"
+                className={cn(
+                  'relative flex h-8 w-8 items-center justify-center rounded-lg text-muted-foreground transition-colors',
+                  activeTab === tab.id
+                    ? 'bg-tech-blue-soft text-tech-blue shadow-sm ring-1 ring-tech-blue/20 dark:bg-tech-blue-soft/70 dark:ring-tech-blue/15'
+                    : 'hover:bg-agent-hover/70 hover:text-sidebar-accent-foreground dark:hover:bg-agent-hover/45'
+                )}
+                onClick={() => setRightContextTab(tab.id)}
+                data-testid={`context-panel-tab-${tab.id}`}
+                data-active={activeTab === tab.id}
+                aria-label={label}
+                title={label}
+              >
+                {activeTab === tab.id && (
+                  <span className="absolute left-0 top-1/2 h-4 w-0.5 -translate-y-1/2 rounded-full bg-primary" />
+                )}
+                <Icon className="h-4 w-4" />
+              </button>
+            )
+          })}
+        </div>
+      </div>
     </div>
   )
 }

--- a/src/renderer/src/components/context-panel/ContextPanelHost.tsx
+++ b/src/renderer/src/components/context-panel/ContextPanelHost.tsx
@@ -1,0 +1,508 @@
+import React, { useEffect, useMemo, useState } from 'react'
+import { BarChart3, Files, GitPullRequest, ListTodo, Target, X } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { useI18n } from '@/i18n/useI18n'
+import { useLayoutStore, type RightContextTab, type RightReviewTab } from '@/stores/useLayoutStore'
+import { useSettingsStore } from '@/stores/useSettingsStore'
+import { useWorktreeStore } from '@/stores/useWorktreeStore'
+import { useGitStore } from '@/stores/useGitStore'
+import { useSessionStore } from '@/stores/useSessionStore'
+import { useSessionRuntimeStore } from '@/stores/useSessionRuntimeStore'
+import { useContextStore, type SessionContextUsage } from '@/stores/useContextStore'
+import { FileTree } from '@/components/file-tree/FileTree'
+import { ChangesView } from '@/components/file-tree/ChangesView'
+import { BranchDiffView } from '@/components/file-tree/BranchDiffView'
+import { DiffCommentsViewer } from '@/components/diff-comments/DiffCommentsViewer'
+import { PrReviewViewer } from '@/components/pr-review/PrReviewViewer'
+import { GoalStatusCard } from '@/components/session-hq/cards/GoalStatusCard'
+import { TodoCard } from '@/components/session-hq/cards/TodoCard'
+import { extractMissionTasks, type SessionTask } from '@/lib/session-tasks'
+
+interface ConnectionMemberInfo {
+  worktree_path: string
+  project_name: string
+  worktree_branch: string
+}
+
+interface ContextPanelHostProps {
+  worktreePath: string | null
+  isConnectionMode?: boolean
+  connectionMembers?: ConnectionMemberInfo[]
+  onClose: () => void
+  onFileClick: (node: { path: string; name: string; isDirectory: boolean }) => void
+  className?: string
+}
+
+interface ContextMetric {
+  label: string
+  value: string
+  muted?: string
+}
+
+const CONTEXT_TABS: Array<{
+  id: RightContextTab
+  icon: React.ComponentType<{ className?: string }>
+  labelKey: string
+}> = [
+  { id: 'overview', icon: BarChart3, labelKey: 'contextPanel.tabs.overview' },
+  { id: 'review', icon: GitPullRequest, labelKey: 'contextPanel.tabs.review' },
+  { id: 'files', icon: Files, labelKey: 'contextPanel.tabs.files' },
+  { id: 'tasks', icon: ListTodo, labelKey: 'contextPanel.tabs.tasks' },
+  { id: 'goal', icon: Target, labelKey: 'contextPanel.tabs.goal' }
+]
+
+const REVIEW_TABS: Array<{ id: RightReviewTab; labelKey: string }> = [
+  { id: 'changes', labelKey: 'fileTree.sidebar.changes' },
+  { id: 'diffs', labelKey: 'fileTree.sidebar.diffs' },
+  { id: 'comments', labelKey: 'fileTree.sidebar.comments' }
+]
+
+function formatCompactNumber(value: number): string {
+  if (!Number.isFinite(value)) return '0'
+  if (Math.abs(value) >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}M`
+  if (Math.abs(value) >= 1_000) return `${(value / 1_000).toFixed(1)}K`
+  return String(Math.round(value))
+}
+
+function formatCost(value: number): string {
+  if (!Number.isFinite(value) || value <= 0) return '$0'
+  if (value < 0.01) return `$${value.toFixed(4)}`
+  return `$${value.toFixed(2)}`
+}
+
+function EmptyPanel({
+  title,
+  description
+}: {
+  title: string
+  description: string
+}): React.JSX.Element {
+  return (
+    <div className="flex min-h-0 flex-1 items-center justify-center p-5 text-center">
+      <div className="max-w-[240px]">
+        <div className="text-sm font-medium text-sidebar-foreground">{title}</div>
+        <div className="mt-1 text-xs leading-relaxed text-muted-foreground">{description}</div>
+      </div>
+    </div>
+  )
+}
+
+function MetricCard({ metric }: { metric: ContextMetric }): React.JSX.Element {
+  return (
+    <div className="rounded-lg border border-sidebar-border/70 bg-sidebar-accent/25 px-3 py-2.5">
+      <div className="text-[10px] font-medium uppercase tracking-[0.14em] text-muted-foreground">
+        {metric.label}
+      </div>
+      <div className="mt-1 text-lg font-semibold tabular-nums text-sidebar-foreground">
+        {metric.value}
+      </div>
+      {metric.muted && (
+        <div className="mt-0.5 text-[11px] text-muted-foreground">{metric.muted}</div>
+      )}
+    </div>
+  )
+}
+
+function findSessionById(state: ReturnType<typeof useSessionStore.getState>, sessionId: string) {
+  for (const sessions of state.sessionsByWorktree.values()) {
+    const match = sessions.find((session) => session.id === sessionId)
+    if (match) return match
+  }
+  for (const sessions of state.sessionsByConnection.values()) {
+    const match = sessions.find((session) => session.id === sessionId)
+    if (match) return match
+  }
+  return null
+}
+
+function useSessionTasks(activeSessionId: string | null): SessionTask[] {
+  const [tasks, setTasks] = useState<SessionTask[]>([])
+  const activityTick = useSessionRuntimeStore((state) =>
+    activeSessionId ? state.getSession(activeSessionId).lastActivityAt : 0
+  )
+
+  useEffect(() => {
+    let cancelled = false
+    if (!activeSessionId || !window.agentOps?.getTimeline) {
+      setTasks([])
+      return () => {
+        cancelled = true
+      }
+    }
+
+    window.agentOps
+      .getTimeline(activeSessionId)
+      .then((result) => {
+        if (!cancelled) {
+          setTasks(extractMissionTasks(result.messages ?? []))
+        }
+      })
+      .catch(() => {
+        if (!cancelled) setTasks([])
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [activeSessionId, activityTick])
+
+  return tasks
+}
+
+function OverviewPanel({
+  activeSessionId,
+  worktreePath,
+  usage
+}: {
+  activeSessionId: string | null
+  worktreePath: string | null
+  usage: SessionContextUsage | null
+}): React.JSX.Element {
+  const { t } = useI18n()
+
+  if (!activeSessionId) {
+    return (
+      <EmptyPanel
+        title={t('contextPanel.empty.noSessionTitle')}
+        description={t('contextPanel.empty.noSessionDescription')}
+      />
+    )
+  }
+
+  const tokens = usage?.tokens
+  const totalTokens = tokens
+    ? tokens.input + tokens.output + tokens.reasoning + tokens.cacheRead + tokens.cacheWrite
+    : 0
+  const metrics: ContextMetric[] = [
+    {
+      label: t('contextPanel.overview.cost'),
+      value: formatCost(usage?.cost ?? 0)
+    },
+    {
+      label: t('contextPanel.overview.tokens'),
+      value: formatCompactNumber(totalTokens),
+      muted:
+        usage?.limit && usage.limit > 0
+          ? t('contextPanel.overview.contextLimit', {
+              used: formatCompactNumber(usage.used),
+              limit: formatCompactNumber(usage.limit)
+            })
+          : undefined
+    },
+    {
+      label: t('contextPanel.overview.input'),
+      value: formatCompactNumber(tokens?.input ?? 0),
+      muted: `${t('contextPanel.overview.output')} ${formatCompactNumber(tokens?.output ?? 0)}`
+    },
+    {
+      label: t('contextPanel.overview.cacheRead'),
+      value: formatCompactNumber(tokens?.cacheRead ?? 0),
+      muted: `${t('contextPanel.overview.cacheWrite')} ${formatCompactNumber(tokens?.cacheWrite ?? 0)}`
+    }
+  ]
+
+  return (
+    <div className="min-h-0 flex-1 overflow-auto p-3" data-testid="context-panel-overview">
+      <div className="grid grid-cols-2 gap-2">
+        {metrics.map((metric) => (
+          <MetricCard key={metric.label} metric={metric} />
+        ))}
+      </div>
+      <div className="mt-3 rounded-lg border border-sidebar-border/70 bg-sidebar-accent/20 px-3 py-2.5">
+        <div className="text-[10px] font-medium uppercase tracking-[0.14em] text-muted-foreground">
+          {t('contextPanel.overview.worktree')}
+        </div>
+        <div className="mt-1 truncate font-mono text-xs text-sidebar-foreground">
+          {worktreePath ?? t('contextPanel.empty.noWorktree')}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function GoalPanel({ activeSessionId }: { activeSessionId: string | null }): React.JSX.Element {
+  const { t } = useI18n()
+  const goal = useSessionRuntimeStore((state) =>
+    activeSessionId ? (state.goals.get(activeSessionId) ?? null) : null
+  )
+
+  if (!activeSessionId) {
+    return (
+      <EmptyPanel
+        title={t('contextPanel.empty.noSessionTitle')}
+        description={t('contextPanel.empty.noSessionDescription')}
+      />
+    )
+  }
+
+  if (!goal) {
+    return (
+      <EmptyPanel
+        title={t('contextPanel.goal.emptyTitle')}
+        description={t('contextPanel.goal.emptyDescription')}
+      />
+    )
+  }
+
+  return (
+    <div className="min-h-0 flex-1 overflow-auto p-3" data-testid="context-panel-goal">
+      <GoalStatusCard goal={goal} />
+    </div>
+  )
+}
+
+function TasksPanel({ activeSessionId }: { activeSessionId: string | null }): React.JSX.Element {
+  const { t } = useI18n()
+  const tasks = useSessionTasks(activeSessionId)
+
+  if (!activeSessionId) {
+    return (
+      <EmptyPanel
+        title={t('contextPanel.empty.noSessionTitle')}
+        description={t('contextPanel.empty.noSessionDescription')}
+      />
+    )
+  }
+
+  if (tasks.length === 0) {
+    return (
+      <EmptyPanel
+        title={t('contextPanel.tasks.emptyTitle')}
+        description={t('contextPanel.tasks.emptyDescription')}
+      />
+    )
+  }
+
+  return (
+    <div className="min-h-0 flex-1 overflow-auto p-3" data-testid="context-panel-tasks">
+      <TodoCard tasks={tasks} />
+    </div>
+  )
+}
+
+function ReviewPanel({
+  worktreePath,
+  isConnectionMode,
+  connectionMembers
+}: Pick<
+  ContextPanelHostProps,
+  'worktreePath' | 'isConnectionMode' | 'connectionMembers'
+>): React.JSX.Element {
+  const { t } = useI18n()
+  const selectedWorktreeId = useWorktreeStore((s) => s.selectedWorktreeId)
+  const activeReviewTab = useLayoutStore((s) => s.rightReviewTab)
+  const setRightReviewTab = useLayoutStore((s) => s.setRightReviewTab)
+  const hasAttachedPR = useGitStore(
+    (s) => !!(selectedWorktreeId && s.attachedPR.get(selectedWorktreeId))
+  )
+  const effectiveReviewTab =
+    !selectedWorktreeId && activeReviewTab === 'comments' ? 'changes' : activeReviewTab
+
+  useEffect(() => {
+    if (!selectedWorktreeId && activeReviewTab === 'comments') {
+      setRightReviewTab('changes')
+    }
+  }, [activeReviewTab, selectedWorktreeId, setRightReviewTab])
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col" data-testid="context-panel-review">
+      <div className="border-b border-sidebar-border/60 px-2.5 py-2">
+        <div className="inline-flex min-w-max items-center gap-1 rounded-lg bg-sidebar-accent/40 p-0.5">
+          {REVIEW_TABS.map((tab) => {
+            if (tab.id === 'comments' && !selectedWorktreeId) return null
+            return (
+              <button
+                key={tab.id}
+                type="button"
+                className={cn(
+                  'shrink-0 rounded-md px-2.5 py-1.5 text-[11px] font-medium transition-colors',
+                  effectiveReviewTab === tab.id
+                    ? 'bg-sidebar-accent text-sidebar-accent-foreground'
+                    : 'text-muted-foreground hover:bg-sidebar-accent/60 hover:text-sidebar-accent-foreground'
+                )}
+                onClick={() => setRightReviewTab(tab.id)}
+                data-testid={`context-panel-review-${tab.id}`}
+              >
+                {t(tab.labelKey)}
+              </button>
+            )
+          })}
+        </div>
+      </div>
+
+      <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+        {effectiveReviewTab === 'comments' && selectedWorktreeId ? (
+          <div className="flex min-h-0 flex-1 flex-col">
+            <DiffCommentsViewer
+              worktreeId={selectedWorktreeId}
+              worktreePath={worktreePath}
+              compact={hasAttachedPR}
+            />
+            {hasAttachedPR && <PrReviewViewer worktreeId={selectedWorktreeId} />}
+          </div>
+        ) : effectiveReviewTab === 'diffs' ? (
+          <BranchDiffView worktreePath={worktreePath} />
+        ) : (
+          <ChangesView
+            worktreePath={worktreePath}
+            isConnectionMode={isConnectionMode}
+            connectionMembers={connectionMembers}
+          />
+        )}
+      </div>
+    </div>
+  )
+}
+
+function FilesPanel({
+  worktreePath,
+  isConnectionMode,
+  onClose,
+  onFileClick
+}: Pick<
+  ContextPanelHostProps,
+  'worktreePath' | 'isConnectionMode' | 'onClose' | 'onFileClick'
+>): React.JSX.Element {
+  return (
+    <FileTree
+      worktreePath={worktreePath}
+      isConnectionMode={isConnectionMode}
+      onClose={onClose}
+      onFileClick={onFileClick}
+      hideHeader
+      hideGitIndicators
+      hideGitContextActions
+    />
+  )
+}
+
+export function ContextPanelHost({
+  worktreePath,
+  isConnectionMode,
+  connectionMembers,
+  onClose,
+  onFileClick,
+  className
+}: ContextPanelHostProps): React.JSX.Element {
+  const { t } = useI18n()
+  const activeTab = useLayoutStore((s) => s.rightContextTab)
+  const setRightContextTab = useLayoutStore((s) => s.setRightContextTab)
+  const setRightReviewTab = useLayoutStore((s) => s.setRightReviewTab)
+  const vimModeEnabled = useSettingsStore((s) => s.vimModeEnabled)
+  const activeSessionId = useSessionStore((s) => s.inlineConnectionSessionId ?? s.activeSessionId)
+  const activeSession = useSessionStore((s) => {
+    const sessionId = s.inlineConnectionSessionId ?? s.activeSessionId
+    return sessionId ? findSessionById(s, sessionId) : null
+  })
+  const contextState = useContextStore()
+  const usage = activeSessionId
+    ? contextState.getContextUsage(
+        activeSessionId,
+        activeSession?.model_id ?? '',
+        activeSession?.model_provider_id ?? undefined
+      )
+    : null
+
+  useEffect(() => {
+    const handler = (event: Event): void => {
+      if (!vimModeEnabled) return
+      const tab = (event as CustomEvent).detail?.tab
+      if (tab === 'files') {
+        setRightContextTab('files')
+        return
+      }
+      if (tab === 'changes' || tab === 'diffs' || tab === 'comments') {
+        setRightContextTab('review')
+        setRightReviewTab(tab)
+      }
+    }
+    window.addEventListener('hive:right-sidebar-tab', handler)
+    return () => window.removeEventListener('hive:right-sidebar-tab', handler)
+  }, [setRightContextTab, setRightReviewTab, vimModeEnabled])
+
+  const content = useMemo(() => {
+    switch (activeTab) {
+      case 'overview':
+        return (
+          <OverviewPanel
+            activeSessionId={activeSessionId}
+            worktreePath={worktreePath}
+            usage={usage}
+          />
+        )
+      case 'review':
+        return (
+          <ReviewPanel
+            worktreePath={worktreePath}
+            isConnectionMode={isConnectionMode}
+            connectionMembers={connectionMembers}
+          />
+        )
+      case 'files':
+        return (
+          <FilesPanel
+            worktreePath={worktreePath}
+            isConnectionMode={isConnectionMode}
+            onClose={onClose}
+            onFileClick={onFileClick}
+          />
+        )
+      case 'tasks':
+        return <TasksPanel activeSessionId={activeSessionId} />
+      case 'goal':
+        return <GoalPanel activeSessionId={activeSessionId} />
+    }
+  }, [
+    activeSessionId,
+    activeTab,
+    connectionMembers,
+    isConnectionMode,
+    onClose,
+    onFileClick,
+    usage,
+    worktreePath
+  ])
+
+  return (
+    <div
+      className={cn('flex h-full flex-col bg-transparent', className)}
+      data-testid="context-panel-host"
+    >
+      <div className="flex items-center gap-2 border-b border-sidebar-border/60 px-2.5 py-2">
+        <div className="min-w-0 flex-1 overflow-x-auto">
+          <div className="inline-flex min-w-max items-center gap-1 rounded-lg bg-sidebar-accent/40 p-0.5">
+            {CONTEXT_TABS.map((tab) => {
+              const Icon = tab.icon
+              return (
+                <button
+                  key={tab.id}
+                  type="button"
+                  className={cn(
+                    'inline-flex shrink-0 items-center gap-1.5 rounded-md px-2.5 py-1.5 text-[11px] font-medium transition-colors',
+                    activeTab === tab.id
+                      ? 'bg-sidebar-accent text-sidebar-accent-foreground'
+                      : 'text-muted-foreground hover:bg-sidebar-accent/60 hover:text-sidebar-accent-foreground'
+                  )}
+                  onClick={() => setRightContextTab(tab.id)}
+                  data-testid={`context-panel-tab-${tab.id}`}
+                >
+                  <Icon className="h-3.5 w-3.5" />
+                  {t(tab.labelKey)}
+                </button>
+              )
+            })}
+          </div>
+        </div>
+        <button
+          type="button"
+          onClick={onClose}
+          className="ml-auto rounded-md p-1.5 text-muted-foreground transition-colors hover:bg-sidebar-accent/60 hover:text-sidebar-accent-foreground"
+          aria-label={t('fileTree.sidebar.closeSidebar')}
+        >
+          <X className="h-3.5 w-3.5" />
+        </button>
+      </div>
+      <div className="flex min-h-0 flex-1 flex-col overflow-hidden bg-transparent">{content}</div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/context-panel/ReviewWorkflowPanel.tsx
+++ b/src/renderer/src/components/context-panel/ReviewWorkflowPanel.tsx
@@ -1,0 +1,754 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
+import {
+  Archive,
+  ChevronDown,
+  FileSearch,
+  GitMerge,
+  GitPullRequest,
+  Loader2,
+  X
+} from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { useI18n } from '@/i18n/useI18n'
+import { useLayoutStore, type RightReviewTab } from '@/stores/useLayoutStore'
+import { useProjectStore } from '@/stores/useProjectStore'
+import { useWorktreeStore } from '@/stores/useWorktreeStore'
+import { useGitStore } from '@/stores/useGitStore'
+import { useSessionStore } from '@/stores/useSessionStore'
+import { Button } from '@/components/ui/button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger
+} from '@/components/ui/dropdown-menu'
+import { Popover, PopoverAnchor, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import { ChangesView } from '@/components/file-tree/ChangesView'
+import { BranchDiffView } from '@/components/file-tree/BranchDiffView'
+import { DiffCommentsViewer } from '@/components/diff-comments/DiffCommentsViewer'
+import { PrReviewViewer } from '@/components/pr-review/PrReviewViewer'
+import { toast } from '@/lib/toast'
+
+export interface ConnectionMemberInfo {
+  worktree_path: string
+  project_name: string
+  worktree_branch: string
+}
+
+interface ReviewWorkflowPanelProps {
+  worktreePath: string | null
+  isConnectionMode?: boolean
+  connectionMembers?: ConnectionMemberInfo[]
+}
+
+type WorktreeRecord =
+  ReturnType<typeof useWorktreeStore.getState>['worktreesByProject'] extends Map<
+    string,
+    Array<infer T>
+  >
+    ? T
+    : never
+
+type RemoteBranch = { name: string; isRemote?: boolean }
+
+type PullRequestListItem = {
+  number: number
+  title: string
+  author: string
+  headRefName: string
+}
+
+const REVIEW_TABS: Array<{ id: RightReviewTab; labelKey: string }> = [
+  { id: 'changes', labelKey: 'fileTree.sidebar.changes' },
+  { id: 'diffs', labelKey: 'fileTree.sidebar.diffs' },
+  { id: 'comments', labelKey: 'fileTree.sidebar.comments' }
+]
+
+function findWorktreeById(
+  worktreesByProject: ReturnType<typeof useWorktreeStore.getState>['worktreesByProject'],
+  worktreeId: string | null
+): WorktreeRecord | null {
+  if (!worktreeId) return null
+  for (const worktrees of worktreesByProject.values()) {
+    const worktree = worktrees.find((item) => item.id === worktreeId)
+    if (worktree) return worktree
+  }
+  return null
+}
+
+function getPullRequestUrl(remoteUrl: string, prNumber: number): string {
+  const cleanUrl = remoteUrl.replace(/\.git$/, '')
+  if (cleanUrl.startsWith('git@github.com:')) {
+    return `https://github.com/${cleanUrl.slice('git@github.com:'.length)}/pull/${prNumber}`
+  }
+  return `${cleanUrl}/pull/${prNumber}`
+}
+
+export function ReviewWorkflowPanel({
+  worktreePath,
+  isConnectionMode,
+  connectionMembers
+}: ReviewWorkflowPanelProps): React.JSX.Element {
+  const { t } = useI18n()
+  const projects = useProjectStore((s) => s.projects)
+  const selectedWorktreeId = useWorktreeStore((s) => s.selectedWorktreeId)
+  const worktreesByProject = useWorktreeStore((s) => s.worktreesByProject)
+  const selectedWorktree = useMemo(
+    () => findWorktreeById(worktreesByProject, selectedWorktreeId),
+    [selectedWorktreeId, worktreesByProject]
+  )
+  const selectedProject = useMemo(
+    () =>
+      selectedWorktree
+        ? projects.find((project) => project.id === selectedWorktree.project_id)
+        : null,
+    [projects, selectedWorktree]
+  )
+  const activeReviewTab = useLayoutStore((s) => s.rightReviewTab)
+  const setRightReviewTab = useLayoutStore((s) => s.setRightReviewTab)
+  const createSession = useSessionStore((s) => s.createSession)
+  const updateSessionName = useSessionStore((s) => s.updateSessionName)
+  const setPendingMessage = useSessionStore((s) => s.setPendingMessage)
+  const remoteInfo = useGitStore((s) =>
+    selectedWorktreeId ? s.remoteInfo.get(selectedWorktreeId) : undefined
+  )
+  const branchInfoByWorktree = useGitStore((s) => s.branchInfoByWorktree)
+  const branchInfo = selectedWorktree?.path
+    ? branchInfoByWorktree.get(selectedWorktree.path)
+    : undefined
+  const reviewTargetBranch = useGitStore((s) =>
+    selectedWorktreeId ? s.reviewTargetBranch.get(selectedWorktreeId) : undefined
+  )
+  const setReviewTargetBranch = useGitStore((s) => s.setReviewTargetBranch)
+  const prTargetBranch = useGitStore((s) =>
+    selectedWorktreeId ? s.prTargetBranch.get(selectedWorktreeId) : undefined
+  )
+  const setPrTargetBranch = useGitStore((s) => s.setPrTargetBranch)
+  const prCreation = useGitStore((s) =>
+    selectedWorktreeId ? s.prCreation.get(selectedWorktreeId) : undefined
+  )
+  const attachedPR = useGitStore((s) =>
+    selectedWorktreeId ? s.attachedPR.get(selectedWorktreeId) : undefined
+  )
+  const setPrCreation = useGitStore((s) => s.setPrCreation)
+  const isOperating = useGitStore((s) => s.isPushing || s.isPulling)
+  const fileStatuses = useGitStore((s) =>
+    selectedWorktree?.path ? s.fileStatusesByWorktree.get(selectedWorktree.path) : undefined
+  )
+  const isCleanTree = !fileStatuses || fileStatuses.length === 0
+  const isGitHub = remoteInfo?.isGitHub ?? false
+  const isCreatingPR = prCreation?.creating ?? false
+  const hasAttachedPR = !!attachedPR
+  const attachedPRNumber = attachedPR?.number
+  const effectiveReviewTab =
+    !selectedWorktreeId && activeReviewTab === 'comments' ? 'changes' : activeReviewTab
+  const [remoteBranches, setRemoteBranches] = useState<RemoteBranch[]>([])
+  const [isMergingPR, setIsMergingPR] = useState(false)
+  const [isArchivingWorktree, setIsArchivingWorktree] = useState(false)
+  const [prPickerOpen, setPrPickerOpen] = useState(false)
+  const [prList, setPrList] = useState<PullRequestListItem[]>([])
+  const [prListLoading, setPrListLoading] = useState(false)
+  const [prLiveState, setPrLiveState] = useState<{
+    number?: number
+    state?: string
+    title?: string
+  } | null>(null)
+  const currentPRLiveState = prLiveState?.number === attachedPRNumber ? prLiveState : null
+  const compareTarget = reviewTargetBranch || branchInfo?.tracking || 'origin/main'
+  const prTarget = prTargetBranch || branchInfo?.tracking || 'origin/main'
+  const branchName =
+    branchInfo?.name || selectedWorktree?.branch_name || t('gitStatusPanel.unknownBranch')
+  const attachedPRTitle = currentPRLiveState?.title?.trim() ?? ''
+  const prBadgeTitle =
+    attachedPRNumber == null
+      ? ''
+      : attachedPRTitle
+        ? `PR #${attachedPRNumber}: ${attachedPRTitle}`
+        : `PR #${attachedPRNumber}`
+
+  const refreshAttachedPRState = useCallback(async (): Promise<void> => {
+    if (attachedPRNumber == null || !selectedProject?.path || !window.gitOps?.getPRState) {
+      setPrLiveState(null)
+      return
+    }
+
+    try {
+      const result = await window.gitOps.getPRState(selectedProject.path, attachedPRNumber)
+      if (result.success) {
+        setPrLiveState({ number: attachedPRNumber, state: result.state, title: result.title })
+      }
+    } catch {
+      /* non-critical */
+    }
+  }, [attachedPRNumber, selectedProject?.path])
+
+  useEffect(() => {
+    if (!selectedWorktreeId && activeReviewTab === 'comments') {
+      setRightReviewTab('changes')
+    }
+  }, [activeReviewTab, selectedWorktreeId, setRightReviewTab])
+
+  useEffect(() => {
+    let cancelled = false
+
+    if (!selectedWorktree?.path || !window.gitOps?.listBranchesWithStatus) {
+      setRemoteBranches([])
+      return () => {
+        cancelled = true
+      }
+    }
+
+    window.gitOps
+      .listBranchesWithStatus(selectedWorktree.path)
+      .then((result) => {
+        if (cancelled) return
+        if (result.success) {
+          setRemoteBranches(result.branches.filter((branch) => branch.isRemote))
+        } else {
+          setRemoteBranches([])
+        }
+      })
+      .catch(() => {
+        if (!cancelled) setRemoteBranches([])
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [selectedWorktree?.path])
+
+  useEffect(() => {
+    void refreshAttachedPRState()
+  }, [refreshAttachedPRState])
+
+  useEffect(() => {
+    if (!prPickerOpen || !selectedProject?.path || !window.gitOps?.listPRs) return
+    let cancelled = false
+    setPrListLoading(true)
+
+    const fetchPRs = window.gitOps
+      .listPRs(selectedProject.path)
+      .then((result) => {
+        if (cancelled) return
+        if (result.success) {
+          const sorted = [...result.prs].sort((a, b) => {
+            const aMatch = a.headRefName === branchName ? 1 : 0
+            const bMatch = b.headRefName === branchName ? 1 : 0
+            if (aMatch !== bMatch) return bMatch - aMatch
+            return b.number - a.number
+          })
+          setPrList(sorted)
+        } else {
+          toast.error(result.error || t('header.toasts.loadPRsError'))
+          setPrPickerOpen(false)
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          toast.error(t('header.toasts.loadPRsError'))
+          setPrPickerOpen(false)
+        }
+      })
+
+    Promise.all([fetchPRs, refreshAttachedPRState()]).finally(() => {
+      if (!cancelled) setPrListLoading(false)
+    })
+
+    return () => {
+      cancelled = true
+    }
+  }, [branchName, prPickerOpen, refreshAttachedPRState, selectedProject?.path, t])
+
+  const handleStartReview = useCallback(async () => {
+    if (!selectedWorktree || !selectedWorktreeId) {
+      toast.error(t('header.toasts.noWorktreeSelected'))
+      return
+    }
+
+    let reviewTemplate = ''
+    try {
+      if (window.fileOps?.readPrompt) {
+        const result = await window.fileOps.readPrompt('review.md')
+        if (result.success && result.content) {
+          reviewTemplate = result.content
+        }
+      }
+    } catch {
+      // readPrompt failed, use fallback
+    }
+
+    const prompt = reviewTemplate
+      ? [
+          reviewTemplate,
+          '',
+          '---',
+          '',
+          `Compare the current branch (${branchName}) against ${compareTarget}.`,
+          `Use \`git diff ${compareTarget}...HEAD\` to see all changes.`
+        ].join('\n')
+      : [
+          `Please review the changes on branch "${branchName}" compared to ${compareTarget}.`,
+          `Use \`git diff ${compareTarget}...HEAD\` to get the full diff.`,
+          'Focus on: bugs, logic errors, and code quality.'
+        ].join('\n')
+
+    const result = await createSession(selectedWorktreeId, selectedWorktree.project_id)
+    if (!result.success || !result.session) {
+      toast.error(t('header.toasts.createReviewSessionError'))
+      return
+    }
+
+    await updateSessionName(
+      result.session.id,
+      t('header.sessionNames.review', { branch: branchName, target: compareTarget })
+    )
+    setPendingMessage(result.session.id, prompt)
+  }, [
+    branchName,
+    compareTarget,
+    createSession,
+    selectedWorktree,
+    selectedWorktreeId,
+    setPendingMessage,
+    t,
+    updateSessionName
+  ])
+
+  const handleCreatePR = useCallback(async () => {
+    if (!selectedWorktree || !selectedWorktreeId) {
+      toast.error(t('header.toasts.noWorktreeSelected'))
+      return
+    }
+
+    const result = await createSession(selectedWorktreeId, selectedWorktree.project_id)
+    if (!result.success || !result.session) {
+      toast.error(t('header.toasts.createPRSessionError'))
+      return
+    }
+
+    await updateSessionName(result.session.id, t('header.sessionNames.pr', { branch: prTarget }))
+    setPendingMessage(
+      result.session.id,
+      [
+        `Create a pull request targeting ${prTarget}.`,
+        `Use \`gh pr create\` to create the PR.`,
+        `Base the PR title and description on the git diff between HEAD and ${prTarget}.`,
+        `Make the description comprehensive, summarizing all changes.`
+      ].join(' ')
+    )
+
+    setPrCreation(selectedWorktreeId, {
+      creating: true,
+      sessionId: result.session.id
+    })
+  }, [
+    createSession,
+    prTarget,
+    selectedWorktree,
+    selectedWorktreeId,
+    setPendingMessage,
+    setPrCreation,
+    t,
+    updateSessionName
+  ])
+
+  const handleSelectPR = useCallback(
+    (pr: PullRequestListItem) => {
+      if (!selectedWorktreeId || !remoteInfo?.url) return
+      useGitStore
+        .getState()
+        .attachPR(selectedWorktreeId, pr.number, getPullRequestUrl(remoteInfo.url, pr.number))
+      setPrLiveState({ number: pr.number, state: 'OPEN', title: pr.title })
+      setPrPickerOpen(false)
+    },
+    [remoteInfo?.url, selectedWorktreeId]
+  )
+
+  const handleDetachPR = useCallback(() => {
+    if (!selectedWorktreeId) return
+    useGitStore.getState().detachPR(selectedWorktreeId)
+    setPrPickerOpen(false)
+    setPrLiveState(null)
+  }, [selectedWorktreeId])
+
+  const handleMergePR = useCallback(async () => {
+    if (!selectedWorktree?.path || !selectedWorktreeId) return
+    const pr = useGitStore.getState().attachedPR.get(selectedWorktreeId)
+    if (!pr?.number || !window.gitOps?.prMerge) return
+
+    setIsMergingPR(true)
+    try {
+      const result = await window.gitOps.prMerge(selectedWorktree.path, pr.number)
+      if (result.success) {
+        toast.success(t('header.toasts.prMergedSuccess'))
+        setPrLiveState({
+          number: pr.number,
+          state: 'MERGED',
+          title: currentPRLiveState?.title
+        })
+      } else {
+        toast.error(t('header.toasts.mergePRErrorWithReason', { error: result.error }))
+      }
+    } catch {
+      toast.error(t('header.toasts.mergePRError'))
+    } finally {
+      setIsMergingPR(false)
+    }
+  }, [currentPRLiveState?.title, selectedWorktree?.path, selectedWorktreeId, t])
+
+  const handleArchiveWorktree = useCallback(async () => {
+    if (!selectedWorktreeId || !selectedWorktree || !selectedProject) return
+    setIsArchivingWorktree(true)
+    try {
+      const result = await useWorktreeStore
+        .getState()
+        .archiveWorktree(
+          selectedWorktreeId,
+          selectedWorktree.path,
+          selectedWorktree.branch_name,
+          selectedProject.path
+        )
+
+      if (!result.success && result.error) {
+        toast.error(result.error)
+      }
+    } finally {
+      setIsArchivingWorktree(false)
+    }
+  }, [selectedProject, selectedWorktree, selectedWorktreeId])
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col" data-testid="context-panel-review">
+      <div className="border-b border-sidebar-border/60 px-2.5 py-2">
+        <div className="inline-flex min-w-max items-center gap-1 rounded-lg bg-sidebar-accent/40 p-0.5">
+          {REVIEW_TABS.map((tab) => {
+            if (tab.id === 'comments' && !selectedWorktreeId) return null
+            return (
+              <button
+                key={tab.id}
+                type="button"
+                className={cn(
+                  'shrink-0 rounded-md px-2.5 py-1.5 text-[11px] font-medium transition-colors',
+                  effectiveReviewTab === tab.id
+                    ? 'bg-sidebar-accent text-sidebar-accent-foreground'
+                    : 'text-muted-foreground hover:bg-sidebar-accent/60 hover:text-sidebar-accent-foreground'
+                )}
+                onClick={() => setRightReviewTab(tab.id)}
+                data-testid={`context-panel-review-${tab.id}`}
+              >
+                {t(tab.labelKey)}
+              </button>
+            )
+          })}
+        </div>
+      </div>
+
+      {selectedWorktree && (
+        <div
+          className="space-y-2 border-b border-sidebar-border/60 px-2.5 py-2.5"
+          data-testid="context-panel-review-actions"
+        >
+          <div className="flex min-w-0 items-center gap-1.5">
+            <Button
+              size="sm"
+              variant="outline"
+              className="h-7 min-w-0 flex-1 justify-center rounded-lg px-2 text-[11px] font-medium"
+              onClick={handleStartReview}
+              disabled={isOperating}
+              title={t('contextPanel.review.startReviewTitle')}
+              data-testid="review-button"
+            >
+              <FileSearch className="mr-1 h-3.5 w-3.5 shrink-0" />
+              <span className="truncate">{t('contextPanel.review.startReview')}</span>
+            </Button>
+
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  className="h-7 max-w-[140px] rounded-lg px-2 text-[11px] text-muted-foreground hover:bg-sidebar-accent/60 hover:text-sidebar-accent-foreground"
+                  data-testid="review-target-branch-trigger"
+                >
+                  <span className="truncate">vs {compareTarget}</span>
+                  <ChevronDown className="ml-1 h-3 w-3 shrink-0" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end" className="max-h-60 overflow-y-auto">
+                {remoteBranches.length === 0 ? (
+                  <DropdownMenuItem disabled>
+                    {t('header.controls.noRemoteBranches')}
+                  </DropdownMenuItem>
+                ) : (
+                  remoteBranches.map((branch) => (
+                    <DropdownMenuItem
+                      key={branch.name}
+                      onClick={() =>
+                        selectedWorktreeId && setReviewTargetBranch(selectedWorktreeId, branch.name)
+                      }
+                      data-testid={`review-target-branch-${branch.name}`}
+                    >
+                      {branch.name}
+                    </DropdownMenuItem>
+                  ))
+                )}
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
+
+          <div className="rounded-lg border border-sidebar-border/60 bg-sidebar-accent/20 px-3 py-2 text-[11px] leading-relaxed text-muted-foreground">
+            {t('contextPanel.review.sessionHint')}
+          </div>
+
+          {isGitHub && (
+            <div className="flex min-w-0 items-center gap-1.5" data-testid="pr-section">
+              {hasAttachedPR &&
+                currentPRLiveState?.state !== 'MERGED' &&
+                currentPRLiveState?.state !== 'CLOSED' &&
+                isCleanTree && (
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    className="h-7 rounded-lg border-emerald-600/30 bg-emerald-600/10 px-2 text-[11px] text-emerald-500 hover:bg-emerald-600/20"
+                    onClick={handleMergePR}
+                    disabled={isMergingPR}
+                    title={t('header.controls.mergePRTitle')}
+                    data-testid="pr-merge-button"
+                  >
+                    {isMergingPR ? (
+                      <Loader2 className="mr-1 h-3.5 w-3.5 animate-spin" />
+                    ) : (
+                      <GitMerge className="mr-1 h-3.5 w-3.5" />
+                    )}
+                    {isMergingPR ? t('header.controls.merging') : t('header.controls.mergePR')}
+                  </Button>
+                )}
+
+              {hasAttachedPR &&
+                currentPRLiveState?.state === 'MERGED' &&
+                !selectedWorktree.is_default && (
+                  <Button
+                    size="sm"
+                    variant="destructive"
+                    className="h-7 rounded-lg px-2 text-[11px]"
+                    onClick={handleArchiveWorktree}
+                    disabled={isArchivingWorktree}
+                    title={t('header.controls.archiveWorktreeTitle')}
+                    data-testid="pr-archive-button"
+                  >
+                    {isArchivingWorktree ? (
+                      <Loader2 className="mr-1 h-3.5 w-3.5 animate-spin" />
+                    ) : (
+                      <Archive className="mr-1 h-3.5 w-3.5" />
+                    )}
+                    {isArchivingWorktree
+                      ? t('header.controls.archiving')
+                      : t('header.controls.archive')}
+                  </Button>
+                )}
+
+              {hasAttachedPR && !isCreatingPR && (
+                <Popover open={prPickerOpen} onOpenChange={setPrPickerOpen}>
+                  <PopoverTrigger asChild>
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      className="h-7 min-w-0 flex-1 rounded-lg px-2 text-[11px] font-medium"
+                      title={prBadgeTitle}
+                      data-testid="pr-badge"
+                    >
+                      <GitPullRequest className="mr-1 h-3.5 w-3.5 shrink-0" />
+                      <span className="truncate">PR #{attachedPR.number}</span>
+                    </Button>
+                  </PopoverTrigger>
+                  <PopoverContent align="end" className="w-80 p-0">
+                    <div className="border-b px-3 py-2">
+                      <div className="text-xs font-medium text-muted-foreground">
+                        {t('header.controls.attached')}: #{attachedPR.number}
+                      </div>
+                      {currentPRLiveState?.title && (
+                        <div className="truncate text-sm">
+                          {currentPRLiveState.title}
+                          {currentPRLiveState?.state && (
+                            <span className="ml-1 text-xs text-muted-foreground">
+                              ({currentPRLiveState.state.toLowerCase()})
+                            </span>
+                          )}
+                        </div>
+                      )}
+                    </div>
+                    <div className="max-h-48 overflow-y-auto">
+                      {prListLoading ? (
+                        <div className="px-3 py-4 text-center text-xs text-muted-foreground">
+                          <Loader2 className="mr-1 inline h-3.5 w-3.5 animate-spin" />
+                          {t('header.controls.loadingPRs')}
+                        </div>
+                      ) : prList.length === 0 ? (
+                        <div className="px-3 py-4 text-center text-xs text-muted-foreground">
+                          {t('header.controls.noOpenPRs')}
+                        </div>
+                      ) : (
+                        prList.map((pr) => (
+                          <button
+                            key={pr.number}
+                            className={cn(
+                              'flex w-full cursor-pointer items-center gap-2 px-3 py-2 text-left text-sm hover:bg-accent',
+                              pr.number === attachedPR.number && 'bg-accent/50'
+                            )}
+                            onClick={() => handleSelectPR(pr)}
+                            data-testid={`pr-picker-item-${pr.number}`}
+                          >
+                            <span
+                              className={cn(
+                                'shrink-0 font-mono text-xs',
+                                pr.number === attachedPR.number && 'font-bold text-primary'
+                              )}
+                            >
+                              {pr.number === attachedPR.number ? '●' : ' '} #{pr.number}
+                            </span>
+                            <span className="truncate">{pr.title}</span>
+                          </button>
+                        ))
+                      )}
+                    </div>
+                    <div className="border-t">
+                      <button
+                        className="flex w-full cursor-pointer items-center gap-1 px-3 py-2 text-left text-sm text-destructive hover:bg-destructive/10"
+                        onClick={handleDetachPR}
+                        data-testid="pr-detach-button"
+                      >
+                        <X className="h-3.5 w-3.5" />
+                        {t('header.controls.detachPR')}
+                      </button>
+                    </div>
+                  </PopoverContent>
+                </Popover>
+              )}
+
+              {isCreatingPR && (
+                <Button
+                  size="sm"
+                  variant="outline"
+                  className="h-7 min-w-0 flex-1 rounded-lg px-2 text-[11px] font-medium"
+                  disabled
+                  data-testid="pr-creating-button"
+                >
+                  <Loader2 className="mr-1 h-3.5 w-3.5 animate-spin" />
+                  PR
+                </Button>
+              )}
+
+              {!hasAttachedPR && !isCreatingPR && (
+                <Popover open={prPickerOpen} onOpenChange={setPrPickerOpen}>
+                  <PopoverAnchor asChild>
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      className="h-7 min-w-0 flex-1 rounded-lg px-2 text-[11px] font-medium"
+                      onClick={handleCreatePR}
+                      onContextMenu={(event) => {
+                        event.preventDefault()
+                        setPrPickerOpen(true)
+                      }}
+                      disabled={isOperating}
+                      title={t('header.controls.createPRTitle')}
+                      data-testid="pr-button"
+                    >
+                      <GitPullRequest className="mr-1 h-3.5 w-3.5 shrink-0" />
+                      PR
+                    </Button>
+                  </PopoverAnchor>
+                  <PopoverContent align="end" className="w-80 p-0">
+                    <div className="border-b px-3 py-2">
+                      <div className="text-xs font-medium text-muted-foreground">
+                        {t('header.controls.attachExistingPR')}
+                      </div>
+                    </div>
+                    <div className="max-h-48 overflow-y-auto">
+                      {prListLoading ? (
+                        <div className="px-3 py-4 text-center text-xs text-muted-foreground">
+                          <Loader2 className="mr-1 inline h-3.5 w-3.5 animate-spin" />
+                          {t('header.controls.loadingPRs')}
+                        </div>
+                      ) : prList.length === 0 ? (
+                        <div className="px-3 py-4 text-center text-xs text-muted-foreground">
+                          {t('header.controls.noOpenPRs')}
+                        </div>
+                      ) : (
+                        prList.map((pr) => (
+                          <button
+                            key={pr.number}
+                            className="flex w-full cursor-pointer items-center gap-2 px-3 py-2 text-left text-sm hover:bg-accent"
+                            onClick={() => handleSelectPR(pr)}
+                            data-testid={`pr-picker-item-${pr.number}`}
+                          >
+                            <span className="shrink-0 font-mono text-xs">#{pr.number}</span>
+                            <span className="truncate">{pr.title}</span>
+                          </button>
+                        ))
+                      )}
+                    </div>
+                  </PopoverContent>
+                </Popover>
+              )}
+
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    className="h-7 max-w-[120px] rounded-lg px-2 text-[11px] text-muted-foreground hover:bg-sidebar-accent/60 hover:text-sidebar-accent-foreground"
+                    data-testid="pr-target-branch-trigger"
+                  >
+                    <span className="truncate">→ {prTarget}</span>
+                    <ChevronDown className="ml-1 h-3 w-3 shrink-0" />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end" className="max-h-60 overflow-y-auto">
+                  {remoteBranches.length === 0 ? (
+                    <DropdownMenuItem disabled>
+                      {t('header.controls.noRemoteBranches')}
+                    </DropdownMenuItem>
+                  ) : (
+                    remoteBranches.map((branch) => (
+                      <DropdownMenuItem
+                        key={branch.name}
+                        onClick={() =>
+                          selectedWorktreeId && setPrTargetBranch(selectedWorktreeId, branch.name)
+                        }
+                        data-testid={`pr-target-branch-${branch.name}`}
+                      >
+                        {branch.name}
+                      </DropdownMenuItem>
+                    ))
+                  )}
+                </DropdownMenuContent>
+              </DropdownMenu>
+            </div>
+          )}
+        </div>
+      )}
+
+      <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+        {effectiveReviewTab === 'comments' && selectedWorktreeId ? (
+          <div className="flex min-h-0 flex-1 flex-col">
+            <DiffCommentsViewer
+              worktreeId={selectedWorktreeId}
+              worktreePath={worktreePath}
+              compact={hasAttachedPR}
+            />
+            {hasAttachedPR && <PrReviewViewer worktreeId={selectedWorktreeId} />}
+          </div>
+        ) : effectiveReviewTab === 'diffs' ? (
+          <BranchDiffView worktreePath={worktreePath} />
+        ) : (
+          <ChangesView
+            worktreePath={worktreePath}
+            isConnectionMode={isConnectionMode}
+            connectionMembers={connectionMembers}
+          />
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/layout/AppLayout.tsx
+++ b/src/renderer/src/components/layout/AppLayout.tsx
@@ -193,7 +193,14 @@ export function AppLayout({ children }: AppLayoutProps): React.JSX.Element {
 
   return (
     <div className="h-screen flex flex-col bg-background text-foreground" data-testid="app-layout">
-      <ErrorBoundary componentName="Header" fallback={<div className="h-12 bg-muted" />}>
+      <ErrorBoundary
+        componentName="Header"
+        fallback={
+          <div className="h-10 flex shrink-0 items-center border-b border-border/45 bg-background/75 px-3 text-xs font-semibold text-foreground">
+            Xuanpu
+          </div>
+        }
+      >
         <Header />
       </ErrorBoundary>
       <div className="flex-1 flex flex-col min-h-0" data-testid="layout-content">

--- a/src/renderer/src/components/layout/Header.tsx
+++ b/src/renderer/src/components/layout/Header.tsx
@@ -1,32 +1,17 @@
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
+import { useShallow } from 'zustand/react/shallow'
 import { isMac } from '@/lib/platform'
 import {
   PanelRightClose,
   PanelRightOpen,
-  History,
   Settings,
   AlertTriangle,
   Loader2,
-  GitPullRequest,
-  GitMerge,
-  Archive,
-  ChevronDown,
-  FileSearch,
-  X,
-  Coffee
+  Zap
 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
-import {
-  DropdownMenu,
-  DropdownMenuTrigger,
-  DropdownMenuContent,
-  DropdownMenuItem
-} from '@/components/ui/dropdown-menu'
-import { Popover, PopoverTrigger, PopoverContent, PopoverAnchor } from '@/components/ui/popover'
-import { toast } from '@/lib/toast'
 import { cn } from '@/lib/utils'
 import { useLayoutStore } from '@/stores/useLayoutStore'
-import { useSessionHistoryStore } from '@/stores/useSessionHistoryStore'
 import { useSettingsStore } from '@/stores/useSettingsStore'
 import { useProjectStore } from '@/stores/useProjectStore'
 import { useWorktreeStore } from '@/stores/useWorktreeStore'
@@ -35,6 +20,11 @@ import { useSessionStore } from '@/stores/useSessionStore'
 import { useGitStore } from '@/stores/useGitStore'
 import { useWorktreeStatusStore } from '@/stores/useWorktreeStatusStore'
 import { useVimModeStore } from '@/stores/useVimModeStore'
+import { useContextStore } from '@/stores/useContextStore'
+import { useSessionRuntimeStore, type SessionLifecycle } from '@/stores/useSessionRuntimeStore'
+import { ModelSelector } from '@/components/sessions/ModelSelector'
+import { SessionTabs } from '@/components/sessions/SessionTabs'
+import { ErrorBoundary } from '@/components/error'
 
 import { usePRDetection } from '@/hooks/usePRDetection'
 import appLogo from '@/assets/icon.png'
@@ -66,9 +56,188 @@ function isConflictFixActiveStatus(status: string | null): boolean {
   )
 }
 
+type HeaderSessionGlanceSession = {
+  id: string
+  name: string | null
+  agent_sdk: string
+  model_id: string | null
+  model_provider_id: string | null
+}
+
+type HeaderContextMeter = {
+  percent: number | null
+  used: number
+  limit: number | null
+  isRefreshing: boolean
+}
+
+const HEADER_PROVIDER_LABELS: Record<string, string> = {
+  'claude-code': 'Claude',
+  opencode: 'OpenCode',
+  codex: 'Codex'
+}
+
+const HEADER_LIFECYCLE_DOT: Record<SessionLifecycle, string> = {
+  idle: 'bg-muted-foreground/45',
+  busy: 'bg-neon-mint crisp-status-dot animate-pulse',
+  retry: 'bg-neon-violet crisp-status-dot animate-pulse',
+  error: 'bg-neon-pink crisp-status-dot',
+  materializing: 'bg-tech-blue crisp-status-dot animate-pulse'
+}
+
+function getHeaderProviderLabel(sdk: string, t: ReturnType<typeof useI18n>['t']): string {
+  if (sdk === 'terminal') return t('bottomPanel.tabs.terminal')
+  return HEADER_PROVIDER_LABELS[sdk] ?? sdk
+}
+
+function getHeaderLifecycleLabel(
+  lifecycle: SessionLifecycle,
+  t: ReturnType<typeof useI18n>['t']
+): string {
+  return t(`sessionHq.header.lifecycle.${lifecycle}`)
+}
+
+function formatHeaderTokens(value: number): string | null {
+  if (!Number.isFinite(value) || value <= 0) return null
+  if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}M`
+  if (value >= 1_000) return `${(value / 1_000).toFixed(1)}K`
+  return String(Math.round(value))
+}
+
+function formatHeaderCost(value: number): string | null {
+  if (!Number.isFinite(value) || value <= 0) return null
+  return `$${value.toFixed(4)}`
+}
+
+function safeTokenValue(value: number | undefined): number {
+  return typeof value === 'number' && Number.isFinite(value) ? value : 0
+}
+
+function clampPercent(value: number): number {
+  if (!Number.isFinite(value)) return 0
+  return Math.min(100, Math.max(0, Math.round(value)))
+}
+
+function getHeaderContextPercent(used: number, limit: number | undefined, percent: number | null) {
+  if (typeof percent === 'number' && Number.isFinite(percent)) return clampPercent(percent)
+  if (typeof limit === 'number' && limit > 0 && used > 0) return clampPercent((used / limit) * 100)
+  return null
+}
+
+function getHeaderContextTitle(
+  context: HeaderContextMeter,
+  t: ReturnType<typeof useI18n>['t']
+): string {
+  const usedLabel = formatHeaderTokens(context.used) ?? '0'
+  const limitLabel = context.limit ? formatHeaderTokens(context.limit) : null
+  const percentLabel = context.percent == null ? null : `${context.percent}%`
+  const parts = [
+    t('sessionHq.header.context'),
+    percentLabel,
+    limitLabel && `${usedLabel}/${limitLabel}`
+  ]
+    .filter(Boolean)
+    .join(' · ')
+  return context.isRefreshing ? `${parts} · ${t('sessionHq.header.compressingContext')}` : parts
+}
+
+function HeaderSessionGlance({
+  session,
+  lifecycle,
+  totalCost,
+  context
+}: {
+  session: HeaderSessionGlanceSession
+  lifecycle: SessionLifecycle
+  totalCost: number
+  context: HeaderContextMeter | null
+}): React.JSX.Element {
+  const { t } = useI18n()
+  const sessionTitle = session.name || t('sessionTabs.common.untitled')
+  const providerLabel = getHeaderProviderLabel(session.agent_sdk, t)
+  const lifecycleLabel = getHeaderLifecycleLabel(lifecycle, t)
+  const costLabel = formatHeaderCost(totalCost)
+  const contextFillPercent =
+    context?.percent ?? (context && (context.used > 0 || context.isRefreshing) ? 18 : 0)
+
+  return (
+    <div
+      className="crisp-panel-surface crisp-subtle-shadow hidden h-8 min-w-0 shrink-0 items-center gap-2 rounded-lg bg-agent-card/90 px-2 text-[11px] text-muted-foreground backdrop-blur-md lg:flex"
+      style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
+      data-testid="header-session-glance"
+      title={`${sessionTitle} · ${providerLabel} · ${lifecycleLabel}`}
+    >
+      <span className={cn('h-1.5 w-1.5 shrink-0 rounded-full', HEADER_LIFECYCLE_DOT[lifecycle])} />
+      <span className="shrink-0 font-medium text-foreground/85">{providerLabel}</span>
+      {session.agent_sdk !== 'terminal' && (
+        <ModelSelector sessionId={session.id} compact showProviderPrefix={false} />
+      )}
+      <span className="shrink-0 rounded-full bg-background/55 px-1.5 py-0.5 font-mono text-[10px] text-muted-foreground">
+        {lifecycleLabel}
+      </span>
+      {context && (
+        <div
+          className="flex h-6 w-16 shrink-0 items-center rounded-full border border-border/60 bg-agent-card px-1.5"
+          title={getHeaderContextTitle(context, t)}
+          data-testid="header-context-meter"
+          aria-label={getHeaderContextTitle(context, t)}
+        >
+          <span className="h-1.5 min-w-0 flex-1 overflow-hidden rounded-full bg-muted">
+            <span
+              className={cn(
+                'block h-full rounded-full bg-neon-mint transition-[width] duration-300',
+                context.percent == null && 'bg-muted-foreground/35',
+                context.isRefreshing && 'animate-pulse'
+              )}
+              style={{ width: `${contextFillPercent}%` }}
+              data-testid="header-context-meter-fill"
+            />
+          </span>
+        </div>
+      )}
+      {costLabel && (
+        <span
+          className="shrink-0 rounded-full border border-neon-pink/20 bg-neon-pink-soft px-1.5 py-0.5 font-mono text-[10px] text-neon-pink dark:bg-neon-pink-soft/40"
+          title={t('sessionView.costPill.title')}
+          data-testid="header-cost-pill"
+        >
+          {costLabel}
+        </span>
+      )}
+    </div>
+  )
+}
+
+function HeaderSessionGlanceFallback({
+  session,
+  lifecycle
+}: {
+  session: HeaderSessionGlanceSession
+  lifecycle: SessionLifecycle
+}): React.JSX.Element {
+  const { t } = useI18n()
+  const sessionTitle = session.name || t('sessionTabs.common.untitled')
+  const providerLabel = getHeaderProviderLabel(session.agent_sdk, t)
+  const lifecycleLabel = getHeaderLifecycleLabel(lifecycle, t)
+
+  return (
+    <div
+      className="crisp-panel-surface hidden h-8 min-w-0 shrink-0 items-center gap-2 rounded-lg bg-agent-card/90 px-2 text-[11px] text-muted-foreground lg:flex"
+      style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
+      data-testid="header-session-glance-fallback"
+      title={`${sessionTitle} · ${providerLabel} · ${lifecycleLabel}`}
+    >
+      <span className={cn('h-1.5 w-1.5 shrink-0 rounded-full', HEADER_LIFECYCLE_DOT[lifecycle])} />
+      <span className="shrink-0 font-medium text-foreground/85">{providerLabel}</span>
+      <span className="shrink-0 rounded-full bg-background/55 px-1.5 py-0.5 font-mono text-[10px] text-muted-foreground">
+        {lifecycleLabel}
+      </span>
+    </div>
+  )
+}
+
 export function Header(): React.JSX.Element {
   const { rightSidebarCollapsed, toggleRightSidebar } = useLayoutStore()
-  const { openPanel: openSessionHistory } = useSessionHistoryStore()
   const openSettings = useSettingsStore((s) => s.openSettings)
   const selectedProjectId = useProjectStore((s) => s.selectedProjectId)
   const projects = useProjectStore((s) => s.projects)
@@ -83,9 +252,98 @@ export function Header(): React.JSX.Element {
   const sessionStatuses = useWorktreeStatusStore((s) => s.sessionStatuses)
   const getWorktreeStatus = useWorktreeStatusStore((s) => s.getWorktreeStatus)
   const getConnectionStatus = useWorktreeStatusStore((s) => s.getConnectionStatus)
-  const showVimHints = vimModeEnabled && vimMode === 'normal'
+  const activeHeaderSession = useSessionStore(
+    useShallow((state) => {
+      const activeId = state.inlineConnectionSessionId ?? state.activeSessionId
+      if (!activeId) return null
+
+      const sessionsByWorktree =
+        state.sessionsByWorktree instanceof Map ? state.sessionsByWorktree : new Map()
+      const sessionsByConnection =
+        state.sessionsByConnection instanceof Map ? state.sessionsByConnection : new Map()
+
+      for (const sessions of sessionsByWorktree.values()) {
+        const match = sessions.find((session) => session.id === activeId)
+        if (match) {
+          return {
+            id: match.id,
+            name: match.name,
+            agent_sdk: match.agent_sdk,
+            model_id: match.model_id,
+            model_provider_id: match.model_provider_id
+          }
+        }
+      }
+
+      for (const sessions of sessionsByConnection.values()) {
+        const match = sessions.find((session) => session.id === activeId)
+        if (match) {
+          return {
+            id: match.id,
+            name: match.name,
+            agent_sdk: match.agent_sdk,
+            model_id: match.model_id,
+            model_provider_id: match.model_provider_id
+          }
+        }
+      }
+
+      return null
+    })
+  )
+  const activeHeaderLifecycle = useSessionRuntimeStore((state) =>
+    activeHeaderSession ? (state.sessions.get(activeHeaderSession.id)?.lifecycle ?? 'idle') : 'idle'
+  )
+  const activeHeaderUsage = useContextStore(
+    useShallow((state) => {
+      if (!activeHeaderSession) {
+        return {
+          totalCost: 0,
+          contextUsed: 0,
+          contextLimit: null,
+          contextPercent: null,
+          contextRefreshing: false,
+          hasContext: false
+        }
+      }
+
+      const tokens = state.tokensBySession[activeHeaderSession.id]
+      const fallbackUsedTokens = tokens
+        ? safeTokenValue(tokens.input) +
+          safeTokenValue(tokens.output) +
+          safeTokenValue(tokens.reasoning) +
+          safeTokenValue(tokens.cacheRead) +
+          safeTokenValue(tokens.cacheWrite)
+        : 0
+      const usage = state.getContextUsage(
+        activeHeaderSession.id,
+        activeHeaderSession.model_id ?? '',
+        activeHeaderSession.model_provider_id ?? undefined
+      )
+      const used = usage.used > 0 ? usage.used : fallbackUsedTokens
+      const limit = typeof usage.limit === 'number' && usage.limit > 0 ? usage.limit : null
+      const percent = getHeaderContextPercent(used, limit ?? undefined, usage.percent)
+
+      return {
+        totalCost: state.costBySession[activeHeaderSession.id] ?? 0,
+        contextUsed: used,
+        contextLimit: limit,
+        contextPercent: percent,
+        contextRefreshing: usage.isRefreshing,
+        hasContext: used > 0 || percent != null || usage.isRefreshing
+      }
+    })
+  )
+  const activeHeaderContext = activeHeaderUsage.hasContext
+    ? {
+        percent: activeHeaderUsage.contextPercent,
+        used: activeHeaderUsage.contextUsed,
+        limit: activeHeaderUsage.contextLimit,
+        isRefreshing: activeHeaderUsage.contextRefreshing
+      }
+    : null
   const [conflictFixFlow, setConflictFixFlow] = useState<ConflictFixFlow | null>(null)
-  const { t, supportsFirstCharHint } = useI18n()
+  const { t } = useI18n()
 
   // Monitor PR session stream events for PR URL detection
   usePRDetection(selectedWorktreeId)
@@ -102,7 +360,17 @@ export function Header(): React.JSX.Element {
 
   // Connection mode detection
   const selectedConnectionId = useConnectionStore((s) => s.selectedConnectionId)
+  const selectedConnection = useConnectionStore((s) =>
+    selectedConnectionId
+      ? s.connections.find((connection) => connection.id === selectedConnectionId)
+      : null
+  )
   const isConnectionMode = !!selectedConnectionId && !selectedWorktreeId
+  const connectionProjects =
+    selectedConnection?.members
+      .map((member) => member.project_name)
+      .filter((name, index, names) => name && names.indexOf(name) === index)
+      .join(' + ') ?? ''
   const isKeepAwakeActive = useMemo(() => {
     if (!Object.values(sessionStatuses).some(Boolean)) {
       return false
@@ -137,42 +405,6 @@ export function Header(): React.JSX.Element {
     (state) =>
       (selectedWorktree?.path ? state.conflictsByWorktree[selectedWorktree.path] : false) ?? false
   )
-
-  // PR / remote info
-  const remoteInfo = useGitStore((state) =>
-    selectedWorktreeId ? state.remoteInfo.get(selectedWorktreeId) : undefined
-  )
-  const isGitHub = remoteInfo?.isGitHub ?? false
-  const prTargetBranch = useGitStore((state) =>
-    selectedWorktreeId ? state.prTargetBranch.get(selectedWorktreeId) : undefined
-  )
-  const setPrTargetBranch = useGitStore((state) => state.setPrTargetBranch)
-  const reviewTargetBranch = useGitStore((state) =>
-    selectedWorktreeId ? state.reviewTargetBranch.get(selectedWorktreeId) : undefined
-  )
-  const setReviewTargetBranch = useGitStore((state) => state.setReviewTargetBranch)
-  const branchInfoByWorktree = useGitStore((state) => state.branchInfoByWorktree)
-  const branchInfo = selectedWorktree?.path
-    ? branchInfoByWorktree.get(selectedWorktree.path)
-    : undefined
-  const isOperating = useGitStore((state) => state.isPushing || state.isPulling)
-
-  // PR lifecycle state (new persistent model)
-  const prCreation = useGitStore((s) =>
-    selectedWorktreeId ? s.prCreation.get(selectedWorktreeId) : undefined
-  )
-  const attachedPR = useGitStore((s) =>
-    selectedWorktreeId ? s.attachedPR.get(selectedWorktreeId) : undefined
-  )
-  const isCreatingPR = prCreation?.creating ?? false
-  const hasAttachedPR = !!attachedPR
-  const attachedPRNumber = attachedPR?.number
-
-  // Clean tree detection for merge button visibility
-  const fileStatuses = useGitStore((s) =>
-    selectedWorktree?.path ? s.fileStatusesByWorktree.get(selectedWorktree.path) : undefined
-  )
-  const isCleanTree = !fileStatuses || fileStatuses.length === 0
 
   const conflictFixSessionStatus = useWorktreeStatusStore((state) =>
     conflictFixFlow?.phase === 'running'
@@ -231,269 +463,6 @@ export function Header(): React.JSX.Element {
     }
   }, [conflictFixFlow, conflictFixSessionStatus])
 
-  // Load remote branches for the PR target and review target dropdowns
-  const [remoteBranches, setRemoteBranches] = useState<{ name: string }[]>([])
-  const [isMergingPR, setIsMergingPR] = useState(false)
-  const [isArchivingWorktree, setIsArchivingWorktree] = useState(false)
-
-  // PR picker popover state
-  const [prPickerOpen, setPrPickerOpen] = useState(false)
-  const [prList, setPrList] = useState<
-    Array<{ number: number; title: string; author: string; headRefName: string }>
-  >([])
-  const [prListLoading, setPrListLoading] = useState(false)
-  const [prLiveState, setPrLiveState] = useState<{
-    number?: number
-    state?: string
-    title?: string
-  } | null>(null)
-  const currentPRLiveState = prLiveState?.number === attachedPRNumber ? prLiveState : null
-
-  const refreshAttachedPRState = useCallback(async (): Promise<void> => {
-    if (attachedPRNumber == null || !selectedProject?.path) {
-      setPrLiveState(null)
-      return
-    }
-
-    try {
-      const res = await window.gitOps.getPRState(selectedProject.path, attachedPRNumber)
-      if (res.success) {
-        setPrLiveState({ number: attachedPRNumber, state: res.state, title: res.title })
-      }
-    } catch {
-      /* non-critical */
-    }
-  }, [attachedPRNumber, selectedProject?.path])
-
-  useEffect(() => {
-    if (!selectedWorktree?.path) {
-      setRemoteBranches([])
-      return
-    }
-    window.gitOps.listBranchesWithStatus(selectedWorktree.path).then((result) => {
-      if (result.success) {
-        setRemoteBranches(result.branches.filter((b: { isRemote: boolean }) => b.isRemote))
-      }
-    })
-  }, [selectedWorktree?.path])
-
-  useEffect(() => {
-    void refreshAttachedPRState()
-  }, [refreshAttachedPRState])
-
-  // Fetch PR list when picker opens; refresh the attached PR metadata too.
-  useEffect(() => {
-    if (!prPickerOpen || !selectedProject?.path) return
-    setPrListLoading(true)
-
-    const fetchPRs = window.gitOps
-      .listPRs(selectedProject.path)
-      .then((res) => {
-        if (res.success) {
-          // Sort: branch-matching PR first, then by number descending
-          const currentBranch = branchInfo?.name ?? ''
-          const sorted = [...res.prs].sort((a, b) => {
-            const aMatch = a.headRefName === currentBranch ? 1 : 0
-            const bMatch = b.headRefName === currentBranch ? 1 : 0
-            if (aMatch !== bMatch) return bMatch - aMatch
-            return b.number - a.number
-          })
-          setPrList(sorted)
-        } else {
-          toast.error(res.error || t('header.toasts.loadPRsError'))
-          setPrPickerOpen(false)
-        }
-      })
-      .catch(() => {
-        toast.error(t('header.toasts.loadPRsError'))
-        setPrPickerOpen(false)
-      })
-
-    Promise.all([fetchPRs, refreshAttachedPRState()]).finally(() => setPrListLoading(false))
-  }, [prPickerOpen, selectedProject?.path, branchInfo?.name, refreshAttachedPRState, t])
-
-  const handleCreatePR = useCallback(async () => {
-    if (!selectedWorktree?.path) return
-
-    const wtId = selectedWorktreeId
-    if (!wtId) {
-      toast.error(t('header.toasts.noWorktreeSelected'))
-      return
-    }
-
-    let projectId = ''
-    const worktreeStore = useWorktreeStore.getState()
-    for (const [projId, wts] of worktreeStore.worktreesByProject) {
-      if (wts.some((w) => w.id === wtId)) {
-        projectId = projId
-        break
-      }
-    }
-    if (!projectId) {
-      toast.error(t('header.toasts.projectNotFound'))
-      return
-    }
-
-    const targetBranch = prTargetBranch || branchInfo?.tracking || 'origin/main'
-
-    const sessionStore = useSessionStore.getState()
-    const result = await sessionStore.createSession(wtId, projectId)
-    if (!result.success || !result.session) {
-      toast.error(t('header.toasts.createPRSessionError'))
-      return
-    }
-
-    await sessionStore.updateSessionName(
-      result.session.id,
-      t('header.sessionNames.pr', { branch: targetBranch })
-    )
-    sessionStore.setPendingMessage(
-      result.session.id,
-      [
-        `Create a pull request targeting ${targetBranch}.`,
-        `Use \`gh pr create\` to create the PR.`,
-        `Base the PR title and description on the git diff between HEAD and ${targetBranch}.`,
-        `Make the description comprehensive, summarizing all changes.`
-      ].join(' ')
-    )
-
-    // Tag this session as a PR session for detection
-    useGitStore.getState().setPrCreation(wtId, {
-      creating: true,
-      sessionId: result.session.id
-    })
-  }, [selectedWorktree?.path, selectedWorktreeId, prTargetBranch, branchInfo, t])
-
-  const handleReview = useCallback(async () => {
-    if (!selectedWorktree?.path) return
-
-    const wtId = selectedWorktreeId
-    if (!wtId) {
-      toast.error(t('header.toasts.noWorktreeSelected'))
-      return
-    }
-
-    let projectId = ''
-    const worktreeStore = useWorktreeStore.getState()
-    for (const [projId, wts] of worktreeStore.worktreesByProject) {
-      if (wts.some((w) => w.id === wtId)) {
-        projectId = projId
-        break
-      }
-    }
-    if (!projectId) {
-      toast.error(t('header.toasts.projectNotFound'))
-      return
-    }
-
-    const targetBranch = reviewTargetBranch || branchInfo?.tracking || 'origin/main'
-    const branchName = branchInfo?.name || t('gitStatusPanel.unknownBranch')
-
-    let reviewTemplate = ''
-    try {
-      const tmpl = await window.fileOps.readPrompt('review.md')
-      if (tmpl.success && tmpl.content) {
-        reviewTemplate = tmpl.content
-      }
-    } catch {
-      // readPrompt failed, use fallback
-    }
-
-    const prompt = reviewTemplate
-      ? [
-          reviewTemplate,
-          '',
-          '---',
-          '',
-          `Compare the current branch (${branchName}) against ${targetBranch}.`,
-          `Use \`git diff ${targetBranch}...HEAD\` to see all changes.`
-        ].join('\n')
-      : [
-          `Please review the changes on branch "${branchName}" compared to ${targetBranch}.`,
-          `Use \`git diff ${targetBranch}...HEAD\` to get the full diff.`,
-          'Focus on: bugs, logic errors, and code quality.'
-        ].join('\n')
-
-    const sessionStore = useSessionStore.getState()
-    const result = await sessionStore.createSession(wtId, projectId)
-    if (!result.success || !result.session) {
-      toast.error(t('header.toasts.createReviewSessionError'))
-      return
-    }
-
-    await sessionStore.updateSessionName(
-      result.session.id,
-      t('header.sessionNames.review', { branch: branchName, target: targetBranch })
-    )
-    sessionStore.setPendingMessage(result.session.id, prompt)
-  }, [selectedWorktree?.path, selectedWorktreeId, reviewTargetBranch, branchInfo, t])
-
-  const handleMergePR = useCallback(async () => {
-    if (!selectedWorktree?.path || !selectedWorktreeId) return
-    const pr = useGitStore.getState().attachedPR.get(selectedWorktreeId)
-    if (!pr?.number) return
-
-    setIsMergingPR(true)
-    try {
-      const result = await window.gitOps.prMerge(selectedWorktree.path, pr.number)
-      if (result.success) {
-        toast.success(t('header.toasts.prMergedSuccess'))
-        setPrLiveState({
-          number: pr.number,
-          state: 'MERGED',
-          title: currentPRLiveState?.title
-        })
-      } else {
-        toast.error(t('header.toasts.mergePRErrorWithReason', { error: result.error }))
-      }
-    } catch {
-      toast.error(t('header.toasts.mergePRError'))
-    } finally {
-      setIsMergingPR(false)
-    }
-  }, [selectedWorktree?.path, selectedWorktreeId, currentPRLiveState?.title, t])
-
-  const handleArchiveWorktree = useCallback(async () => {
-    if (!selectedWorktreeId || !selectedWorktree || !selectedProject) return
-    setIsArchivingWorktree(true)
-    try {
-      const result = await useWorktreeStore
-        .getState()
-        .archiveWorktree(
-          selectedWorktreeId,
-          selectedWorktree.path,
-          selectedWorktree.branch_name,
-          selectedProject.path
-        )
-
-      if (!result.success && result.error) {
-        toast.error(result.error)
-      }
-    } finally {
-      setIsArchivingWorktree(false)
-    }
-  }, [selectedWorktreeId, selectedWorktree, selectedProject])
-
-  const handleSelectPR = useCallback(
-    (pr: { number: number; headRefName: string; title?: string }) => {
-      if (!selectedWorktreeId || !remoteInfo?.url) return
-      // Construct PR URL from remote URL + number
-      const cleanUrl = remoteInfo.url.replace(/\.git$/, '')
-      const prUrl = `${cleanUrl}/pull/${pr.number}`
-      useGitStore.getState().attachPR(selectedWorktreeId, pr.number, prUrl)
-      setPrLiveState({ number: pr.number, state: 'OPEN', title: pr.title })
-      setPrPickerOpen(false)
-    },
-    [selectedWorktreeId, remoteInfo?.url]
-  )
-
-  const handleDetachPR = useCallback(() => {
-    if (!selectedWorktreeId) return
-    useGitStore.getState().detachPR(selectedWorktreeId)
-    setPrPickerOpen(false)
-    setPrLiveState(null)
-  }, [selectedWorktreeId])
-
   const handleFixConflicts = async () => {
     if (!selectedWorktreeId || !selectedProjectId || !selectedWorktree?.path) return
 
@@ -527,39 +496,100 @@ export function Header(): React.JSX.Element {
     conflictFixFlow.worktreePath === selectedWorktree.path
 
   const showFixConflictsButton = hasConflicts || isFixConflictsLoading
-  const attachedPRTitle = currentPRLiveState?.title?.trim() ?? ''
-  const prBadgeTitle =
-    attachedPRNumber == null
-      ? ''
-      : attachedPRTitle
-        ? `PR #${attachedPRNumber}: ${attachedPRTitle}`
-        : `PR #${attachedPRNumber}`
+  const showTopbarTabs = Boolean(selectedWorktreeId || selectedConnectionId)
 
   return (
     <header
-      className="h-[54px] border-b border-border/70 bg-background/90 backdrop-blur-xl flex items-center justify-between px-5 flex-shrink-0 select-none"
+      className="relative h-10 border-b border-border/45 bg-background/75 backdrop-blur-xl flex items-center gap-2 px-3 flex-shrink-0 select-none"
       style={{ WebkitAppRegion: 'drag' } as React.CSSProperties}
       data-testid="header"
     >
       {/* Spacer for macOS traffic lights */}
-      {isMac() && <div className="w-[72px] flex-shrink-0" />}
-      <div className="flex items-center gap-3 flex-1 min-w-0">
-        <div className="flex items-center gap-3 min-w-0 rounded-xl border border-border/60 bg-muted/35 px-3 py-1.5">
-          <img src={appLogo} alt="玄圃" className="h-5 w-5 shrink-0 rounded-md" draggable={false} />
-          <span className="text-sm font-semibold">玄圃</span>
+      {isMac() && <div className="w-[70px] flex-shrink-0" />}
+      <div
+        className={cn(
+          'crisp-panel-surface flex h-7 min-w-0 items-center gap-2.5 rounded-lg bg-agent-card/85 px-2.5',
+          showTopbarTabs ? 'max-w-[190px]' : 'max-w-[360px] flex-1'
+        )}
+      >
+        <img
+          src={appLogo}
+          alt="Xuanpu"
+          className="h-[18px] w-[18px] shrink-0 rounded-[5px]"
+          draggable={false}
+        />
+        {isConnectionMode && selectedConnection ? (
+          <div className="flex min-w-0 items-baseline gap-1.5" data-testid="header-connection-info">
+            <div className="truncate text-xs font-semibold">{selectedConnection.name}</div>
+            {connectionProjects && !showTopbarTabs && (
+              <div className="truncate text-[10px] text-muted-foreground">
+                ({connectionProjects})
+              </div>
+            )}
+          </div>
+        ) : selectedProject ? (
+          <div className="flex min-w-0 items-baseline gap-1.5" data-testid="header-project-info">
+            <div className="truncate text-xs font-semibold">{selectedProject.name}</div>
+            {!showTopbarTabs &&
+              selectedWorktree?.branch_name &&
+              selectedWorktree.branch_name !== '(no-worktree)' &&
+              selectedWorktree.branch_name !== selectedProject.name && (
+                <div className="truncate text-[10px] text-muted-foreground">
+                  ({selectedWorktree.branch_name})
+                </div>
+              )}
+          </div>
+        ) : (
+          <span className="truncate text-xs font-semibold">Xuanpu</span>
+        )}
+      </div>
+      {showTopbarTabs && (
+        <div
+          className="min-w-[180px] flex-1"
+          style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
+        >
+          <SessionTabs variant="topbar" />
         </div>
+      )}
+      <div
+        className="ml-auto flex min-w-0 items-center gap-2"
+        style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
+      >
+        {/*
+         * Session glance is intentionally right-aligned in the merged topbar:
+         * tabs own the main horizontal span while provider/model/cost remain
+         * compact low-frequency widgets.
+         */}
         {vimModeEnabled && (
           <span
             className={cn(
-              'text-[10px] font-mono px-2 py-1 rounded-md border select-none',
+              'text-[9px] font-mono px-1.5 py-0.5 rounded-md border select-none',
               vimMode === 'normal'
-                ? 'text-muted-foreground bg-muted/60 border-border/50'
+                ? 'text-muted-foreground bg-muted/50 border-border/50'
                 : 'text-primary bg-primary/10 border-primary/30'
             )}
             data-testid="vim-mode-pill"
           >
             {vimMode === 'normal' ? 'NORMAL' : 'INSERT'}
           </span>
+        )}
+        {activeHeaderSession && (
+          <ErrorBoundary
+            componentName="HeaderSessionGlance"
+            fallback={
+              <HeaderSessionGlanceFallback
+                session={activeHeaderSession}
+                lifecycle={activeHeaderLifecycle}
+              />
+            }
+          >
+            <HeaderSessionGlance
+              session={activeHeaderSession}
+              lifecycle={activeHeaderLifecycle}
+              totalCost={activeHeaderUsage.totalCost}
+              context={activeHeaderContext}
+            />
+          </ErrorBoundary>
         )}
       </div>
       {!isConnectionMode && showFixConflictsButton && (
@@ -583,371 +613,25 @@ export function Header(): React.JSX.Element {
           </Button>
         </div>
       )}
-      <div className="flex-1" />
       <div
-        className="flex items-center gap-1.5"
+        className="flex items-center gap-1"
         style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
       >
-        {!isConnectionMode &&
-          isGitHub &&
-          hasAttachedPR &&
-          currentPRLiveState?.state === 'MERGED' &&
-          !selectedWorktree?.is_default && (
-            <Button
-              size="sm"
-              variant="destructive"
-              className="h-7 text-xs"
-              onClick={handleArchiveWorktree}
-              disabled={isArchivingWorktree}
-              title={t('header.controls.archiveWorktreeTitle')}
-              data-testid="pr-archive-button"
-            >
-              {isArchivingWorktree ? (
-                <Loader2 className="h-3.5 w-3.5 mr-1 animate-spin" />
-              ) : (
-                <Archive className="h-3.5 w-3.5 mr-1" />
-              )}
-              {isArchivingWorktree ? (
-                t('header.controls.archiving')
-              ) : showVimHints ? (
-                supportsFirstCharHint ? (
-                  <span>
-                    <span className="text-primary font-bold">A</span>
-                    {t('header.controls.archive').slice(1)}
-                  </span>
-                ) : (
-                  t('header.controls.archive')
-                )
-              ) : (
-                t('header.controls.archive')
-              )}
-            </Button>
-          )}
-        {!isConnectionMode &&
-          isGitHub &&
-          hasAttachedPR &&
-          currentPRLiveState?.state !== 'MERGED' &&
-          currentPRLiveState?.state !== 'CLOSED' &&
-          isCleanTree && (
-            <Button
-              size="sm"
-              variant="outline"
-              className="h-7 text-xs bg-emerald-600/10 border-emerald-600/30 text-emerald-500 hover:bg-emerald-600/20"
-              onClick={handleMergePR}
-              disabled={isMergingPR}
-              title={t('header.controls.mergePRTitle')}
-              data-testid="pr-merge-button"
-            >
-              {isMergingPR ? (
-                <Loader2 className="h-3.5 w-3.5 mr-1 animate-spin" />
-              ) : (
-                <GitMerge className="h-3.5 w-3.5 mr-1" />
-              )}
-              {isMergingPR ? (
-                t('header.controls.merging')
-              ) : showVimHints ? (
-                supportsFirstCharHint ? (
-                  <span>
-                    <span className="text-primary font-bold">M</span>
-                    {t('header.controls.mergePR').slice(1)}
-                  </span>
-                ) : (
-                  t('header.controls.mergePR')
-                )
-              ) : (
-                t('header.controls.mergePR')
-              )}
-            </Button>
-          )}
-        {!isConnectionMode && selectedWorktree && (
-          <>
-            <Button
-              size="sm"
-              variant="outline"
-              className="h-8 rounded-full px-3 text-[12px] font-medium"
-              onClick={handleReview}
-              disabled={isOperating}
-              title={t('header.controls.reviewTitle')}
-              data-testid="review-button"
-            >
-              <FileSearch className="h-3.5 w-3.5 mr-1" />
-              {showVimHints ? (
-                supportsFirstCharHint ? (
-                  <span>
-                    <span className="text-primary font-bold">R</span>
-                    {t('header.controls.review').slice(1)}
-                  </span>
-                ) : (
-                  t('header.controls.review')
-                )
-              ) : (
-                t('header.controls.review')
-              )}
-            </Button>
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button
-                  size="sm"
-                  variant="ghost"
-                  className="h-8 rounded-full px-3 text-[12px] text-muted-foreground hover:text-foreground hover:bg-muted/60"
-                  data-testid="review-target-branch-trigger"
-                >
-                  vs {reviewTargetBranch || branchInfo?.tracking || 'origin/main'}
-                  <ChevronDown className="h-3 w-3 ml-1" />
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end" className="max-h-60 overflow-y-auto">
-                {remoteBranches.length === 0 ? (
-                  <DropdownMenuItem disabled>
-                    {t('header.controls.noRemoteBranches')}
-                  </DropdownMenuItem>
-                ) : (
-                  remoteBranches.map((branch) => (
-                    <DropdownMenuItem
-                      key={branch.name}
-                      onClick={() =>
-                        selectedWorktreeId && setReviewTargetBranch(selectedWorktreeId, branch.name)
-                      }
-                      data-testid={`review-target-branch-${branch.name}`}
-                    >
-                      {branch.name}
-                    </DropdownMenuItem>
-                  ))
-                )}
-              </DropdownMenuContent>
-            </DropdownMenu>
-          </>
-        )}
-        {/* PR Badge with Popover Picker — shown when a PR is attached and not creating */}
-        {!isConnectionMode && isGitHub && hasAttachedPR && !isCreatingPR && (
-          <Popover open={prPickerOpen} onOpenChange={setPrPickerOpen}>
-            <PopoverTrigger asChild>
-              <Button
-                size="sm"
-                variant="outline"
-                className="h-8 max-w-[320px] rounded-full px-3 text-[12px] font-medium"
-                title={prBadgeTitle}
-                data-testid="pr-badge"
-              >
-                <GitPullRequest className="h-3.5 w-3.5 mr-1" />
-                <span className="shrink-0">PR #{attachedPR!.number}</span>
-                {attachedPRTitle && (
-                  <span className="min-w-0 max-w-[170px] truncate text-muted-foreground">
-                    · {attachedPRTitle}
-                  </span>
-                )}
-                {currentPRLiveState?.state === 'MERGED' && (
-                  <span className="text-muted-foreground ml-1 shrink-0">
-                    · {t('header.controls.merged')}
-                  </span>
-                )}
-                {currentPRLiveState?.state === 'CLOSED' && (
-                  <span className="text-muted-foreground ml-1 shrink-0">
-                    · {t('header.controls.closed')}
-                  </span>
-                )}
-              </Button>
-            </PopoverTrigger>
-            <PopoverContent align="end" className="w-80 p-0">
-              {/* Attached PR header */}
-              <div className="px-3 py-2 border-b">
-                <div className="text-xs font-medium text-muted-foreground">
-                  {t('header.controls.attached')}: #{attachedPR!.number}
-                </div>
-                {currentPRLiveState?.title && (
-                  <div className="text-sm truncate">
-                    {currentPRLiveState.title}
-                    {currentPRLiveState?.state && (
-                      <span className="text-muted-foreground ml-1 text-xs">
-                        ({currentPRLiveState.state.toLowerCase()})
-                      </span>
-                    )}
-                  </div>
-                )}
-              </div>
-              {/* PR list */}
-              <div className="max-h-48 overflow-y-auto">
-                {prListLoading ? (
-                  <div className="px-3 py-4 text-center text-xs text-muted-foreground">
-                    <Loader2 className="h-3.5 w-3.5 animate-spin inline mr-1" />
-                    {t('header.controls.loadingPRs')}
-                  </div>
-                ) : prList.length === 0 ? (
-                  <div className="px-3 py-4 text-center text-xs text-muted-foreground">
-                    {t('header.controls.noOpenPRs')}
-                  </div>
-                ) : (
-                  prList.map((pr) => (
-                    <button
-                      key={pr.number}
-                      className={cn(
-                        'w-full text-left px-3 py-2 text-sm hover:bg-accent cursor-pointer',
-                        'flex items-center gap-2',
-                        pr.number === attachedPR!.number && 'bg-accent/50'
-                      )}
-                      onClick={() => handleSelectPR(pr)}
-                      data-testid={`pr-picker-item-${pr.number}`}
-                    >
-                      <span
-                        className={cn(
-                          'text-xs font-mono shrink-0',
-                          pr.number === attachedPR!.number && 'text-primary font-bold'
-                        )}
-                      >
-                        {pr.number === attachedPR!.number ? '●' : ' '} #{pr.number}
-                      </span>
-                      <span className="truncate">{pr.title}</span>
-                    </button>
-                  ))
-                )}
-              </div>
-              {/* Detach action */}
-              <div className="border-t">
-                <button
-                  className="w-full text-left px-3 py-2 text-sm text-destructive hover:bg-destructive/10 cursor-pointer flex items-center gap-1"
-                  onClick={handleDetachPR}
-                  data-testid="pr-detach-button"
-                >
-                  <X className="h-3.5 w-3.5" />
-                  {t('header.controls.detachPR')}
-                </button>
-              </div>
-            </PopoverContent>
-          </Popover>
-        )}
-        {/* Creating PR spinner */}
-        {!isConnectionMode && isGitHub && isCreatingPR && (
-          <Button
-            size="sm"
-            variant="outline"
-            className="h-8 rounded-full px-3 text-[12px] font-medium"
-            disabled
-            data-testid="pr-creating-button"
-          >
-            <Loader2 className="h-3.5 w-3.5 mr-1 animate-spin" />
-            PR
-          </Button>
-        )}
-        {/* Create PR button — shown when no PR attached and not creating */}
-        {!isConnectionMode && isGitHub && !hasAttachedPR && !isCreatingPR && (
-          <Popover open={prPickerOpen} onOpenChange={setPrPickerOpen}>
-            <PopoverAnchor asChild>
-              <Button
-                size="sm"
-                variant="outline"
-                className="h-8 rounded-full px-3 text-[12px] font-medium"
-                onClick={handleCreatePR}
-                onContextMenu={(e) => {
-                  e.preventDefault()
-                  setPrPickerOpen(true)
-                }}
-                disabled={isOperating}
-                title={t('header.controls.createPRTitle')}
-                data-testid="pr-button"
-              >
-                <GitPullRequest className="h-3.5 w-3.5 mr-1" />
-                {showVimHints ? (
-                  <span>
-                    <span className="text-primary font-bold">P</span>R
-                  </span>
-                ) : (
-                  'PR'
-                )}
-              </Button>
-            </PopoverAnchor>
-            <PopoverContent align="end" className="w-80 p-0">
-              <div className="px-3 py-2 border-b">
-                <div className="text-xs font-medium text-muted-foreground">
-                  {t('header.controls.attachExistingPR')}
-                </div>
-              </div>
-              <div className="max-h-48 overflow-y-auto">
-                {prListLoading ? (
-                  <div className="px-3 py-4 text-center text-xs text-muted-foreground">
-                    <Loader2 className="h-3.5 w-3.5 animate-spin inline mr-1" />
-                    {t('header.controls.loadingPRs')}
-                  </div>
-                ) : prList.length === 0 ? (
-                  <div className="px-3 py-4 text-center text-xs text-muted-foreground">
-                    {t('header.controls.noOpenPRs')}
-                  </div>
-                ) : (
-                  prList.map((pr) => (
-                    <button
-                      key={pr.number}
-                      className={cn(
-                        'w-full text-left px-3 py-2 text-sm hover:bg-accent cursor-pointer',
-                        'flex items-center gap-2'
-                      )}
-                      onClick={() => handleSelectPR(pr)}
-                      data-testid={`pr-picker-item-${pr.number}`}
-                    >
-                      <span className="text-xs font-mono shrink-0">#{pr.number}</span>
-                      <span className="truncate">{pr.title}</span>
-                    </button>
-                  ))
-                )}
-              </div>
-            </PopoverContent>
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button
-                  size="sm"
-                  variant="ghost"
-                  className="h-8 rounded-full px-3 text-[12px] text-muted-foreground hover:text-foreground hover:bg-muted/60"
-                  data-testid="pr-target-branch-trigger"
-                >
-                  → {prTargetBranch || branchInfo?.tracking || 'origin/main'}
-                  <ChevronDown className="h-3 w-3 ml-1" />
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end" className="max-h-60 overflow-y-auto">
-                {remoteBranches.length === 0 ? (
-                  <DropdownMenuItem disabled>
-                    {t('header.controls.noRemoteBranches')}
-                  </DropdownMenuItem>
-                ) : (
-                  remoteBranches.map((branch) => (
-                    <DropdownMenuItem
-                      key={branch.name}
-                      onClick={() =>
-                        selectedWorktreeId && setPrTargetBranch(selectedWorktreeId, branch.name)
-                      }
-                      data-testid={`pr-target-branch-${branch.name}`}
-                    >
-                      {branch.name}
-                    </DropdownMenuItem>
-                  ))
-                )}
-              </DropdownMenuContent>
-            </DropdownMenu>
-          </Popover>
-        )}
         <Button
           variant="ghost"
           size="icon"
-          className="h-8 w-8 rounded-lg text-muted-foreground hover:text-foreground hover:bg-muted/60"
-          onClick={openSessionHistory}
-          title={t('header.controls.sessionHistoryTitle')}
-          data-testid="session-history-toggle"
-        >
-          <History className="h-4 w-4" />
-        </Button>
-        <Button
-          variant="ghost"
-          size="icon"
-          className="h-8 w-8 rounded-lg text-muted-foreground hover:text-foreground hover:bg-muted/60"
+          className="h-7 w-7 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted/55"
           onClick={() => openSettings()}
           title={t('header.controls.settingsTitle')}
           data-testid="settings-toggle"
         >
-          <Settings className="h-4 w-4" />
+          <Settings className="h-3.5 w-3.5" />
         </Button>
         {keepAwakeEnabled && (
           <div
             className={cn(
-              'inline-flex h-8 w-8 items-center justify-center rounded-lg text-muted-foreground',
-              isKeepAwakeActive && 'text-amber-500'
+              'inline-flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground',
+              isKeepAwakeActive && 'text-neon-mint'
             )}
             title={t(
               isKeepAwakeActive
@@ -956,14 +640,14 @@ export function Header(): React.JSX.Element {
             )}
             data-testid="keep-awake-indicator"
           >
-            <Coffee className="h-4 w-4" />
+            <Zap className="h-3.5 w-3.5" />
           </div>
         )}
         <Button
           onClick={toggleRightSidebar}
           variant="ghost"
           size="icon"
-          className="h-8 w-8 rounded-lg text-muted-foreground hover:text-foreground hover:bg-muted/60"
+          className="h-7 w-7 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted/55"
           title={
             rightSidebarCollapsed
               ? t('header.controls.showSidebar')
@@ -972,9 +656,9 @@ export function Header(): React.JSX.Element {
           data-testid="right-sidebar-toggle"
         >
           {rightSidebarCollapsed ? (
-            <PanelRightOpen className="h-4 w-4" />
+            <PanelRightOpen className="h-3.5 w-3.5" />
           ) : (
-            <PanelRightClose className="h-4 w-4" />
+            <PanelRightClose className="h-3.5 w-3.5" />
           )}
         </Button>
       </div>

--- a/src/renderer/src/components/layout/LeftSidebar.tsx
+++ b/src/renderer/src/components/layout/LeftSidebar.tsx
@@ -120,7 +120,7 @@ export function LeftSidebar(): React.JSX.Element {
   return (
     <div className="flex flex-shrink-0" data-testid="left-sidebar-container">
       <aside
-        className="bg-sidebar text-sidebar-foreground border-r border-sidebar-border/60 flex flex-col overflow-hidden"
+        className="bg-sidebar/85 text-sidebar-foreground border-r border-sidebar-border/45 flex flex-col overflow-hidden backdrop-blur-sm"
         style={{ width: leftSidebarWidth }}
         data-testid="left-sidebar"
         data-width={leftSidebarWidth}
@@ -128,7 +128,7 @@ export function LeftSidebar(): React.JSX.Element {
         aria-label={t('leftSidebar.ariaLabel')}
       >
         {connectionModeActive ? (
-          <div className="px-4 py-3 border-b border-sidebar-border/60 flex items-center justify-between bg-muted/50">
+          <div className="px-4 py-3 border-b border-sidebar-border/45 flex items-center justify-between bg-agent-card-muted/60">
             <div className="flex items-center gap-2 text-sm font-medium min-w-0">
               <Link className="h-4 w-4 text-primary shrink-0" />
               <span className="truncate">{t('sidebar.connectionMode.selectWorktrees')}</span>
@@ -164,7 +164,7 @@ export function LeftSidebar(): React.JSX.Element {
             </div>
           </div>
         ) : (
-          <div className="px-3 pt-2 pb-0 border-b border-sidebar-border/60">
+          <div className="px-3 pt-3 pb-0 border-b border-sidebar-border/45">
             {/* Tab row */}
             <div className="flex items-center gap-3">
               <button
@@ -194,7 +194,9 @@ export function LeftSidebar(): React.JSX.Element {
                 <Link className="h-3 w-3 shrink-0" />
                 {t('connectionList.title')}
                 {connectionCount > 0 && (
-                  <span className="text-[10px] tabular-nums text-muted-foreground">{connectionCount}</span>
+                  <span className="text-[10px] tabular-nums text-muted-foreground">
+                    {connectionCount}
+                  </span>
                 )}
                 {sidebarTab === 'connections' && (
                   <div className="absolute bottom-0 left-0 right-0 h-0.5 rounded-full bg-primary" />
@@ -221,16 +223,16 @@ export function LeftSidebar(): React.JSX.Element {
           </div>
         )}
         {!connectionModeActive && sidebarTab === 'projects' && projectCount > 1 && (
-          <div className="px-4 py-3 border-b border-sidebar-border/70">
+          <div className="px-4 py-3 border-b border-sidebar-border/45">
             <ProjectFilter value={filterQuery} onChange={setFilterQuery} />
           </div>
         )}
         {sidebarTab === 'projects' && activeLanguages.length > 0 && (
-          <div className="px-4 py-2 border-b border-sidebar-border/70">
+          <div className="px-4 py-2 border-b border-sidebar-border/45">
             <FilterChips languages={activeLanguages} onRemove={removeLanguage} />
           </div>
         )}
-        <div className="flex-1 overflow-auto px-3 py-3" data-testid="sidebar-scroll-container">
+        <div className="flex-1 overflow-auto px-3 py-4" data-testid="sidebar-scroll-container">
           {sidebarTab === 'projects' || connectionModeActive ? (
             <>
               <PinnedList />
@@ -246,11 +248,11 @@ export function LeftSidebar(): React.JSX.Element {
         </div>
         {!connectionModeActive &&
           (showUsageIndicator ? (
-            <div className="border-t border-sidebar-border/70">
+            <div className="border-t border-sidebar-border/45">
               <UsageIndicator />
             </div>
           ) : (
-            <div className="border-t border-sidebar-border/70 px-2 py-2">
+            <div className="border-t border-sidebar-border/45 px-2 py-2">
               <SpacesTabBar />
             </div>
           ))}

--- a/src/renderer/src/components/layout/MainPane.tsx
+++ b/src/renderer/src/components/layout/MainPane.tsx
@@ -1,6 +1,5 @@
 import { useCallback, useEffect, useMemo, useState, lazy, Suspense } from 'react'
 import { Loader2 } from 'lucide-react'
-import { SessionTabs } from '@/components/sessions'
 import { FileViewer } from '@/components/file-viewer'
 import { InlineDiffViewer, ImageDiffView } from '@/components/diff'
 import { isImageFile } from '@shared/types/file-utils'
@@ -39,6 +38,13 @@ interface MainPaneProps {
   children?: React.ReactNode
 }
 
+function getSessionRuntimeKind(session: {
+  runtime_id?: string | null
+  agent_sdk?: string | null
+}): string | null {
+  return session.runtime_id ?? session.agent_sdk ?? null
+}
+
 export function MainPane({ children }: MainPaneProps): React.JSX.Element {
   const { t } = useI18n()
   const selectedWorktreeId = useWorktreeStore((state) => state.selectedWorktreeId)
@@ -63,11 +69,11 @@ export function MainPane({ children }: MainPaneProps): React.JSX.Element {
     const state = useSessionStore.getState()
     for (const sessions of state.sessionsByWorktree.values()) {
       const found = sessions.find((s) => s.id === sid)
-      if (found) return found.runtime_id
+      if (found) return getSessionRuntimeKind(found)
     }
     for (const sessions of state.sessionsByConnection.values()) {
       const found = sessions.find((s) => s.id === sid)
-      if (found) return found.runtime_id
+      if (found) return getSessionRuntimeKind(found)
     }
     return null
   }, [])
@@ -79,14 +85,14 @@ export function MainPane({ children }: MainPaneProps): React.JSX.Element {
     if (selectedWorktreeId) {
       const sessions = sessionsByWorktree.get(selectedWorktreeId) || []
       for (const s of sessions) {
-        if (s.runtime_id === 'terminal') terminals.push(s.id)
+        if (getSessionRuntimeKind(s) === 'terminal') terminals.push(s.id)
       }
     }
 
     if (selectedConnectionId) {
       const sessions = sessionsByConnection.get(selectedConnectionId) || []
       for (const s of sessions) {
-        if (s.runtime_id === 'terminal') terminals.push(s.id)
+        if (getSessionRuntimeKind(s) === 'terminal') terminals.push(s.id)
       }
     }
 
@@ -191,7 +197,7 @@ export function MainPane({ children }: MainPaneProps): React.JSX.Element {
             src={onboardingBgDark}
             alt=""
             aria-hidden="true"
-            className="pointer-events-none absolute inset-0 hidden h-full w-full object-cover opacity-40 dark:block"
+            className="pointer-events-none absolute inset-0 hidden h-full w-full object-cover opacity-25 dark:block"
           />
           <div className="relative text-center">
             <p className="text-lg font-medium">{t('mainPane.welcomeTitle')}</p>
@@ -300,11 +306,18 @@ export function MainPane({ children }: MainPaneProps): React.JSX.Element {
         return null
       }
       return (
-        <Suspense fallback={<div className="flex-1 flex items-center justify-center"><Loader2 className="h-5 w-5 animate-spin text-muted-foreground" /></div>}>
-          {sessionUiV2
-            ? <SessionShell key={inlineConnectionSessionId} sessionId={inlineConnectionSessionId} />
-            : <SessionView key={inlineConnectionSessionId} sessionId={inlineConnectionSessionId} />
+        <Suspense
+          fallback={
+            <div className="flex-1 flex items-center justify-center">
+              <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+            </div>
           }
+        >
+          {sessionUiV2 ? (
+            <SessionShell key={inlineConnectionSessionId} sessionId={inlineConnectionSessionId} />
+          ) : (
+            <SessionView key={inlineConnectionSessionId} sessionId={inlineConnectionSessionId} />
+          )}
         </Suspense>
       )
     }
@@ -323,7 +336,7 @@ export function MainPane({ children }: MainPaneProps): React.JSX.Element {
             src={onboardingBgDark}
             alt=""
             aria-hidden="true"
-            className="pointer-events-none absolute inset-0 hidden h-full w-full object-cover opacity-40 dark:block"
+            className="pointer-events-none absolute inset-0 hidden h-full w-full object-cover opacity-25 dark:block"
           />
           <div className="relative text-center">
             <p className="text-lg font-medium">{t('mainPane.noActiveSessionTitle')}</p>
@@ -339,11 +352,18 @@ export function MainPane({ children }: MainPaneProps): React.JSX.Element {
       return null
     }
     return (
-      <Suspense fallback={<div className="flex-1 flex items-center justify-center"><Loader2 className="h-5 w-5 animate-spin text-muted-foreground" /></div>}>
-        {sessionUiV2
-          ? <SessionShell key={activeSessionId} sessionId={activeSessionId} />
-          : <SessionView key={activeSessionId} sessionId={activeSessionId} />
+      <Suspense
+        fallback={
+          <div className="flex-1 flex items-center justify-center">
+            <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+          </div>
         }
+      >
+        {sessionUiV2 ? (
+          <SessionShell key={activeSessionId} sessionId={activeSessionId} />
+        ) : (
+          <SessionView key={activeSessionId} sessionId={activeSessionId} />
+        )}
       </Suspense>
     )
   }
@@ -353,14 +373,19 @@ export function MainPane({ children }: MainPaneProps): React.JSX.Element {
       className="flex-1 flex flex-col min-w-0 bg-background overflow-hidden"
       data-testid="main-pane"
     >
-      {(selectedWorktreeId || selectedConnectionId) && <SessionTabs />}
       {renderContent()}
       {/* Always-mounted terminal sessions — kept alive to preserve PTY state across tab switches */}
       {mountedTerminalSessionIds.map((sessionId) => {
         const isActive = visibleTerminalId === sessionId
         return (
           <div key={sessionId} className={isActive ? 'flex-1 flex flex-col min-h-0' : 'hidden'}>
-            <Suspense fallback={<div className="flex-1 flex items-center justify-center"><Loader2 className="h-5 w-5 animate-spin text-muted-foreground" /></div>}>
+            <Suspense
+              fallback={
+                <div className="flex-1 flex items-center justify-center">
+                  <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+                </div>
+              }
+            >
               <SessionTerminalView sessionId={sessionId} isVisible={isActive} />
             </Suspense>
           </div>

--- a/src/renderer/src/components/layout/RightSidebar.tsx
+++ b/src/renderer/src/components/layout/RightSidebar.tsx
@@ -1,6 +1,5 @@
-import { useCallback, useMemo, useRef } from 'react'
+import { useMemo } from 'react'
 import { useLayoutStore } from '@/stores/useLayoutStore'
-import { LAYOUT_CONSTRAINTS } from '@/stores/useLayoutStore'
 import { useWorktreeStore } from '@/stores/useWorktreeStore'
 import { useConnectionStore } from '@/stores/useConnectionStore'
 import { useFileViewerStore } from '@/stores/useFileViewerStore'
@@ -16,9 +15,8 @@ export function RightSidebar(): React.JSX.Element {
   const { rightSidebarWidth, rightSidebarCollapsed, setRightSidebarWidth, toggleRightSidebar } =
     useLayoutStore()
   const bottomPanelTab = useLayoutStore((s) => s.bottomPanelTab)
+  const rightContextTab = useLayoutStore((s) => s.rightContextTab)
   const terminalDock = useLayoutStore((s) => s.terminalDock)
-  const splitFractionByEntity = useLayoutStore((s) => s.splitFractionByEntity)
-  const setSplitFraction = useLayoutStore((s) => s.setSplitFraction)
 
   const { selectedWorktreeId, worktreesByProject } = useWorktreeStore()
   const selectedConnectionId = useConnectionStore((s) => s.selectedConnectionId)
@@ -26,13 +24,6 @@ export function RightSidebar(): React.JSX.Element {
     s.selectedConnectionId ? s.connections.find((c) => c.id === s.selectedConnectionId) : null
   )
   const isConnectionMode = !!selectedConnectionId && !selectedWorktreeId
-
-  const entityKey = selectedWorktreeId || selectedConnectionId
-  const splitFraction = entityKey
-    ? (splitFractionByEntity[entityKey] ?? LAYOUT_CONSTRAINTS.splitFraction.default)
-    : LAYOUT_CONSTRAINTS.splitFraction.default
-
-  const sidebarRef = useRef<HTMLElement>(null)
 
   // Get the selected worktree path by searching all projects' worktrees
   const selectedWorktreePath = useMemo(() => {
@@ -57,18 +48,6 @@ export function RightSidebar(): React.JSX.Element {
     setRightSidebarWidth(rightSidebarWidth + delta)
   }
 
-  const handleVerticalResize = useCallback(
-    (delta: number) => {
-      if (!entityKey || !sidebarRef.current) return
-      const totalHeight = sidebarRef.current.clientHeight
-      if (totalHeight <= 0) return
-      const fractionDelta = delta / totalHeight
-      const current = splitFractionByEntity[entityKey] ?? LAYOUT_CONSTRAINTS.splitFraction.default
-      setSplitFraction(entityKey, current + fractionDelta)
-    },
-    [entityKey, splitFractionByEntity, setSplitFraction]
-  )
-
   const handleFileClick = (node: { path: string; name: string; isDirectory: boolean }): void => {
     // Open file in the file viewer tab
     const contextId = selectedWorktreeId || selectedConnectionId
@@ -84,13 +63,23 @@ export function RightSidebar(): React.JSX.Element {
   // PTY state across sidebar collapse/expand and worktree switches.
   // When terminal is docked to bottom, TerminalManager lives in BottomDock instead.
   const isDockRight = terminalDock === 'right'
+  const terminalPanelVisible = isDockRight && rightContextTab === 'terminal'
   const terminalManager = isDockRight ? (
     <TerminalManager
       selectedWorktreeId={selectedWorktreeId}
       worktreePath={selectedWorktreePath}
-      isVisible={!rightSidebarCollapsed && effectiveBottomPanelTab === 'terminal'}
+      isVisible={
+        !rightSidebarCollapsed && terminalPanelVisible && effectiveBottomPanelTab === 'terminal'
+      }
     />
   ) : null
+  const terminalPanel = isDockRight ? (
+    <BottomPanel
+      terminalSlot={terminalManager}
+      isConnectionMode={isConnectionMode}
+      worktreePath={selectedWorktreePath}
+    />
+  ) : undefined
 
   if (rightSidebarCollapsed) {
     return (
@@ -105,63 +94,32 @@ export function RightSidebar(): React.JSX.Element {
     <div className="flex flex-shrink-0" data-testid="right-sidebar-container">
       <ResizeHandle onResize={handleResize} direction="right" />
       <aside
-        ref={sidebarRef}
-        className="flex flex-col overflow-hidden border-l border-sidebar-border/60 bg-sidebar text-sidebar-foreground"
+        className="flex flex-col overflow-hidden border-l border-sidebar-border/45 bg-sidebar/70 text-sidebar-foreground backdrop-blur-sm"
         style={{ width: rightSidebarWidth }}
         data-testid="right-sidebar"
         data-width={rightSidebarWidth}
         role="complementary"
         aria-label={t('rightSidebar.ariaLabel')}
       >
-        {/* Top half: Context panel host (Overview / Review / Files / Tasks / Goal) */}
-        <div
-          className="flex min-h-0 flex-col overflow-hidden"
-          style={{ flex: isDockRight ? `${splitFraction} 1 0%` : '1 1 0%' }}
-          data-testid="right-sidebar-top"
-        >
-          <ErrorBoundary
-            componentName="ContextPanelHost"
-            fallback={
-              <div className="flex-1 p-2">
-                <ErrorFallback compact title={t('rightSidebar.fileSidebarError')} />
-              </div>
-            }
-          >
-            <ContextPanelHost
-              worktreePath={selectedWorktreePath}
-              isConnectionMode={isConnectionMode}
-              connectionMembers={selectedConnection?.members}
-              onClose={toggleRightSidebar}
-              onFileClick={handleFileClick}
-              className="flex-1 min-h-0"
-            />
-          </ErrorBoundary>
-        </div>
-
-        {/* Bottom panel — only when terminal is docked to right */}
-        {isDockRight && (
-          <>
-            {/* Draggable divider between top and bottom panels */}
-            <ResizeHandle
-              onResize={handleVerticalResize}
-              direction="up"
-              className="h-px border-0 bg-sidebar-border/60 hover:bg-primary/20 active:bg-primary/30"
-            />
-
-            {/* Bottom half: Tab panel */}
-            <div
-              className="flex min-h-0 flex-col overflow-hidden bg-sidebar"
-              style={{ flex: `${1 - splitFraction} 1 0%` }}
-              data-testid="right-sidebar-bottom"
-            >
-              <BottomPanel
-                terminalSlot={terminalManager}
-                isConnectionMode={isConnectionMode}
-                worktreePath={selectedWorktreePath}
-              />
+        <ErrorBoundary
+          componentName="ContextPanelHost"
+          fallback={
+            <div className="flex-1 p-2">
+              <ErrorFallback compact title={t('rightSidebar.fileSidebarError')} />
             </div>
-          </>
-        )}
+          }
+        >
+          <ContextPanelHost
+            worktreePath={selectedWorktreePath}
+            scopeId={isConnectionMode ? selectedConnectionId : selectedWorktreeId}
+            isConnectionMode={isConnectionMode}
+            connectionMembers={selectedConnection?.members}
+            onClose={toggleRightSidebar}
+            onFileClick={handleFileClick}
+            terminalPanel={terminalPanel}
+            className="flex-1 min-h-0"
+          />
+        </ErrorBoundary>
       </aside>
     </div>
   )

--- a/src/renderer/src/components/layout/RightSidebar.tsx
+++ b/src/renderer/src/components/layout/RightSidebar.tsx
@@ -5,7 +5,7 @@ import { useWorktreeStore } from '@/stores/useWorktreeStore'
 import { useConnectionStore } from '@/stores/useConnectionStore'
 import { useFileViewerStore } from '@/stores/useFileViewerStore'
 import { ResizeHandle } from './ResizeHandle'
-import { FileSidebar } from '@/components/file-tree'
+import { ContextPanelHost } from '@/components/context-panel/ContextPanelHost'
 import { BottomPanel } from './BottomPanel'
 import { TerminalManager } from '@/components/terminal/TerminalManager'
 import { ErrorBoundary, ErrorFallback } from '@/components/error'
@@ -113,21 +113,21 @@ export function RightSidebar(): React.JSX.Element {
         role="complementary"
         aria-label={t('rightSidebar.ariaLabel')}
       >
-        {/* Top half: Tabbed sidebar (Changes / Files) */}
+        {/* Top half: Context panel host (Overview / Review / Files / Tasks / Goal) */}
         <div
           className="flex min-h-0 flex-col overflow-hidden"
           style={{ flex: isDockRight ? `${splitFraction} 1 0%` : '1 1 0%' }}
           data-testid="right-sidebar-top"
         >
           <ErrorBoundary
-            componentName="FileSidebar"
+            componentName="ContextPanelHost"
             fallback={
               <div className="flex-1 p-2">
                 <ErrorFallback compact title={t('rightSidebar.fileSidebarError')} />
               </div>
             }
           >
-            <FileSidebar
+            <ContextPanelHost
               worktreePath={selectedWorktreePath}
               isConnectionMode={isConnectionMode}
               connectionMembers={selectedConnection?.members}
@@ -154,7 +154,11 @@ export function RightSidebar(): React.JSX.Element {
               style={{ flex: `${1 - splitFraction} 1 0%` }}
               data-testid="right-sidebar-bottom"
             >
-              <BottomPanel terminalSlot={terminalManager} isConnectionMode={isConnectionMode} worktreePath={selectedWorktreePath} />
+              <BottomPanel
+                terminalSlot={terminalManager}
+                isConnectionMode={isConnectionMode}
+                worktreePath={selectedWorktreePath}
+              />
             </div>
           </>
         )}

--- a/src/renderer/src/components/projects/ProjectItem.tsx
+++ b/src/renderer/src/components/projects/ProjectItem.tsx
@@ -286,10 +286,8 @@ export function ProjectItem({
         <ContextMenuTrigger asChild>
           <div
             className={cn(
-              'group flex items-center gap-2 px-2.5 py-2.5 rounded-xl cursor-pointer transition-colors',
-              isSelected
-                ? 'bg-sidebar-accent text-sidebar-accent-foreground ring-1 ring-sidebar-border/60 shadow-sm'
-                : 'hover:bg-sidebar-accent/70',
+              'group flex items-center gap-2 px-2.5 py-3 rounded-xl cursor-pointer transition-colors',
+              isSelected ? 'crisp-parent-active-row' : 'crisp-hover-row',
               isDragging && 'opacity-50',
               isDragOver && 'border-t-2 border-primary'
             )}
@@ -358,7 +356,7 @@ export function ProjectItem({
                   <HighlightedText
                     text={project.path}
                     indices={pathMatchIndices}
-                    className="text-[11px] text-muted-foreground/90 truncate block mt-0.5"
+                    className="text-[11px] text-muted-foreground/70 truncate block mt-0.5"
                   />
                 )}
               </div>

--- a/src/renderer/src/components/session-hq/AgentTimeline.tsx
+++ b/src/renderer/src/components/session-hq/AgentTimeline.tsx
@@ -431,6 +431,13 @@ function TimelineNodeView({
                 </span>
               </div>
             )}
+            {node.message.deliveryStatus === 'queued' && (
+              <div className="mb-2">
+                <span className="inline-flex items-center rounded-md bg-amber-500/15 px-2 py-0.5 text-[10px] font-semibold text-amber-600 dark:text-amber-400">
+                  {t('queuedMessageBubble.badge')}
+                </span>
+              </div>
+            )}
             {images.length > 0 && (
               <div className="flex flex-wrap gap-2">
                 {images.map((img, i) => (

--- a/src/renderer/src/components/session-hq/AgentTimeline.tsx
+++ b/src/renderer/src/components/session-hq/AgentTimeline.tsx
@@ -15,7 +15,6 @@ import { cn } from '@/lib/utils'
 import { formatMessageTime } from '@/lib/format-time'
 import type { TimelineMessage, StreamingPart, ToolUseInfo } from '@shared/lib/timeline-types'
 import type { MessagePart } from '@shared/types/opencode'
-import type { AgentSessionGoalState } from '@shared/types/agent-protocol'
 import type { SessionLifecycle } from '@/stores/useSessionRuntimeStore'
 import { CopyMessageButton } from '@/components/sessions/CopyMessageButton'
 import { ForkMessageButton } from '@/components/sessions/ForkMessageButton'
@@ -32,8 +31,7 @@ import {
   AskUserCard,
   SubAgentCard,
   TextCard,
-  TodoCard,
-  GoalStatusCard
+  TodoCard
 } from './cards'
 import { ThreadStatusRow, type ThreadStatusRowData } from './ThreadStatusRow'
 import { SystemNotificationBar } from '../sessions/SystemNotificationBar'
@@ -702,8 +700,6 @@ export interface AgentTimelineProps {
    */
   activeRunStartedAt?: number | string | null
   lifecycle: SessionLifecycle
-  sessionGoal?: AgentSessionGoalState | null
-  onDismissSessionGoal?: () => void
   ephemeralStatusRows?: ThreadStatusRowData[]
   /**
    * Live compaction marker that should appear inline at its own timestamp
@@ -712,9 +708,9 @@ export interface AgentTimelineProps {
    * passing this so the durable copy takes over.
    */
   inflightCompaction?: ThreadStatusRowData | null
-  /** Suppress inline TodoCard rendering when MissionControl handles tasks */
+  /** Suppress inline TodoCard rendering when the right context panel owns tasks. */
   suppressTodoCards?: boolean
-  /** Aggregated final task list — renders ONE TodoCard after MissionControl fades */
+  /** Aggregated final task list — renders one TodoCard when explicitly requested. */
   finalTodoTasks?: Array<{ id: string; content: string; status: string }>
   /** Session ID — needed for interactive AskUserCard reply */
   sessionId?: string
@@ -761,8 +757,6 @@ export function AgentTimeline({
   isStreaming,
   activeRunStartedAt,
   lifecycle: _lifecycle,
-  sessionGoal = null,
-  onDismissSessionGoal,
   ephemeralStatusRows = [],
   inflightCompaction = null,
   suppressTodoCards,
@@ -825,7 +819,7 @@ export function AgentTimeline({
     return filteredMessages
       .flatMap((msg) => messageToNodes(msg))
       .filter((node) => {
-        // Suppress inline TodoCards when MissionControl handles tasks
+        // Suppress inline TodoCards when the right context panel owns tasks.
         if (suppressTodoCards && node.cardType === 'todo') return false
         return true
       })
@@ -1003,12 +997,6 @@ export function AgentTimeline({
           paddingBottom: `${Math.max(bottomFloatingHeight + 88, 360)}px`
         }}
       >
-        {sessionGoal && (
-          <div className="sticky top-3 z-20 mb-5" data-testid="goal-status-sticky">
-            <GoalStatusCard goal={sessionGoal} onDismiss={onDismissSessionGoal} />
-          </div>
-        )}
-
         {/* Inline compaction marker inserted by timestamp. */}
         {inflightCompaction && inflightCompactionInsertAfter === -1 && (
           <ThreadStatusRow key={inflightCompaction.id} status={inflightCompaction} />
@@ -1149,7 +1137,7 @@ export function AgentTimeline({
           )
         })}
 
-        {/* Final aggregated TodoCard — appears after MissionControl fades */}
+        {/* Final aggregated TodoCard — rendered only when a parent explicitly passes it. */}
         {finalTodoTasks && finalTodoTasks.length > 0 && (
           <div className="relative pl-10 mb-4">
             <div className="absolute left-[15px] top-0 bottom-0 w-[2px] bg-border" />
@@ -1256,7 +1244,7 @@ export function AgentTimeline({
         ))}
 
         {/* Empty state */}
-        {nodes.length === 0 && ephemeralStatusRows.length === 0 && !isStreaming && !sessionGoal && (
+        {nodes.length === 0 && ephemeralStatusRows.length === 0 && !isStreaming && (
           <div className="flex flex-col items-center justify-center py-20 text-muted-foreground">
             <MessageSquare className="h-10 w-10 mb-3 opacity-30" />
             <div className="text-sm font-medium">{t('sessionHq.timeline.emptyTitle')}</div>

--- a/src/renderer/src/components/session-hq/AgentTimeline.tsx
+++ b/src/renderer/src/components/session-hq/AgentTimeline.tsx
@@ -304,42 +304,50 @@ interface IconConfig {
 const ICON_MAP: Record<CardType, IconConfig> = {
   'user-message': {
     icon: User,
-    colorClass: 'text-blue-600 dark:text-blue-400',
-    bgClass: 'bg-blue-500/15'
+    colorClass: 'text-tech-blue',
+    bgClass: 'bg-tech-blue-soft'
   },
-  system: { icon: MessageSquare, colorClass: 'text-muted-foreground', bgClass: 'bg-muted' },
+  system: { icon: MessageSquare, colorClass: 'text-steel', bgClass: 'bg-agent-card-muted' },
   'task-notification': {
     icon: MessageSquare,
-    colorClass: 'text-muted-foreground',
-    bgClass: 'bg-muted'
+    colorClass: 'text-steel',
+    bgClass: 'bg-agent-card-muted'
   },
-  thinking: { icon: Brain, colorClass: 'text-muted-foreground', bgClass: 'bg-muted' },
-  bash: { icon: Terminal, colorClass: 'text-celadon', bgClass: 'bg-celadon/15' },
-  'file-read': { icon: FileText, colorClass: 'text-celadon', bgClass: 'bg-celadon/15' },
+  thinking: {
+    icon: Brain,
+    colorClass: 'text-neon-violet',
+    bgClass: 'bg-neon-violet-soft'
+  },
+  bash: { icon: Terminal, colorClass: 'text-neon-mint', bgClass: 'bg-neon-mint-soft' },
+  'file-read': { icon: FileText, colorClass: 'text-neon-mint', bgClass: 'bg-neon-mint-soft' },
   'file-write': {
     icon: Pencil,
-    colorClass: 'text-blue-600 dark:text-blue-400',
-    bgClass: 'bg-blue-500/15'
+    colorClass: 'text-tech-blue',
+    bgClass: 'bg-tech-blue-soft'
   },
-  search: { icon: Search, colorClass: 'text-celadon', bgClass: 'bg-celadon/15' },
+  search: { icon: Search, colorClass: 'text-neon-mint', bgClass: 'bg-neon-mint-soft' },
   'sub-agent': {
     icon: Users,
-    colorClass: 'text-purple-600 dark:text-purple-400',
-    bgClass: 'bg-purple-500/15'
+    colorClass: 'text-neon-violet',
+    bgClass: 'bg-neon-violet-soft'
   },
   plan: {
     icon: ClipboardList,
-    colorClass: 'text-purple-600 dark:text-purple-400',
-    bgClass: 'bg-purple-500/15'
+    colorClass: 'text-neon-violet',
+    bgClass: 'bg-neon-violet-soft'
   },
   'ask-user': {
     icon: HelpCircle,
-    colorClass: 'text-amber-600 dark:text-amber-400',
-    bgClass: 'bg-amber-500/15'
+    colorClass: 'text-neon-pink',
+    bgClass: 'bg-neon-pink-soft'
   },
-  todo: { icon: CheckSquare, colorClass: 'text-celadon', bgClass: 'bg-celadon/15' },
-  'tool-call': { icon: Terminal, colorClass: 'text-muted-foreground', bgClass: 'bg-muted' },
-  text: { icon: MessageSquare, colorClass: 'text-foreground', bgClass: 'bg-muted' }
+  todo: { icon: CheckSquare, colorClass: 'text-neon-mint', bgClass: 'bg-neon-mint-soft' },
+  'tool-call': {
+    icon: Terminal,
+    colorClass: 'text-neon-violet',
+    bgClass: 'bg-neon-violet-soft'
+  },
+  text: { icon: MessageSquare, colorClass: 'text-ink', bgClass: 'bg-agent-card-muted' }
 }
 
 // ---------------------------------------------------------------------------
@@ -421,10 +429,10 @@ function TimelineNodeView({
 
       return (
         <div className="group/user-message">
-          <div className="bg-blue-500/5 border border-blue-500/20 rounded-[10px] px-3.5 py-2.5">
+          <div className="crisp-subtle-shadow rounded-xl border border-tech-blue/15 bg-tech-blue-soft/70 px-3.5 py-2.5">
             {node.message.steered === true && (
               <div className="mb-2">
-                <span className="inline-flex items-center rounded-md bg-sky-500/15 px-2 py-0.5 text-[10px] font-semibold text-sky-500">
+                <span className="inline-flex items-center rounded-md bg-neon-violet-soft px-2 py-0.5 text-[10px] font-semibold text-neon-violet">
                   {t('sessionHq.timeline.steered')}
                 </span>
               </div>
@@ -494,7 +502,7 @@ function TimelineNodeView({
             ) : displayText ? (
               <div
                 className={cn(
-                  'text-sm text-foreground whitespace-pre-wrap break-words',
+                  'crisp-readable text-sm text-foreground whitespace-pre-wrap break-words',
                   (images.length > 0 || files.length > 0) && 'mt-2'
                 )}
               >
@@ -656,9 +664,10 @@ function TimelineNodeView({
       const isError = node.toolUse.status === 'error'
       const isRunning = node.toolUse.status === 'running' || node.toolUse.status === 'pending'
       return (
-        <div className="rounded-lg border border-border/50 bg-card/80 px-3.5 py-2">
+        <div className="crisp-subtle-shadow rounded-xl border border-neon-violet/25 bg-neon-violet-soft/55 px-3.5 py-2">
           <div className="flex items-center gap-2 text-sm">
-            <span className="font-medium text-foreground">{label}</span>
+            <span className="crisp-status-dot h-2 w-2 rounded-full bg-neon-violet text-neon-violet" />
+            <span className="font-medium text-ink">{label}</span>
             <span className="text-xs text-muted-foreground">
               {isRunning
                 ? t('sessionHq.timeline.genericToolStatus.running')
@@ -974,6 +983,8 @@ export function AgentTimeline({
     })
   }, [streamingParts, suppressTodoCards, committedToolUseIds])
 
+  const safeBottomPadding = Math.max(bottomFloatingHeight + 88, 140)
+
   return (
     <div
       ref={scrollContainerRef}
@@ -990,11 +1001,9 @@ export function AgentTimeline({
         style={{
           // The ComposerBar is `absolute bottom-16` (64px from viewport bottom).
           // Its TOP edge sits `composerHeight + 64` above the bottom. Reserve
-          // that much plus 24px breathing room so the last transcript node is
-          // never hidden behind it. Fallback is generous (360px) because the
-          // initial ResizeObserver tick can arrive AFTER the first paint — a
-          // small 232px fallback leaves the last node covered for one frame.
-          paddingBottom: `${Math.max(bottomFloatingHeight + 88, 360)}px`
+          // that much plus breathing room so the last transcript node is never
+          // hidden behind it. Keep a hard 140px minimum for the floating console.
+          paddingBottom: `${safeBottomPadding}px`
         }}
       >
         {/* Inline compaction marker inserted by timestamp. */}
@@ -1058,7 +1067,7 @@ export function AgentTimeline({
                 <div className="relative pl-10 mb-4">
                   {/* Vertical line */}
                   {renderConnector && (
-                    <div className="absolute left-[15px] top-0 bottom-0 w-[2px] bg-border" />
+                    <div className="absolute left-[15px] top-0 bottom-0 w-[2px] bg-agent-hover/70" />
                   )}
                   <TimelineNodeView
                     node={node}
@@ -1093,7 +1102,7 @@ export function AgentTimeline({
               <div className="relative pl-10 mb-4">
                 {/* Vertical line */}
                 {renderConnector && (
-                  <div className="absolute left-[15px] top-0 bottom-0 w-[2px] bg-border" />
+                  <div className="absolute left-[15px] top-0 bottom-0 w-[2px] bg-agent-hover/70" />
                 )}
 
                 {/* Icon node */}
@@ -1140,7 +1149,7 @@ export function AgentTimeline({
         {/* Final aggregated TodoCard — rendered only when a parent explicitly passes it. */}
         {finalTodoTasks && finalTodoTasks.length > 0 && (
           <div className="relative pl-10 mb-4">
-            <div className="absolute left-[15px] top-0 bottom-0 w-[2px] bg-border" />
+            <div className="absolute left-[15px] top-0 bottom-0 w-[2px] bg-agent-hover/70" />
             <div
               className={cn(
                 'absolute left-[4px] top-2.5 w-[24px] h-[24px] rounded-full',
@@ -1166,13 +1175,13 @@ export function AgentTimeline({
             if (node.cardType === 'text') {
               return (
                 <div key={node.key} className="relative pl-10 mb-4">
-                  <div className="absolute left-[15px] top-0 bottom-0 w-[2px] bg-border" />
+                  <div className="absolute left-[15px] top-0 bottom-0 w-[2px] bg-agent-hover/70" />
                   <div
                     className={cn(
                       'absolute left-[4px] top-2.5 w-[24px] h-[24px] rounded-full',
                       'flex items-center justify-center z-10',
                       isLastStreamNode
-                        ? 'bg-muted text-foreground'
+                        ? 'bg-neon-mint-soft text-neon-mint'
                         : iconCfg.bgClass + ' ' + iconCfg.colorClass
                     )}
                   >
@@ -1189,7 +1198,7 @@ export function AgentTimeline({
 
             return (
               <div key={node.key} className="relative pl-10 mb-4">
-                <div className="absolute left-[15px] top-0 bottom-0 w-[2px] bg-border" />
+                <div className="absolute left-[15px] top-0 bottom-0 w-[2px] bg-agent-hover/70" />
                 <div
                   className={cn(
                     'absolute left-[4px] top-2.5 w-[24px] h-[24px] rounded-full',
@@ -1228,7 +1237,7 @@ export function AgentTimeline({
               className={cn(
                 'absolute left-[4px] top-2.5 w-[24px] h-[24px] rounded-full',
                 'flex items-center justify-center z-10',
-                'bg-muted text-muted-foreground'
+                'bg-neon-mint-soft text-neon-mint'
               )}
             >
               <Loader2 className="h-3 w-3 animate-spin" />

--- a/src/renderer/src/components/session-hq/ComposerBar.tsx
+++ b/src/renderer/src/components/session-hq/ComposerBar.tsx
@@ -78,6 +78,7 @@ export interface ComposerBarProps {
   commandsVersion?: number
   containerRef?: React.RefObject<HTMLDivElement | null>
   contextAttachmentSlot?: React.ReactNode
+  controlSlot?: React.ReactNode
 }
 
 // ---------------------------------------------------------------------------
@@ -292,6 +293,7 @@ interface ComposerToolbarProps {
   primaryLabel: string
   onAttach: (file: Omit<Attachment, 'id'>) => void
   voiceSlot?: React.ReactNode
+  controlSlot?: React.ReactNode
 }
 
 const ComposerToolbar = React.memo(function ComposerToolbar({
@@ -311,7 +313,8 @@ const ComposerToolbar = React.memo(function ComposerToolbar({
   iconHint,
   primaryLabel,
   onAttach,
-  voiceSlot
+  voiceSlot,
+  controlSlot
 }: ComposerToolbarProps): React.JSX.Element {
   const { t } = useI18n()
   const showQueueShortcutHint = iconHint === 'steer' && availableAlternatives.includes('queue')
@@ -319,6 +322,7 @@ const ComposerToolbar = React.memo(function ComposerToolbar({
     <div className="flex items-center gap-2 px-3 pb-3 pt-1">
       <AttachmentButton onAttach={onAttach} disabled={disabled} />
       {voiceSlot}
+      {controlSlot}
 
       {/* Plan mode toggle */}
       {pendingPlan ? (
@@ -451,7 +455,8 @@ export function ComposerBar({
   worktreePath,
   commandsVersion = 0,
   containerRef,
-  contextAttachmentSlot
+  contextAttachmentSlot,
+  controlSlot
 }: ComposerBarProps): React.JSX.Element {
   const { t } = useI18n()
   const textareaRef = useRef<HTMLTextAreaElement>(null)
@@ -840,9 +845,9 @@ export function ComposerBar({
         ? t('sessionHq.composer.placeholders.queueFollowUp')
         : actionSet.primary === 'steer' || canSteerBusyTurn
           ? t('sessionHq.composer.placeholders.steerCurrent')
-        : actionSet.iconHint === 'stop'
-          ? t('sessionHq.composer.placeholders.stopAndSend')
-          : t('sessionHq.composer.placeholders.message')
+          : actionSet.iconHint === 'stop'
+            ? t('sessionHq.composer.placeholders.stopAndSend')
+            : t('sessionHq.composer.placeholders.message')
 
   // Determine if button should be enabled
   const buttonEnabled =
@@ -874,16 +879,13 @@ export function ComposerBar({
       className={cn(
         'absolute bottom-16 z-20',
         'w-[85%] ml-[5%]',
-        'rounded-2xl border border-border/50',
-        'bg-background/70 backdrop-blur-xl',
-        'shadow-lg shadow-black/5 dark:shadow-black/20',
-        voiceCaptureVisible &&
-          'border-cyan-300/50 bg-cyan-500/[0.035] shadow-[0_0_0_1px_rgba(103,232,249,0.14),0_20px_70px_rgba(6,182,212,0.16)] dark:border-cyan-300/30 dark:bg-cyan-400/[0.045]'
+        'crisp-floating-surface rounded-xl backdrop-blur-xl',
+        voiceCaptureVisible && 'crisp-voice-surface'
       )}
     >
       {voiceCaptureVisible && (
         <div
-          className="pointer-events-none absolute inset-0 rounded-2xl bg-[radial-gradient(circle_at_18%_0%,rgba(34,211,238,0.18),transparent_30%),radial-gradient(circle_at_82%_100%,rgba(14,165,233,0.14),transparent_34%)]"
+          className="crisp-voice-aura pointer-events-none absolute inset-0 rounded-xl"
           data-testid="composer-voice-field-aura"
         />
       )}
@@ -972,6 +974,7 @@ export function ComposerBar({
           hasPendingMessages: pendingCount > 0
         })}
         onAttach={handleAttach}
+        controlSlot={controlSlot}
         voiceSlot={
           voiceInputEnabled ? (
             <VoiceRecorderButton

--- a/src/renderer/src/components/session-hq/ComposerBar.tsx
+++ b/src/renderer/src/components/session-hq/ComposerBar.tsx
@@ -605,10 +605,12 @@ export function ComposerBar({
 
       const consumed = await onAction(action, snapshotContent, snapshotAttachments)
       if (!consumed) {
-        // Send failed — restore the text so the user can retry. Attachments
-        // aren't restored (files have been consumed by the optimistic path).
+        // Send failed or was rejected by the busy-state action policy. Restore
+        // the full payload so attachments are not silently dropped.
         contentRef.current = snapshotContent
+        attachmentsRef.current = snapshotAttachments
         setContent(snapshotContent)
+        setAttachments(snapshotAttachments)
       }
     },
     [clearInput, onAction]

--- a/src/renderer/src/components/session-hq/SessionHeader.tsx
+++ b/src/renderer/src/components/session-hq/SessionHeader.tsx
@@ -8,13 +8,17 @@ import { useMemo, useState } from 'react'
 import { Lock, TerminalSquare, Check } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { ModelSelector } from '../sessions/ModelSelector'
+import { ContextIndicator } from '../sessions/ContextIndicator'
+import { SessionCostPill } from '../sessions/SessionCostPill'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { useSettingsStore } from '@/stores/useSettingsStore'
 import { useSessionStore } from '@/stores/useSessionStore'
+import { useContextStore } from '@/stores/useContextStore'
 import { useI18n } from '@/i18n/useI18n'
 import { toast } from '@/lib/toast'
 import type { SessionLifecycle } from '@/stores/useSessionRuntimeStore'
+import type { UsageAnalyticsSessionSummary } from '@shared/types/usage-analytics'
 
 type AgentSdk = 'opencode' | 'claude-code' | 'codex' | 'terminal'
 
@@ -49,10 +53,10 @@ function getLifecycleLabel(
 
 const LIFECYCLE_META: Record<SessionLifecycle, { dotClass: string }> = {
   idle: { dotClass: 'bg-muted-foreground/50' },
-  busy: { dotClass: 'bg-celadon animate-pulse' },
-  retry: { dotClass: 'bg-yellow-500 animate-pulse' },
-  error: { dotClass: 'bg-red-500' },
-  materializing: { dotClass: 'bg-blue-500 animate-pulse' }
+  busy: { dotClass: 'bg-neon-mint crisp-status-dot animate-pulse' },
+  retry: { dotClass: 'bg-neon-violet crisp-status-dot animate-pulse' },
+  error: { dotClass: 'bg-neon-pink crisp-status-dot' },
+  materializing: { dotClass: 'bg-tech-blue crisp-status-dot animate-pulse' }
 }
 
 function ProviderCapsule({
@@ -146,7 +150,7 @@ function ProviderCapsule({
               )}
             >
               <span className="flex items-center gap-1.5">
-                {s === 'terminal' && <TerminalSquare className="h-3.5 w-3.5 text-emerald-500" />}
+                {s === 'terminal' && <TerminalSquare className="h-3.5 w-3.5 text-tech-blue" />}
                 {getProviderLabel(s, t)}
               </span>
               {active && <Check className="h-3.5 w-3.5" />}
@@ -162,20 +166,25 @@ export interface SessionHeaderProps {
   sessionId: string
   session: {
     agent_sdk: string
+    opencode_session_id: string | null
     model_id: string | null
     model_provider_id: string | null
     first_message_at?: number | null
   }
   lifecycle: SessionLifecycle
+  usageSummary?: UsageAnalyticsSessionSummary | null
 }
 
 export function SessionHeader({
   sessionId,
   session,
-  lifecycle
+  lifecycle,
+  usageSummary
 }: SessionHeaderProps): React.JSX.Element {
   const locked = session.first_message_at != null
   const isTerminal = session.agent_sdk === 'terminal'
+  const sessionCostSnapshot = useContextStore((state) => state.costBySession[sessionId] ?? 0)
+  const sessionTokenSnapshot = useContextStore((state) => state.tokensBySession[sessionId] ?? null)
 
   return (
     <div className="flex items-center gap-2 px-4 py-2 border-b border-border/60 shrink-0">
@@ -186,6 +195,29 @@ export function SessionHeader({
         locked={locked}
       />
       {!isTerminal && <ModelSelector sessionId={sessionId} compact showProviderPrefix={false} />}
+      {!isTerminal && (
+        <ContextIndicator
+          sessionId={sessionId}
+          modelId={session.model_id ?? ''}
+          providerId={session.model_provider_id ?? undefined}
+        />
+      )}
+      {!isTerminal && (
+        <SessionCostPill
+          summary={usageSummary}
+          fallbackCost={sessionCostSnapshot}
+          fallbackTokens={
+            sessionTokenSnapshot
+              ? {
+                  input: sessionTokenSnapshot.input,
+                  output: sessionTokenSnapshot.output,
+                  cacheRead: sessionTokenSnapshot.cacheRead,
+                  cacheWrite: sessionTokenSnapshot.cacheWrite
+                }
+              : null
+          }
+        />
+      )}
 
       <div className="flex-1" />
     </div>

--- a/src/renderer/src/components/session-hq/SessionHeader.tsx
+++ b/src/renderer/src/components/session-hq/SessionHeader.tsx
@@ -2,38 +2,19 @@
  * SessionHeader — thin-border capsule layout
  *
  * Left:  provider+lifecycle │ model selector
- * Right: context capsule │ cost capsule
  */
 
 import { useMemo, useState } from 'react'
-import {
-  DollarSign,
-  Clock3,
-  Layers3,
-  TriangleAlert,
-  Lock,
-  TerminalSquare,
-  Check
-} from 'lucide-react'
+import { Lock, TerminalSquare, Check } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { ModelSelector } from '../sessions/ModelSelector'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
-import {
-  Popover,
-  PopoverContent,
-  PopoverHeader,
-  PopoverTitle,
-  PopoverTrigger
-} from '@/components/ui/popover'
-import { useShallow } from 'zustand/react/shallow'
-import { useContextStore } from '@/stores/useContextStore'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { useSettingsStore } from '@/stores/useSettingsStore'
 import { useSessionStore } from '@/stores/useSessionStore'
 import { useI18n } from '@/i18n/useI18n'
 import { toast } from '@/lib/toast'
 import type { SessionLifecycle } from '@/stores/useSessionRuntimeStore'
-import type { UsageAnalyticsSessionSummary } from '@shared/types/usage-analytics'
-import { formatModelLabelSummary, getSessionSummaryModelLabels } from '@/lib/model-labels'
 
 type AgentSdk = 'opencode' | 'claude-code' | 'codex' | 'terminal'
 
@@ -72,36 +53,6 @@ const LIFECYCLE_META: Record<SessionLifecycle, { dotClass: string }> = {
   retry: { dotClass: 'bg-yellow-500 animate-pulse' },
   error: { dotClass: 'bg-red-500' },
   materializing: { dotClass: 'bg-blue-500 animate-pulse' }
-}
-
-function formatNumber(n: number): string {
-  return n.toLocaleString()
-}
-
-function formatTokensShort(value: number): string {
-  if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(2)}M`
-  if (value >= 1_000) return `${(value / 1_000).toFixed(1)}K`
-  return value.toLocaleString()
-}
-
-function formatCurrency(amount: number): string {
-  return `$${amount.toFixed(4)}`
-}
-
-function formatDuration(seconds: number): string {
-  const hours = Math.floor(seconds / 3600)
-  const minutes = Math.floor((seconds % 3600) / 60)
-  const secs = seconds % 60
-  if (hours > 0) return `${hours}h ${minutes}m`
-  if (minutes > 0) return `${minutes}m ${secs}s`
-  return `${secs}s`
-}
-
-function getBarColor(percent: number): string {
-  if (percent >= 90) return '#d9485f'
-  if (percent >= 80) return '#d17a22'
-  if (percent >= 60) return '#b28a17'
-  return '#237a68'
 }
 
 function ProviderCapsule({
@@ -207,233 +158,6 @@ function ProviderCapsule({
   )
 }
 
-function ContextCapsule({
-  sessionId,
-  modelId,
-  providerId
-}: {
-  sessionId: string
-  modelId: string
-  providerId: string
-}): React.JSX.Element | null {
-  const { t } = useI18n()
-
-  // useShallow + field picking is required: getContextUsage() returns a fresh
-  // object each call, and some fields (model, cost, rawMaxTokens) can also be
-  // freshly-allocated — a naive selector would loop useSyncExternalStore.
-  const { used, limit, percent, tokens, categories, isRefreshing } = useContextStore(
-    useShallow((state) => {
-      const usage = state.getContextUsage(sessionId, modelId, providerId)
-      return {
-        used: usage.used,
-        limit: usage.limit,
-        percent: usage.percent,
-        tokens: usage.tokens,
-        categories: usage.categories,
-        isRefreshing: usage.isRefreshing
-      }
-    })
-  )
-
-  if (!limit && used === 0 && !isRefreshing) return null
-
-  const pct = Math.min(100, Math.max(0, percent ?? 0))
-  const barColor = getBarColor(pct)
-
-  return (
-    <Tooltip>
-      <TooltipTrigger asChild>
-        <div
-          className={cn(
-            'inline-flex items-center gap-1.5 border border-border/40 rounded-md px-2 py-1 text-[11px] font-medium text-muted-foreground cursor-default',
-            isRefreshing && 'animate-pulse'
-          )}
-          data-testid="context-capsule"
-        >
-          <div className="h-1 w-8 rounded-full bg-muted overflow-hidden">
-            <div
-              className="h-full rounded-full transition-all duration-300"
-              style={{ width: `${pct}%`, backgroundColor: barColor }}
-            />
-          </div>
-          <span className="font-mono">{pct}%</span>
-        </div>
-      </TooltipTrigger>
-      <TooltipContent side="bottom" sideOffset={8} className="max-w-[260px]">
-        <div className="space-y-1.5">
-          <div className="font-medium">{t('contextIndicator.title')}</div>
-          <div>
-            {formatNumber(used)}
-            {limit ? ` / ${formatNumber(limit)}` : ''} {t('sessionHq.header.tokens')}
-          </div>
-          {categories && categories.length > 0 ? (
-            <div className="border-t border-background/20 pt-1.5 space-y-0.5 text-[10px] opacity-80">
-              {categories.slice(0, 6).map((category) => (
-                <div key={category.name} className="flex items-center justify-between gap-3">
-                  <span className="truncate">{category.name}</span>
-                  <span className="font-mono shrink-0">{formatNumber(category.tokens)}</span>
-                </div>
-              ))}
-            </div>
-          ) : (
-            <div className="border-t border-background/20 pt-1.5 space-y-0.5 text-[10px] opacity-80">
-              <div className="text-[10px] opacity-100">{t('contextIndicator.latestTurn')}</div>
-              <div>
-                {t('contextIndicator.labels.input')}: {formatNumber(tokens.input)}
-              </div>
-              <div>
-                {t('contextIndicator.labels.cacheRead')}: {formatNumber(tokens.cacheRead)}
-              </div>
-              <div>
-                {t('contextIndicator.labels.cacheWrite')}: {formatNumber(tokens.cacheWrite)}
-              </div>
-            </div>
-          )}
-          {(tokens.output > 0 || tokens.reasoning > 0) && (
-            <div className="border-t border-background/20 pt-1.5 space-y-0.5 text-[10px] opacity-60">
-              <div className="text-[10px]">{t('contextIndicator.generated.title')}</div>
-              {tokens.output > 0 && (
-                <div>
-                  {t('contextIndicator.generated.output')}: {formatNumber(tokens.output)}
-                </div>
-              )}
-              {tokens.reasoning > 0 && (
-                <div>
-                  {t('contextIndicator.generated.reasoning')}: {formatNumber(tokens.reasoning)}
-                </div>
-              )}
-            </div>
-          )}
-          {isRefreshing && (
-            <div className="border-t border-background/20 pt-1.5 text-[10px] opacity-70">
-              {t('sessionHq.header.compressingContext')}
-            </div>
-          )}
-        </div>
-      </TooltipContent>
-    </Tooltip>
-  )
-}
-
-function CostCapsule({
-  summary,
-  fallbackCost,
-  fallbackTokens: _fallbackTokens
-}: {
-  summary: UsageAnalyticsSessionSummary | null
-  fallbackCost: number
-  fallbackTokens: { input: number; output: number; cacheRead: number; cacheWrite: number } | null
-}): React.JSX.Element | null {
-  const { t } = useI18n()
-  const totalCost = Math.max(summary?.total_cost ?? 0, fallbackCost ?? 0)
-  const hasSummaryTokens = (summary?.total_tokens ?? 0) > 0
-  const totalTokens = summary?.total_tokens ?? 0
-  const modelSummary = formatModelLabelSummary(getSessionSummaryModelLabels(summary))
-
-  void _fallbackTokens
-
-  if (totalCost <= 0 && !hasSummaryTokens) return null
-
-  return (
-    <Popover>
-      <PopoverTrigger asChild>
-        <button
-          className="inline-flex items-center gap-1 border border-border/40 rounded-md px-2 py-1 text-[11px] font-medium text-muted-foreground hover:bg-muted/40 hover:text-foreground transition-colors cursor-pointer"
-          data-testid="cost-capsule"
-        >
-          <span className="font-mono">${totalCost.toFixed(2)}</span>
-        </button>
-      </PopoverTrigger>
-      <PopoverContent side="bottom" align="end" className="w-72">
-        <PopoverHeader className="gap-2">
-          <PopoverTitle className="flex items-center gap-2 text-sm">
-            <DollarSign className="h-4 w-4 text-muted-foreground" />
-            {t('sessionView.costPill.title')}
-          </PopoverTitle>
-        </PopoverHeader>
-        <div className="mt-3 space-y-2 text-xs">
-          <div className="flex items-center justify-between gap-3">
-            <span className="text-muted-foreground">{t('sessionView.costPill.totalCost')}</span>
-            <span className="font-mono font-medium">{formatCurrency(totalCost)}</span>
-          </div>
-          <div className="flex items-center justify-between gap-3">
-            <span className="text-muted-foreground">{t('sessionView.costPill.totalTokens')}</span>
-            {hasSummaryTokens ? (
-              <span className="font-mono">{formatTokensShort(totalTokens)}</span>
-            ) : (
-              <span className="text-muted-foreground">
-                {t('sessionView.costPill.totalsSyncing')}
-              </span>
-            )}
-          </div>
-          {hasSummaryTokens ? (
-            <div className="grid grid-cols-2 gap-2 border-t border-border/70 pt-2">
-              <div className="rounded-lg bg-muted/45 px-2 py-1.5">
-                <div className="text-[10px] uppercase tracking-wide text-muted-foreground">
-                  {t('sessionView.costPill.input')}
-                </div>
-                <div className="mt-1 font-mono">
-                  {formatTokensShort(summary?.input_tokens ?? 0)}
-                </div>
-              </div>
-              <div className="rounded-lg bg-muted/45 px-2 py-1.5">
-                <div className="text-[10px] uppercase tracking-wide text-muted-foreground">
-                  {t('sessionView.costPill.output')}
-                </div>
-                <div className="mt-1 font-mono">
-                  {formatTokensShort(summary?.output_tokens ?? 0)}
-                </div>
-              </div>
-              <div className="rounded-lg bg-muted/45 px-2 py-1.5">
-                <div className="text-[10px] uppercase tracking-wide text-muted-foreground">
-                  {t('sessionView.costPill.cacheWrite')}
-                </div>
-                <div className="mt-1 font-mono">
-                  {formatTokensShort(summary?.cache_write_tokens ?? 0)}
-                </div>
-              </div>
-              <div className="rounded-lg bg-muted/45 px-2 py-1.5">
-                <div className="text-[10px] uppercase tracking-wide text-muted-foreground">
-                  {t('sessionView.costPill.cacheRead')}
-                </div>
-                <div className="mt-1 font-mono">
-                  {formatTokensShort(summary?.cache_read_tokens ?? 0)}
-                </div>
-              </div>
-            </div>
-          ) : null}
-          {modelSummary && (
-            <div className="flex items-center justify-between gap-3 border-t border-border/70 pt-2">
-              <span className="flex items-center gap-1.5 text-muted-foreground">
-                <Layers3 className="h-3.5 w-3.5" />
-                {t('sessionView.costPill.model')}
-              </span>
-              <span className="truncate font-medium" title={modelSummary.full}>
-                {modelSummary.short}
-              </span>
-            </div>
-          )}
-          {summary && summary.duration_seconds > 0 && (
-            <div className="flex items-center justify-between gap-3">
-              <span className="flex items-center gap-1.5 text-muted-foreground">
-                <Clock3 className="h-3.5 w-3.5" />
-                {t('sessionView.costPill.duration')}
-              </span>
-              <span className="font-mono">{formatDuration(summary.duration_seconds)}</span>
-            </div>
-          )}
-          {summary?.partial && (
-            <div className="rounded-lg border border-amber-500/20 bg-amber-500/10 px-2.5 py-2 text-[11px] text-amber-700 dark:text-amber-300">
-              <TriangleAlert className="inline h-3 w-3 mr-1" />
-              {t('sessionView.costPill.partialData')}
-            </div>
-          )}
-        </div>
-      </PopoverContent>
-    </Popover>
-  )
-}
-
 export interface SessionHeaderProps {
   sessionId: string
   session: {
@@ -443,25 +167,13 @@ export interface SessionHeaderProps {
     first_message_at?: number | null
   }
   lifecycle: SessionLifecycle
-  modelId?: string
-  providerId?: string
-  sessionCost?: number
-  sessionTokens?: { input: number; output: number; cacheRead: number; cacheWrite: number } | null
-  usageSummary?: UsageAnalyticsSessionSummary | null
 }
 
 export function SessionHeader({
   sessionId,
   session,
-  lifecycle,
-  modelId,
-  providerId,
-  sessionCost,
-  sessionTokens,
-  usageSummary
+  lifecycle
 }: SessionHeaderProps): React.JSX.Element {
-  const effectiveModelId = modelId ?? session.model_id ?? ''
-  const effectiveProviderId = providerId ?? session.model_provider_id ?? ''
   const locked = session.first_message_at != null
   const isTerminal = session.agent_sdk === 'terminal'
 
@@ -476,19 +188,6 @@ export function SessionHeader({
       {!isTerminal && <ModelSelector sessionId={sessionId} compact showProviderPrefix={false} />}
 
       <div className="flex-1" />
-
-      {effectiveModelId && (
-        <ContextCapsule
-          sessionId={sessionId}
-          modelId={effectiveModelId}
-          providerId={effectiveProviderId}
-        />
-      )}
-      <CostCapsule
-        summary={usageSummary ?? null}
-        fallbackCost={sessionCost ?? 0}
-        fallbackTokens={sessionTokens ?? null}
-      />
     </div>
   )
 }

--- a/src/renderer/src/components/session-hq/SessionShell.tsx
+++ b/src/renderer/src/components/session-hq/SessionShell.tsx
@@ -128,6 +128,32 @@ function extractMissionTasks(messages: TimelineMessage[]): MissionTask[] {
   return []
 }
 
+function attachmentToMessagePart(attachment: Attachment): MessagePart | null {
+  if (attachment.kind !== 'data') return null
+  return {
+    type: 'file',
+    mime: attachment.mime,
+    url: attachment.dataUrl,
+    filename: attachment.name
+  }
+}
+
+function attachmentsToMessageParts(attachments: Attachment[]): MessagePart[] {
+  return attachments
+    .map(attachmentToMessagePart)
+    .filter((part): part is MessagePart => part != null)
+}
+
+function cacheMessageAttachments(
+  cache: Map<string, MessagePart[]>,
+  message: TimelineMessage
+): void {
+  if (message.role !== 'user') return
+  if (!message.content.trim()) return
+  if (!message.attachments || message.attachments.length === 0) return
+  cache.set(message.content.trim(), message.attachments)
+}
+
 function escapeContextAttribute(value: string): string {
   return value.replace(/&/g, '&amp;').replace(/"/g, '&quot;')
 }
@@ -327,15 +353,16 @@ function useTimeline(
     // Clearing early causes a flash-of-empty and loses optimistic messages
     // when SessionShell remounts (e.g. tab switch).
     attachmentCacheRef.current.clear()
+    for (const msg of optimisticRef.current) {
+      cacheMessageAttachments(attachmentCacheRef.current, msg)
+    }
     refresh()
   }, [sessionId, refresh])
 
   // Optimistic insert — append a local user message before the server confirms
   const appendOptimistic = useCallback((msg: TimelineMessage) => {
     // Cache attachments keyed by normalised content for restoreUserAttachments
-    if (msg.attachments && msg.attachments.length > 0 && msg.content.trim()) {
-      attachmentCacheRef.current.set(msg.content.trim(), msg.attachments)
-    }
+    cacheMessageAttachments(attachmentCacheRef.current, msg)
     // Track optimistic messages so they survive tab switches via streaming buffer
     optimisticRef.current = [...optimisticRef.current, msg]
     setMessages((prev) => [...prev, msg])
@@ -1386,7 +1413,12 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
         resetLiveOverlay(true)
       }
 
-      if (action === 'send' || action === 'stop_and_send' || action === 'steer') {
+      if (
+        action === 'send' ||
+        action === 'stop_and_send' ||
+        action === 'steer' ||
+        action === 'queue'
+      ) {
         // Lock provider/model selectors immediately. Main process also stamps
         // first_message_at via createSessionMessage / upsertSessionActivity,
         // but the UI shouldn't wait for the round-trip.
@@ -1401,16 +1433,18 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
       // Optimistic insert — show user message immediately in the timeline
       if (
         (contentToSend.trim() || attachments.length > 0) &&
-        (action === 'send' || action === 'stop_and_send' || action === 'steer')
+        (action === 'send' ||
+          action === 'stop_and_send' ||
+          action === 'steer' ||
+          action === 'queue')
       ) {
-        const optimisticAttachments: MessagePart[] = attachments
-          .filter((a) => a.kind === 'data')
-          .map((a) => ({ type: 'file' as const, mime: a.mime, url: a.dataUrl, filename: a.name }))
+        const optimisticAttachments = attachmentsToMessageParts(attachments)
         const optimisticMsg: TimelineMessage = {
-          id: `optimistic-${Date.now()}`,
+          id: `${action === 'queue' ? 'queued' : 'optimistic'}-${Date.now()}`,
           role: 'user',
           content: contentToSend.trim(),
           timestamp: new Date().toISOString(),
+          ...(action === 'queue' ? { deliveryStatus: 'queued' as const } : {}),
           ...(optimisticAttachments.length > 0 ? { attachments: optimisticAttachments } : {})
         }
         optimisticMessageId = optimisticMsg.id

--- a/src/renderer/src/components/session-hq/SessionShell.tsx
+++ b/src/renderer/src/components/session-hq/SessionShell.tsx
@@ -4,8 +4,7 @@
  * Composition root for the new session UI. Wires together hooks and
  * passes data to child components:
  *
- *   SessionHeader    — provider badge, model, lifecycle, tokens
- *   MissionControl   — current task display + progress bar (inside scroll)
+ *   SessionHeader    — provider badge, model, lifecycle
  *   AgentTimeline    — vertical timeline of agent actions
  *   InterruptDock    — first pending HITL prompt
  *   ComposerBar      — glassmorphism floating input (Phase 5 state machine)
@@ -27,7 +26,6 @@ import React, {
 import { SessionHeader } from './SessionHeader'
 import { AgentTimeline } from './AgentTimeline'
 import type { ThreadStatusRowData } from './ThreadStatusRow'
-import { MissionControl, type MissionTask } from './MissionControl'
 import { InterruptDock } from './InterruptDock'
 import { ComposerBar } from './ComposerBar'
 import { FieldContextDebug } from '@/components/sessions/FieldContextDebug'
@@ -73,7 +71,7 @@ import { applySessionContextUsage } from '@/lib/context-usage'
 import { mapRawTranscriptToTimeline } from '@shared/lib/timeline-mappers'
 import { lastSendMode, messageSendTimes } from '@/lib/message-send-times'
 import { refreshSessionLastMessageAt } from '@/lib/session-last-message'
-import { extractMissionTasks } from '@/lib/session-tasks'
+import { extractMissionTasks, type SessionTask } from '@/lib/session-tasks'
 import {
   getMessageDisplayContent,
   getUserMessageForkCutoff,
@@ -82,22 +80,7 @@ import {
 import { useI18n } from '@/i18n/useI18n'
 import { useSessionSmartScroll } from '@/hooks/useSessionSmartScroll'
 import { toast } from 'sonner'
-
-function getGoalSignature(goal: {
-  threadId?: string
-  objective: string
-  successCriteria?: string
-  status: string
-  createdAt?: number | null
-}): string {
-  return [
-    goal.threadId?.trim() ?? '',
-    goal.objective.trim(),
-    goal.successCriteria?.trim() ?? '',
-    goal.status.trim().toLowerCase(),
-    goal.createdAt ?? ''
-  ].join('|')
-}
+import { isTodoWriteTool } from '@/components/sessions/tools/todo-utils'
 
 function attachmentToMessagePart(attachment: Attachment): MessagePart | null {
   if (attachment.kind !== 'data') return null
@@ -348,14 +331,10 @@ function useTimeline(
 
 function useSessionRuntime(sessionId: string) {
   const lifecycle = useSessionRuntimeStore((s) => s.getSession(sessionId).lifecycle)
-  const goal = useSessionRuntimeStore((s) => s.getSessionGoal(sessionId))
-  const dismissedGoalSignature = useSessionRuntimeStore((s) =>
-    s.getDismissedGoalSignature(sessionId)
-  )
   const interruptQueue = useSessionRuntimeStore((s) => s.getInterruptQueue(sessionId))
   const pendingCount = useSessionRuntimeStore((s) => s.getPendingCount(sessionId))
 
-  return { lifecycle, goal, dismissedGoalSignature, interruptQueue, pendingCount }
+  return { lifecycle, interruptQueue, pendingCount }
 }
 
 function useStreamingMirror(sessionId: string) {
@@ -501,8 +480,7 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
     opencodeSessionId: opcSessionId ?? droidSessionId,
     agentSdk
   })
-  const { lifecycle, goal, dismissedGoalSignature, interruptQueue, pendingCount } =
-    useSessionRuntime(sessionId)
+  const { lifecycle, interruptQueue, pendingCount } = useSessionRuntime(sessionId)
 
   useEffect(() => {
     void useSessionRuntimeStore.getState().hydratePendingMessages(sessionId)
@@ -538,36 +516,7 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
     setSuccessCriteria('')
   }, [sessionId])
 
-  const visibleSessionGoal = useMemo(() => {
-    if (!goal) return null
-    if (goal.status.trim().toLowerCase() !== 'completed') return goal
-    const signature = getGoalSignature(goal)
-    if (dismissedGoalSignature === signature) return null
-    return goal
-  }, [goal, dismissedGoalSignature])
-
-  const dismissGoalCard = useCallback(() => {
-    if (!goal || goal.status.trim().toLowerCase() !== 'completed') return
-    useSessionRuntimeStore.getState().dismissGoalSignature(sessionId, getGoalSignature(goal))
-  }, [goal, sessionId])
-
-  // --- Cost / tokens ---
-  const sessionCost = useContextStore((s) => s.costBySession?.[sessionId] ?? 0)
-  const rawTokens = useContextStore((s) => s.tokensBySession?.[sessionId] ?? null)
-  const sessionTokens = useMemo(() => {
-    if (!rawTokens) return null
-    return {
-      input: rawTokens.input ?? 0,
-      output: rawTokens.output ?? 0,
-      cacheRead: rawTokens.cacheRead ?? 0,
-      cacheWrite: rawTokens.cacheWrite ?? 0
-    }
-  }, [rawTokens])
-
   // --- Persisted usage summary (survives restart) ---
-  const [usageSummary, setUsageSummary] = useState<
-    import('@shared/types/usage-analytics').UsageAnalyticsSessionSummary | null
-  >(null)
   const refreshUsageSummary = useCallback(async (): Promise<void> => {
     if (!window.usageAnalyticsOps?.fetchSessionSummary) return
 
@@ -576,8 +525,6 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
       if (!result.success || !result.data) return
 
       const data = result.data
-      setUsageSummary(data)
-
       const store = useContextStore.getState()
       if ((store.costBySession[sessionId] ?? 0) < data.total_cost) {
         store.setSessionCost(sessionId, data.total_cost)
@@ -678,7 +625,6 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
     },
     [agentSdk, mode, promptOptions, supportsSessionGoalMode]
   )
-  const currentModelId = resolvedModel?.modelID ?? ''
   const currentProviderId = resolvedModel?.providerID ?? ''
   const skipForkFromMessageConfirm = useSettingsStore((s) => s.skipForkFromMessageConfirm)
 
@@ -802,26 +748,25 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
     [sessionId]
   )
 
-  // --- Mission Control task state ---
-  const [missionTasks, setMissionTasks] = useState<MissionTask[]>([])
-  const [triggerMessageContent, setTriggerMessageContent] = useState<string | null>(null)
-  const [missionVisible, setMissionVisible] = useState(false)
-  const missionTasksRef = useRef<MissionTask[]>([])
-  const missionVisibleRef = useRef(false)
+  // --- Mission task state (shared with the right-side context panel) ---
+  const missionTasksRef = useRef<SessionTask[]>([])
   const timelineMessagesRef = useRef<TimelineMessage[]>([])
 
-  // Keep refs in sync
-  useEffect(() => {
-    missionVisibleRef.current = missionVisible
-  }, [missionVisible])
   useEffect(() => {
     timelineMessagesRef.current = timelineMessages
   }, [timelineMessages])
 
-  const allTasksComplete = useMemo(
-    () => missionTasks.length > 0 && missionTasks.every((t) => t.status === 'completed'),
-    [missionTasks]
+  const setSharedMissionTasks = useCallback(
+    (tasks: SessionTask[]) => {
+      missionTasksRef.current = tasks
+      useSessionRuntimeStore.getState().setSessionTasks(sessionId, tasks)
+    },
+    [sessionId]
   )
+
+  useEffect(() => {
+    missionTasksRef.current = useSessionRuntimeStore.getState().getSessionTasks(sessionId)
+  }, [sessionId])
 
   const lastUserMessageId = useMemo(() => {
     for (let i = timelineMessages.length - 1; i >= 0; i--) {
@@ -892,30 +837,6 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
       )
     }
   }, [hasDurableCompactionMessage, compactionState, sessionId])
-
-  // Auto-hide MissionControl after all tasks complete
-  useEffect(() => {
-    if (allTasksComplete && missionVisible) {
-      const timer = setTimeout(() => {
-        setMissionVisible(false)
-        setTriggerMessageContent(null)
-      }, 2000)
-      return () => clearTimeout(timer)
-    }
-  }, [allTasksComplete, missionVisible])
-
-  // Failsafe: hide MissionControl when streaming stops and all tasks are done.
-  // The primary timer above can be disrupted by rapid state updates; this
-  // guarantees the panel disappears once the session goes idle.
-  useEffect(() => {
-    if (allTasksComplete && !isStreaming && missionVisible) {
-      const failsafe = setTimeout(() => {
-        setMissionVisible(false)
-        setTriggerMessageContent(null)
-      }, 4000)
-      return () => clearTimeout(failsafe)
-    }
-  }, [allTasksComplete, isStreaming, missionVisible])
 
   const transitionToolStatus = useCallback(
     (toolUseID: string, status: 'success' | 'error', error?: string) => {
@@ -1138,50 +1059,33 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
             if (isTodoWriteTool(lowerToolName)) {
               const todos = (state.input as Record<string, unknown>)?.todos
               if (Array.isArray(todos)) {
-                const newTasks: MissionTask[] = todos.map(
+                const newTasks: SessionTask[] = todos.map(
                   (t: Record<string, unknown>, idx: number) => ({
                     id: String(t.id ?? `todo-${idx}`),
                     content: String(t.content ?? t.subject ?? t.activeForm ?? ''),
-                    status: (t.status as MissionTask['status']) ?? 'pending'
+                    status: (t.status as SessionTask['status']) ?? 'pending'
                   })
                 )
-                missionTasksRef.current = newTasks
-                setMissionTasks(newTasks)
-                if (!missionVisibleRef.current) {
-                  const lastUserMsg = [...timelineMessagesRef.current]
-                    .reverse()
-                    .find((m) => m.role === 'user')
-                  setTriggerMessageContent(lastUserMsg?.content?.trim() ?? null)
-                  setMissionVisible(true)
-                  missionVisibleRef.current = true
-                }
+                setSharedMissionTasks(newTasks)
               }
             } else if (lowerToolName === 'taskcreate' || lowerToolName === 'task_create') {
               const input = (state.input as Record<string, unknown>) ?? {}
-              const newTask: MissionTask = {
+              const newTask: SessionTask = {
                 id: String(input.taskId ?? `task-${Date.now()}`),
                 content: String(input.subject ?? input.description ?? ''),
                 status: 'pending'
               }
-              missionTasksRef.current = [...missionTasksRef.current, newTask]
-              setMissionTasks([...missionTasksRef.current])
-              if (!missionVisibleRef.current) {
-                const lastUserMsg = [...timelineMessagesRef.current]
-                  .reverse()
-                  .find((m) => m.role === 'user')
-                setTriggerMessageContent(lastUserMsg?.content?.trim() ?? null)
-                setMissionVisible(true)
-                missionVisibleRef.current = true
-              }
+              setSharedMissionTasks([...missionTasksRef.current, newTask])
             } else if (lowerToolName === 'taskupdate' || lowerToolName === 'task_update') {
               const input = (state.input as Record<string, unknown>) ?? {}
               const taskId = String(input.taskId ?? '')
-              const newStatus = input.status as MissionTask['status'] | undefined
+              const newStatus = input.status as SessionTask['status'] | undefined
               if (taskId && newStatus) {
-                missionTasksRef.current = missionTasksRef.current.map((t) =>
-                  t.id === taskId ? { ...t, status: newStatus } : t
+                setSharedMissionTasks(
+                  missionTasksRef.current.map((t) =>
+                    t.id === taskId ? { ...t, status: newStatus } : t
+                  )
                 )
-                setMissionTasks([...missionTasksRef.current])
               }
             }
           }
@@ -1226,8 +1130,7 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
                       missionTasksRef.current.length > 0 &&
                       missionTasksRef.current.every((t) => t.status === 'completed')
                     if (!currentAllComplete) {
-                      missionTasksRef.current = extracted
-                      setMissionTasks(extracted)
+                      setSharedMissionTasks(extracted)
                     }
                   }
                 }
@@ -1321,7 +1224,8 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
     optimisticRef,
     currentProviderId,
     drainQueuedMessage,
-    refreshUsageSummary
+    refreshUsageSummary,
+    setSharedMissionTasks
   ])
 
   // --- Composer action handler ---
@@ -1413,8 +1317,8 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
         }
         optimisticMessageId = optimisticMsg.id
         appendOptimistic(optimisticMsg)
-        // Sync ref immediately so MissionControl's streaming callback can find
-        // the user message before the next useEffect tick
+        // Sync ref immediately so streaming callbacks can find the user message
+        // before the next useEffect tick.
         timelineMessagesRef.current = [...timelineMessagesRef.current, optimisticMsg]
         syncOptimisticMessagesToMirror()
       }
@@ -1922,25 +1826,7 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
 
   return (
     <div className="flex flex-col h-full">
-      <SessionHeader
-        sessionId={sessionId}
-        session={sessionRecord}
-        lifecycle={lifecycle}
-        modelId={currentModelId}
-        providerId={currentProviderId}
-        sessionCost={sessionCost}
-        sessionTokens={sessionTokens}
-        usageSummary={usageSummary}
-      />
-
-      {/* Mission Control — sticky floating task progress panel */}
-      <MissionControl
-        tasks={missionTasks}
-        triggerQuestion={triggerMessageContent}
-        visible={missionVisible}
-        allComplete={allTasksComplete}
-        isStreaming={isStreaming}
-      />
+      <SessionHeader sessionId={sessionId} session={sessionRecord} lifecycle={lifecycle} />
 
       {/* Main content area — relative for floating ComposerBar */}
       <div className="flex-1 flex flex-col overflow-hidden relative">
@@ -1951,11 +1837,9 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
           isStreaming={isStreaming}
           activeRunStartedAt={runStartedAt}
           lifecycle={lifecycle}
-          sessionGoal={visibleSessionGoal}
-          onDismissSessionGoal={dismissGoalCard}
           ephemeralStatusRows={ephemeralStatusRows}
           inflightCompaction={inflightCompactionRow}
-          suppressTodoCards={missionVisible}
+          suppressTodoCards
           sessionId={sessionId}
           worktreePath={worktreePath}
           childPartsMap={childPartsMap}

--- a/src/renderer/src/components/session-hq/SessionShell.tsx
+++ b/src/renderer/src/components/session-hq/SessionShell.tsx
@@ -73,6 +73,7 @@ import { applySessionContextUsage } from '@/lib/context-usage'
 import { mapRawTranscriptToTimeline } from '@shared/lib/timeline-mappers'
 import { lastSendMode, messageSendTimes } from '@/lib/message-send-times'
 import { refreshSessionLastMessageAt } from '@/lib/session-last-message'
+import { extractMissionTasks } from '@/lib/session-tasks'
 import {
   getMessageDisplayContent,
   getUserMessageForkCutoff,
@@ -81,7 +82,6 @@ import {
 import { useI18n } from '@/i18n/useI18n'
 import { useSessionSmartScroll } from '@/hooks/useSessionSmartScroll'
 import { toast } from 'sonner'
-import { isTodoWriteTool } from '@/components/sessions/tools/todo-utils'
 
 function getGoalSignature(goal: {
   threadId?: string
@@ -97,35 +97,6 @@ function getGoalSignature(goal: {
     goal.status.trim().toLowerCase(),
     goal.createdAt ?? ''
   ].join('|')
-}
-
-// ---------------------------------------------------------------------------
-// Extract mission tasks from committed timeline messages
-// ---------------------------------------------------------------------------
-
-function extractMissionTasks(messages: TimelineMessage[]): MissionTask[] {
-  // Scan from end to find the latest todo-like tool snapshot
-  for (let i = messages.length - 1; i >= 0; i--) {
-    const msg = messages[i]
-    if (msg.role !== 'assistant') continue
-
-    for (const part of msg.parts ?? []) {
-      if (part.type !== 'tool_use' || !part.toolUse) continue
-      const toolName = part.toolUse.name?.toLowerCase() ?? ''
-      if (!isTodoWriteTool(toolName)) continue
-
-      const todos = part.toolUse.input?.todos
-      if (!Array.isArray(todos)) continue
-
-      return todos.map((t: Record<string, unknown>, idx: number) => ({
-        id: String(t.id ?? `todo-${idx}`),
-        content: String(t.content ?? t.subject ?? t.activeForm ?? ''),
-        status: (t.status as MissionTask['status']) ?? 'pending'
-      }))
-    }
-  }
-
-  return []
 }
 
 function attachmentToMessagePart(attachment: Attachment): MessagePart | null {
@@ -768,14 +739,7 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
       console.error('[SessionShell] drainNextPending failed:', err)
       return false
     }
-  }, [
-    droidSessionId,
-    pendingDrainController,
-    promptOptions,
-    requestModel,
-    sessionId,
-    worktreePath
-  ])
+  }, [droidSessionId, pendingDrainController, promptOptions, requestModel, sessionId, worktreePath])
 
   useEffect(() => {
     if (lifecycle !== 'idle' || pendingCount === 0) return

--- a/src/renderer/src/components/session-hq/SessionShell.tsx
+++ b/src/renderer/src/components/session-hq/SessionShell.tsx
@@ -4,7 +4,6 @@
  * Composition root for the new session UI. Wires together hooks and
  * passes data to child components:
  *
- *   SessionHeader    — provider badge, model, lifecycle
  *   AgentTimeline    — vertical timeline of agent actions
  *   InterruptDock    — first pending HITL prompt
  *   ComposerBar      — glassmorphism floating input (Phase 5 state machine)
@@ -23,7 +22,6 @@ import React, {
   useMemo,
   useSyncExternalStore
 } from 'react'
-import { SessionHeader } from './SessionHeader'
 import { AgentTimeline } from './AgentTimeline'
 import type { ThreadStatusRowData } from './ThreadStatusRow'
 import { InterruptDock } from './InterruptDock'
@@ -518,11 +516,15 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
 
   // --- Persisted usage summary (survives restart) ---
   const refreshUsageSummary = useCallback(async (): Promise<void> => {
-    if (!window.usageAnalyticsOps?.fetchSessionSummary) return
+    if (!window.usageAnalyticsOps?.fetchSessionSummary) {
+      return
+    }
 
     try {
       const result = await window.usageAnalyticsOps.fetchSessionSummary(sessionId)
-      if (!result.success || !result.data) return
+      if (!result.success || !result.data) {
+        return
+      }
 
       const data = result.data
       const store = useContextStore.getState()
@@ -1826,8 +1828,6 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
 
   return (
     <div className="flex flex-col h-full">
-      <SessionHeader sessionId={sessionId} session={sessionRecord} lifecycle={lifecycle} />
-
       {/* Main content area — relative for floating ComposerBar */}
       <div className="flex-1 flex flex-col overflow-hidden relative">
         <AgentTimeline
@@ -1886,6 +1886,8 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
           superpowersAvailable={false}
         />
 
+        <div className="crisp-composer-veil pointer-events-none absolute bottom-0 left-0 right-0 z-10 h-44" />
+
         <ComposerBar
           containerRef={composerBarRef}
           sessionId={sessionId}
@@ -1907,24 +1909,20 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
           worktreePath={worktreePath}
           commandsVersion={commandsVersion}
           contextAttachmentSlot={<DiffCommentAttachments />}
+          controlSlot={<MemoryPanel worktreeId={worktreeId} variant="composer" />}
         />
 
-        {/* v1.4.2: User-facing Memory panel — Pinned Facts / Observed
-            (Episodic) / Semantic. Sits above the FieldContextDebug
-            (which is dev-only) so it's the daily-driver for memory edits. */}
-        <div className="absolute bottom-0 left-0 right-0 z-30">
-          <MemoryPanel worktreeId={worktreeId} />
-          {/* Phase 22A debug: collapsible view of the last Field Context injection.
-              Only visible in dev builds — production users use the MemoryPanel
-              above for daily memory inspection. */}
-          {process.env.NODE_ENV === 'development' && (
+        {process.env.NODE_ENV === 'development' && (
+          <div className="absolute bottom-0 left-0 right-0 z-30">
+            {/* Phase 22A debug: collapsible view of the last Field Context injection.
+                Production users inspect memory through the Composer console. */}
             <FieldContextDebug
               sessionId={droidSessionId}
               fallbackSessionIds={[sessionId]}
               worktreeId={worktreeId}
             />
-          )}
-        </div>
+          </div>
+        )}
 
         <ForkFromMessageConfirmDialog
           open={pendingForkMessageId !== null}

--- a/src/renderer/src/components/session-hq/cards/ActionCard.tsx
+++ b/src/renderer/src/components/session-hq/cards/ActionCard.tsx
@@ -42,7 +42,7 @@ export function ActionCard({
   return (
     <div
       className={cn(
-        'rounded-lg border border-border/50 bg-card/80 overflow-hidden',
+        'crisp-subtle-shadow overflow-hidden rounded-[10px] border border-border/60 bg-agent-card/85',
         accentClass,
         className
       )}
@@ -78,9 +78,7 @@ export function ActionCard({
 
       {/* Body */}
       {children && expanded && (
-        <div className="px-3.5 py-3 text-sm text-muted-foreground leading-relaxed">
-          {children}
-        </div>
+        <div className="px-3.5 py-3 text-sm text-muted-foreground leading-relaxed">{children}</div>
       )}
     </div>
   )

--- a/src/renderer/src/components/session-hq/cards/BashCard.tsx
+++ b/src/renderer/src/components/session-hq/cards/BashCard.tsx
@@ -27,10 +27,10 @@ function TokenSaverBadge({ parsed }: { parsed: ParsedTokenSaverFooter }): React.
   const { t } = useI18n()
   return (
     <div
-      className="mb-2 flex flex-wrap items-center gap-2 rounded-md border border-emerald-500/20 bg-emerald-500/10 px-2.5 py-1.5 text-[11px] text-emerald-700 dark:text-emerald-200"
+      className="mb-2 flex flex-wrap items-center gap-2 rounded-md border border-neon-mint/20 bg-neon-mint-soft px-2.5 py-1.5 text-[11px] text-neon-mint dark:bg-neon-mint-soft/35"
       data-testid="token-saver-badge"
     >
-      <Sparkles className="h-3.5 w-3.5 text-emerald-500" />
+      <Sparkles className="h-3.5 w-3.5 text-neon-mint" />
       <span className="font-semibold">
         {t('toolViews.tokenSaver.savedBadge', {
           percent: parsed.savedPercent,
@@ -38,7 +38,7 @@ function TokenSaverBadge({ parsed }: { parsed: ParsedTokenSaverFooter }): React.
           after: formatBytes(parsed.afterBytes)
         })}
       </span>
-      <span className="text-emerald-700/70 dark:text-emerald-300/70">
+      <span className="text-steel">
         {t('toolViews.tokenSaver.viaRules', { rules: parsed.rules.join(', ') })}
       </span>
     </div>
@@ -81,7 +81,7 @@ function OriginalOutputButton({ archivePath }: { archivePath: string }): React.J
       <button
         type="button"
         onClick={() => void toggle()}
-        className="inline-flex items-center gap-1.5 text-xs font-medium text-blue-600 transition-colors hover:text-blue-500 dark:text-blue-400 dark:hover:text-blue-300"
+        className="inline-flex items-center gap-1.5 text-xs font-medium text-tech-blue transition-colors hover:text-tech-blue/80"
         data-testid="token-saver-show-original"
       >
         <FileText className="h-3.5 w-3.5" />
@@ -96,7 +96,7 @@ function OriginalOutputButton({ archivePath }: { archivePath: string }): React.J
           )}
           {error && <div className="text-xs text-red-500">{error}</div>}
           {content !== null && (
-            <pre className="mt-1 max-h-80 overflow-y-auto whitespace-pre-wrap break-all rounded-md bg-zinc-950/80 p-2 font-mono text-[11px] text-zinc-300">
+            <pre className="mt-1 max-h-80 overflow-y-auto whitespace-pre-wrap break-all rounded-md border border-[color:var(--code-block-border)] bg-[var(--code-block-bg)] p-2 font-mono text-[11px] text-[var(--code-block-text)]">
               {content}
             </pre>
           )}
@@ -126,7 +126,7 @@ export function BashCard({ toolUse }: BashCardProps): React.JSX.Element {
     <ActionCard
       headerLeft={
         <div className="flex items-center gap-2 font-mono text-xs min-w-0">
-          <span className="text-celadon font-semibold shrink-0">$_</span>
+          <span className="text-tech-blue font-semibold shrink-0">$_</span>
           <span className="truncate text-foreground">{command}</span>
         </div>
       }
@@ -143,7 +143,7 @@ export function BashCard({ toolUse }: BashCardProps): React.JSX.Element {
                 : t('sessionHq.cards.bash.exitZero')}
           </span>
           {parsed && (
-            <span className="rounded border border-emerald-500/25 bg-emerald-500/10 px-1.5 py-0.5 text-[10px] font-semibold text-emerald-700 dark:text-emerald-300">
+            <span className="rounded border border-neon-mint/25 bg-neon-mint-soft px-1.5 py-0.5 text-[10px] font-semibold text-neon-mint dark:bg-neon-mint-soft/35">
               {t('sessionHq.cards.bash.tokenSaverCompact', { percent: parsed.savedPercent })}
             </span>
           )}

--- a/src/renderer/src/components/session-hq/cards/TextCard.tsx
+++ b/src/renderer/src/components/session-hq/cards/TextCard.tsx
@@ -15,8 +15,8 @@ interface TextCardProps {
 
 export function TextCard({ content, isStreaming = false }: TextCardProps): React.JSX.Element {
   return (
-    <div className="bg-muted/20 rounded-[10px] px-3.5 py-2.5">
-      <div className="prose prose-sm dark:prose-invert max-w-none text-sm leading-relaxed text-foreground">
+    <div className="rounded-xl bg-agent-card/80 px-3.5 py-2.5">
+      <div className="prose prose-sm dark:prose-invert crisp-readable max-w-none text-sm text-foreground">
         <MarkdownRenderer content={content} />
         {isStreaming && (
           <span className="inline-block w-[3px] h-[1.1em] bg-foreground/60 ml-0.5 align-text-bottom animate-pulse" />

--- a/src/renderer/src/components/session-hq/cards/TodoCard.tsx
+++ b/src/renderer/src/components/session-hq/cards/TodoCard.tsx
@@ -3,7 +3,7 @@
  *
  * Supports two modes:
  *   1. toolUse mode — renders from a single tool_use (normal timeline rendering)
- *   2. tasks mode — renders from an aggregated task list (final card after MissionControl)
+ *   2. tasks mode — renders from an aggregated task list (right context panel)
  */
 
 import React from 'react'
@@ -19,7 +19,7 @@ interface TodoCardPropsToolUse {
 
 interface TodoCardPropsTasks {
   toolUse?: never
-  /** Aggregated task list — used for the final card after MissionControl fades */
+  /** Aggregated task list — used by the right context panel and optional timeline summaries */
   tasks: Array<{ id: string; content: string; status: string }>
 }
 

--- a/src/renderer/src/components/sessions/CodeBlock.tsx
+++ b/src/renderer/src/components/sessions/CodeBlock.tsx
@@ -1,19 +1,136 @@
-import { useState } from 'react'
+import { Fragment, useEffect, useRef, useState } from 'react'
 import { Copy, Check } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { toast } from '@/lib/toast'
 import Ansi from 'ansi-to-react'
 import { containsAnsi, stripAnsi } from '@/lib/ansi-utils'
 import { useI18n } from '@/i18n/useI18n'
+import { cn } from '@/lib/utils'
 
 interface CodeBlockProps {
   code: string
   language?: string
 }
 
+const SHELL_LANGUAGES = new Set(['bash', 'sh', 'shell', 'zsh', 'fish', 'console', 'terminal'])
+
+function isShellLanguage(language: string): boolean {
+  return SHELL_LANGUAGES.has(language.trim().toLowerCase())
+}
+
+function renderShellRemainder(remainder: string): React.ReactNode {
+  const commentStart = remainder.search(/\s#/)
+
+  if (commentStart === -1) {
+    return remainder
+  }
+
+  return (
+    <>
+      {remainder.slice(0, commentStart)}
+      <span className="text-[var(--code-block-muted)]">{remainder.slice(commentStart)}</span>
+    </>
+  )
+}
+
+function renderShellLine(line: string): React.ReactNode {
+  const trimmedStart = line.trimStart()
+
+  if (trimmedStart.length === 0) {
+    return line
+  }
+
+  const leadingWhitespace = line.slice(0, line.length - trimmedStart.length)
+
+  if (trimmedStart.startsWith('#')) {
+    return (
+      <>
+        {leadingWhitespace}
+        <span className="text-[var(--code-block-muted)]">{trimmedStart}</span>
+      </>
+    )
+  }
+
+  const promptMatch = trimmedStart.match(/^([$#>%❯➜])(\s+)/)
+  const prompt = promptMatch ? `${promptMatch[1]}${promptMatch[2]}` : ''
+  const rest = prompt ? trimmedStart.slice(prompt.length) : trimmedStart
+  const commandMatch = rest.match(
+    /^((?:[A-Za-z_][A-Za-z0-9_]*=\S+\s+)*(?:sudo\s+|env\s+|command\s+|builtin\s+|time\s+)*)([./~A-Za-z0-9_:@%+-][^\s;&|()]*)/
+  )
+
+  if (!commandMatch) {
+    return line
+  }
+
+  const modifiers = commandMatch[1] ?? ''
+  const command = commandMatch[2] ?? ''
+  const remainder = rest.slice(commandMatch[0].length)
+
+  return (
+    <>
+      {leadingWhitespace}
+      {prompt && <span className="text-[var(--code-block-warm)]">{prompt}</span>}
+      {modifiers && <span className="text-[var(--code-block-muted)]">{modifiers}</span>}
+      <span className="font-semibold text-[var(--code-block-accent)]">{command}</span>
+      {renderShellRemainder(remainder)}
+    </>
+  )
+}
+
+function renderShellCode(code: string): React.ReactNode {
+  const lines = code.split('\n')
+
+  return lines.map((line, index) => (
+    <Fragment key={`${index}-${line}`}>
+      {renderShellLine(line)}
+      {index < lines.length - 1 ? '\n' : null}
+    </Fragment>
+  ))
+}
+
+function renderCodeContent(code: string, language: string): React.ReactNode {
+  if (containsAnsi(code)) {
+    return <Ansi>{code}</Ansi>
+  }
+
+  if (isShellLanguage(language)) {
+    return renderShellCode(code)
+  }
+
+  return code
+}
+
 export function CodeBlock({ code, language = 'typescript' }: CodeBlockProps): React.JSX.Element {
   const { t } = useI18n()
+  const preRef = useRef<HTMLPreElement>(null)
   const [copied, setCopied] = useState(false)
+  const [expanded, setExpanded] = useState(false)
+  const [isOverflowing, setIsOverflowing] = useState(false)
+
+  useEffect(() => {
+    setExpanded(false)
+  }, [code, language])
+
+  useEffect(() => {
+    const node = preRef.current
+    if (!node) return
+
+    const updateOverflow = (): void => {
+      setIsOverflowing(node.scrollHeight > 322)
+    }
+
+    updateOverflow()
+
+    const resizeObserver =
+      typeof ResizeObserver === 'undefined' ? null : new ResizeObserver(updateOverflow)
+    resizeObserver?.observe(node)
+    window.addEventListener('resize', updateOverflow)
+
+    return () => {
+      resizeObserver?.disconnect()
+      window.removeEventListener('resize', updateOverflow)
+    }
+  }, [code, language, expanded])
 
   const handleCopy = async (): Promise<void> => {
     try {
@@ -28,16 +145,18 @@ export function CodeBlock({ code, language = 'typescript' }: CodeBlockProps): Re
 
   return (
     <div
-      className="relative group my-4 rounded-lg overflow-hidden border border-border/60 bg-muted/50"
+      className="group relative my-4 overflow-hidden rounded-[10px] border border-[color:var(--code-block-border)] bg-[var(--code-block-bg)] shadow-[0_1px_3px_0_rgb(var(--agent-shadow-rgb)_/_0.10)]"
       data-testid="code-block"
     >
-      <div className="flex items-center justify-between px-4 py-1.5 border-b border-border/50 bg-muted/70">
-        <span className="text-[11px] font-medium text-muted-foreground uppercase tracking-wide">{language}</span>
+      <div className="flex items-center justify-between border-b border-[color:var(--code-block-border)] bg-[var(--code-block-header)] px-4 py-1.5">
+        <span className="text-[11px] font-medium uppercase tracking-wide text-tech-blue">
+          {language}
+        </span>
         <Button
           variant="ghost"
           size="sm"
           onClick={handleCopy}
-          className="h-7 px-2 opacity-0 group-hover:opacity-100 transition-opacity"
+          className="h-7 px-2 text-[var(--code-block-muted)] opacity-0 transition-opacity hover:bg-white/10 hover:text-[var(--code-block-text)] group-hover:opacity-100"
           aria-label={t('codeBlock.copyButton')}
           data-testid="copy-code-button"
         >
@@ -48,9 +167,34 @@ export function CodeBlock({ code, language = 'typescript' }: CodeBlockProps): Re
           )}
         </Button>
       </div>
-      <pre className="p-4 overflow-x-auto text-sm font-mono text-foreground/90">
-        <code>{containsAnsi(code) ? <Ansi>{code}</Ansi> : code}</code>
+      <pre
+        ref={preRef}
+        className={cn(
+          'overflow-x-auto p-4 font-mono text-sm leading-relaxed text-[var(--code-block-text)]',
+          isOverflowing && !expanded ? 'max-h-[320px] overflow-y-hidden' : 'overflow-y-auto'
+        )}
+      >
+        <code>{renderCodeContent(code, language)}</code>
       </pre>
+      {isOverflowing && !expanded && (
+        <div
+          className="pointer-events-none absolute bottom-0 left-0 right-0 h-16"
+          style={{
+            background:
+              'linear-gradient(to top, var(--code-block-bg), color-mix(in srgb, var(--code-block-bg) 92%, transparent), transparent)'
+          }}
+        />
+      )}
+      {isOverflowing && (
+        <button
+          type="button"
+          className="absolute bottom-2 right-3 z-10 rounded-full border border-white/10 bg-[var(--code-block-header)] px-2.5 py-1 text-[11px] font-medium text-[var(--code-block-text)] shadow-sm transition-colors hover:border-tech-blue/55 hover:bg-white/10 hover:text-[var(--code-block-text)]"
+          aria-expanded={expanded}
+          onClick={() => setExpanded((value) => !value)}
+        >
+          {expanded ? t('codeBlock.collapse') : t('codeBlock.expand')}
+        </button>
+      )}
     </div>
   )
 }

--- a/src/renderer/src/components/sessions/MarkdownRenderer.tsx
+++ b/src/renderer/src/components/sessions/MarkdownRenderer.tsx
@@ -10,17 +10,25 @@ interface MarkdownRendererProps {
 }
 
 const components: Components = {
-  h1: ({ children }) => <h1 className="text-xl font-bold mt-6 mb-3 first:mt-0">{children}</h1>,
-  h2: ({ children }) => <h2 className="text-lg font-semibold mt-5 mb-2 first:mt-0">{children}</h2>,
-  h3: ({ children }) => (
-    <h3 className="text-base font-semibold mt-4 mb-2 first:mt-0">{children}</h3>
+  h1: ({ children }) => (
+    <h1 className="crisp-strong-title text-xl mt-6 mb-3 first:mt-0">{children}</h1>
   ),
-  p: ({ children }) => <p className="mb-3 last:mb-0 leading-relaxed">{children}</p>,
-  ul: ({ children }) => <ul className="list-disc pl-6 mb-3 space-y-1">{children}</ul>,
-  ol: ({ children }) => <ol className="list-decimal pl-6 mb-3 space-y-1">{children}</ol>,
-  li: ({ children }) => <li className="leading-relaxed">{children}</li>,
+  h2: ({ children }) => (
+    <h2 className="crisp-strong-title text-lg mt-5 mb-2 first:mt-0">{children}</h2>
+  ),
+  h3: ({ children }) => (
+    <h3 className="crisp-strong-title text-base mt-4 mb-2 first:mt-0">{children}</h3>
+  ),
+  p: ({ children }) => <p className="mb-3 last:mb-0 leading-[1.6]">{children}</p>,
+  ul: ({ children }) => (
+    <ul className="list-disc pl-6 mb-3 space-y-1.5 marker:text-steel/70">{children}</ul>
+  ),
+  ol: ({ children }) => (
+    <ol className="list-decimal pl-6 mb-3 space-y-1.5 marker:text-steel/70">{children}</ol>
+  ),
+  li: ({ children }) => <li className="leading-[1.6]">{children}</li>,
   blockquote: ({ children }) => (
-    <blockquote className="border-l-2 border-muted-foreground/40 pl-4 italic text-muted-foreground my-3">
+    <blockquote className="my-3 border-l-2 border-steel/25 pl-4 italic text-muted-foreground">
       {children}
     </blockquote>
   ),
@@ -40,7 +48,7 @@ const components: Components = {
       href={href}
       target="_blank"
       rel="noopener noreferrer"
-      className="text-blue-500 hover:text-blue-400 underline underline-offset-2"
+      className="text-primary hover:text-neon-violet underline underline-offset-2"
     >
       {children}
     </a>
@@ -58,7 +66,11 @@ const components: Components = {
       return <CodeBlock code={code} language={match?.[1] ?? 'text'} />
     }
 
-    return <code className="bg-muted px-1.5 py-0.5 rounded text-sm font-mono">{children}</code>
+    return (
+      <code className="rounded border border-border/70 bg-agent-card-muted px-1.5 py-0.5 font-mono text-sm text-ink">
+        {children}
+      </code>
+    )
   },
   pre: ({ children }) => <>{children}</>
 }

--- a/src/renderer/src/components/sessions/MemoryPanel.tsx
+++ b/src/renderer/src/components/sessions/MemoryPanel.tsx
@@ -14,8 +14,8 @@
  *      existing files show an [Open] CTA that asks the system to open
  *      them in the user's editor.
  *
- * Mounted as a sibling of `FieldContextDebug`. Unlike FieldContextDebug,
- * which we now hide outside dev builds, this panel is the daily-driver
+ * Mounted either as a standalone panel or as a compact Composer console
+ * control. FieldContextDebug remains dev-only; this is the daily-driver
  * view for inspecting and editing memory.
  */
 import { useCallback, useEffect, useState } from 'react'
@@ -63,11 +63,16 @@ interface SemanticMemoryEntry {
 interface MemoryPanelProps {
   worktreeId: string | null | undefined
   className?: string
+  variant?: 'panel' | 'composer'
 }
 
 type Tab = 'pinned' | 'observed' | 'semantic'
 
-export function MemoryPanel({ worktreeId, className }: MemoryPanelProps): React.JSX.Element | null {
+export function MemoryPanel({
+  worktreeId,
+  className,
+  variant = 'panel'
+}: MemoryPanelProps): React.JSX.Element | null {
   const { t } = useI18n()
   const [open, setOpen] = useState(false)
   const [tab, setTab] = useState<Tab>('pinned')
@@ -138,6 +143,95 @@ export function MemoryPanel({ worktreeId, className }: MemoryPanelProps): React.
           : t('memory.empty.observed')
         : t('memory.semanticSection')
 
+  const body = (
+    <>
+      {/* Tab bar */}
+      <div className="flex items-center gap-1 mb-2 text-[11px]">
+        <TabButton
+          active={tab === 'pinned'}
+          onClick={() => setTab('pinned')}
+          icon={<Pin size={11} />}
+          label={t('memory.pinnedSection')}
+        />
+        <TabButton
+          active={tab === 'observed'}
+          onClick={() => setTab('observed')}
+          icon={<Brain size={11} />}
+          label={t('memory.observedSection')}
+        />
+        <TabButton
+          active={tab === 'semantic'}
+          onClick={() => setTab('semantic')}
+          icon={<FolderOpen size={11} />}
+          label={t('memory.semanticSection')}
+        />
+      </div>
+
+      {tab === 'pinned' && (
+        <div className="bg-background/30 rounded">
+          <PinnedFactsCard worktreeId={worktreeId} />
+        </div>
+      )}
+
+      {tab === 'observed' && (
+        <ObservedSection
+          episodic={episodic}
+          loading={loading}
+          actionPending={actionPending}
+          onRegenerate={handleRegenerate}
+          onClear={handleClear}
+        />
+      )}
+
+      {tab === 'semantic' && <SemanticSection semantic={semantic} loading={loading} />}
+    </>
+  )
+
+  if (variant === 'composer') {
+    return (
+      <div className={cn('relative shrink-0', className)} data-testid="memory-panel">
+        <button
+          type="button"
+          onClick={() => setOpen((v) => !v)}
+          className={cn(
+            'inline-flex h-7 items-center gap-1.5 rounded-full border px-2.5 text-xs font-medium transition-colors',
+            open
+              ? 'border-tech-blue/35 bg-tech-blue-soft text-tech-blue'
+              : 'border-border/70 bg-background/65 text-muted-foreground hover:border-border hover:bg-background/85 hover:text-foreground'
+          )}
+          data-testid="memory-panel-trigger"
+        >
+          <Brain size={12} className={open ? 'text-tech-blue' : 'text-muted-foreground'} />
+          <span>{t('memory.title')}</span>
+        </button>
+        {open && (
+          <div className="absolute bottom-full left-0 z-50 mb-2 w-[min(540px,calc(100vw-4rem))] overflow-hidden rounded-xl border border-border bg-popover text-popover-foreground shadow-xl">
+            <div className="flex items-center justify-between gap-3 border-b border-border/60 px-3 py-2">
+              <div className="min-w-0 text-xs">
+                <div className="font-semibold text-foreground">{t('memory.title')}</div>
+                <div className="mt-0.5 truncate text-[11px] text-muted-foreground">
+                  {headerLabel}
+                </div>
+              </div>
+              <button
+                type="button"
+                onClick={() => void refresh()}
+                className={cn(
+                  'rounded-md p-1 text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground',
+                  loading && 'animate-spin text-muted-foreground/60'
+                )}
+                title={t('memory.refresh')}
+              >
+                <RefreshCw size={13} />
+              </button>
+            </div>
+            <div className="max-h-[58vh] overflow-auto px-3 pb-3 pt-2">{body}</div>
+          </div>
+        )}
+      </div>
+    )
+  }
+
   return (
     <div
       className={cn('border-t border-border/40 bg-muted/20 text-xs', className)}
@@ -150,7 +244,7 @@ export function MemoryPanel({ worktreeId, className }: MemoryPanelProps): React.
       >
         <div className="flex items-center gap-1.5">
           {open ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
-          <Brain size={12} className="text-amber-400" />
+          <Brain size={12} className="text-tech-blue" />
           <span>{t('memory.title')}</span>
           <span className="text-muted-foreground/70 ml-2 truncate max-w-[40ch]">{headerLabel}</span>
         </div>
@@ -173,56 +267,14 @@ export function MemoryPanel({ worktreeId, className }: MemoryPanelProps): React.
               'p-1 rounded hover:bg-muted/50',
               loading && 'animate-spin text-muted-foreground/60'
             )}
-            title="Refresh"
+            title={t('memory.refresh')}
           >
             <RefreshCw size={12} />
           </span>
         )}
       </button>
 
-      {open && (
-        <div className="px-3 pb-3 pt-1 max-h-[60vh] overflow-auto">
-          {/* Tab bar */}
-          <div className="flex items-center gap-1 mb-2 text-[11px]">
-            <TabButton
-              active={tab === 'pinned'}
-              onClick={() => setTab('pinned')}
-              icon={<Pin size={11} />}
-              label={t('memory.pinnedSection')}
-            />
-            <TabButton
-              active={tab === 'observed'}
-              onClick={() => setTab('observed')}
-              icon={<Brain size={11} />}
-              label={t('memory.observedSection')}
-            />
-            <TabButton
-              active={tab === 'semantic'}
-              onClick={() => setTab('semantic')}
-              icon={<FolderOpen size={11} />}
-              label={t('memory.semanticSection')}
-            />
-          </div>
-
-          {tab === 'pinned' && (
-            <div className="bg-background/30 rounded">
-              <PinnedFactsCard worktreeId={worktreeId} />
-            </div>
-          )}
-
-          {tab === 'observed' && (
-            <ObservedSection
-              episodic={episodic}
-              loading={loading}
-              actionPending={actionPending}
-              onRegenerate={handleRegenerate}
-              onClear={handleClear}
-            />
-          )}
-
-          {tab === 'semantic' && <SemanticSection semantic={semantic} loading={loading} />}
-        </div>
-      )}
+      {open && <div className="px-3 pb-3 pt-1 max-h-[60vh] overflow-auto">{body}</div>}
     </div>
   )
 }
@@ -245,9 +297,7 @@ function TabButton({ active, onClick, icon, label }: TabButtonProps): React.JSX.
       onClick={onClick}
       className={cn(
         'inline-flex items-center gap-1 px-2 py-0.5 rounded',
-        active
-          ? 'bg-primary/20 text-foreground'
-          : 'text-muted-foreground hover:bg-muted/50'
+        active ? 'bg-primary/20 text-foreground' : 'text-muted-foreground hover:bg-muted/50'
       )}
     >
       {icon}
@@ -307,9 +357,7 @@ function ObservedSection({
           {t('memory.clear')}
         </Button>
       </div>
-      {loading && !episodic && (
-        <div className="text-muted-foreground/60">Loading…</div>
-      )}
+      {loading && !episodic && <div className="text-muted-foreground/60">Loading…</div>}
       {!loading && !episodic && (
         <div className="text-muted-foreground/60 italic">{t('memory.empty.observed')}</div>
       )}

--- a/src/renderer/src/components/sessions/SessionCostPill.tsx
+++ b/src/renderer/src/components/sessions/SessionCostPill.tsx
@@ -21,6 +21,8 @@ interface SessionCostPillProps {
     cacheRead: number
     cacheWrite: number
   } | null
+  popoverSide?: 'top' | 'bottom' | 'left' | 'right'
+  popoverAlign?: 'start' | 'center' | 'end'
 }
 
 function formatCurrency(amount: number): string {
@@ -50,17 +52,34 @@ function formatDuration(seconds: number): string {
 export function SessionCostPill({
   summary,
   fallbackCost,
-  fallbackTokens: _fallbackTokens
+  fallbackTokens,
+  popoverSide = 'top',
+  popoverAlign = 'start'
 }: SessionCostPillProps): React.JSX.Element | null {
   const { t } = useI18n()
   const modelSummary = formatModelLabelSummary(getSessionSummaryModelLabels(summary))
   const totalCost = Math.max(summary?.total_cost ?? 0, fallbackCost ?? 0)
   const hasSummaryTokens = (summary?.total_tokens ?? 0) > 0
-  const totalTokens = summary?.total_tokens ?? 0
+  const fallbackTotalTokens = fallbackTokens
+    ? fallbackTokens.input +
+      fallbackTokens.output +
+      fallbackTokens.cacheRead +
+      fallbackTokens.cacheWrite
+    : 0
+  const totalTokens = hasSummaryTokens ? (summary?.total_tokens ?? 0) : fallbackTotalTokens
+  const hasAnyTokens = totalTokens > 0
+  const inputTokens = hasSummaryTokens ? (summary?.input_tokens ?? 0) : (fallbackTokens?.input ?? 0)
+  const outputTokens = hasSummaryTokens
+    ? (summary?.output_tokens ?? 0)
+    : (fallbackTokens?.output ?? 0)
+  const cacheWriteTokens = hasSummaryTokens
+    ? (summary?.cache_write_tokens ?? 0)
+    : (fallbackTokens?.cacheWrite ?? 0)
+  const cacheReadTokens = hasSummaryTokens
+    ? (summary?.cache_read_tokens ?? 0)
+    : (fallbackTokens?.cacheRead ?? 0)
 
-  void _fallbackTokens
-
-  if (totalCost <= 0 && !hasSummaryTokens) return null
+  if (totalCost <= 0 && !hasAnyTokens) return null
 
   return (
     <Popover>
@@ -70,7 +89,7 @@ export function SessionCostPill({
           variant="ghost"
           size="sm"
           className={cn(
-            'h-7 rounded-full border border-emerald-500/30 bg-emerald-500/10 px-2.5 text-[12px] font-medium text-emerald-700 shadow-[0_0_0_1px_rgba(16,185,129,0.08)] transition-colors hover:bg-emerald-500/14 hover:text-emerald-800 dark:border-emerald-400/30 dark:bg-emerald-500/12 dark:text-emerald-200 dark:hover:bg-emerald-500/18'
+            'h-7 rounded-full border border-neon-pink/20 bg-neon-pink-soft px-2.5 text-[12px] font-medium text-neon-pink shadow-none transition-colors hover:bg-neon-pink-soft/85 hover:text-neon-pink dark:bg-neon-pink-soft/35 dark:hover:bg-neon-pink-soft/45'
           )}
           data-testid="session-cost-pill"
         >
@@ -79,10 +98,10 @@ export function SessionCostPill({
           {summary?.partial && <TriangleAlert className="h-3.5 w-3.5 text-amber-500" />}
         </Button>
       </PopoverTrigger>
-      <PopoverContent side="top" align="start" className="w-72">
+      <PopoverContent side={popoverSide} align={popoverAlign} className="w-72">
         <PopoverHeader className="gap-2">
           <PopoverTitle className="flex items-center gap-2 text-sm">
-            <DollarSign className="h-4 w-4 text-emerald-600 dark:text-emerald-300" />
+            <DollarSign className="h-4 w-4 text-neon-pink" />
             {t('sessionView.costPill.title')}
           </PopoverTitle>
         </PopoverHeader>
@@ -93,7 +112,7 @@ export function SessionCostPill({
           </div>
           <div className="flex items-center justify-between gap-3">
             <span className="text-muted-foreground">{t('sessionView.costPill.totalTokens')}</span>
-            {hasSummaryTokens ? (
+            {hasAnyTokens ? (
               <span className="font-mono">{formatTokens(totalTokens)}</span>
             ) : (
               <span className="text-muted-foreground">
@@ -101,35 +120,31 @@ export function SessionCostPill({
               </span>
             )}
           </div>
-          {hasSummaryTokens ? (
+          {hasAnyTokens ? (
             <div className="grid grid-cols-2 gap-2 border-t border-border/70 pt-2">
               <div className="rounded-lg bg-muted/45 px-2 py-1.5">
                 <div className="text-[10px] uppercase tracking-wide text-muted-foreground">
                   {t('sessionView.costPill.input')}
                 </div>
-                <div className="mt-1 font-mono">{formatTokens(summary?.input_tokens ?? 0)}</div>
+                <div className="mt-1 font-mono">{formatTokens(inputTokens)}</div>
               </div>
               <div className="rounded-lg bg-muted/45 px-2 py-1.5">
                 <div className="text-[10px] uppercase tracking-wide text-muted-foreground">
                   {t('sessionView.costPill.output')}
                 </div>
-                <div className="mt-1 font-mono">{formatTokens(summary?.output_tokens ?? 0)}</div>
+                <div className="mt-1 font-mono">{formatTokens(outputTokens)}</div>
               </div>
               <div className="rounded-lg bg-muted/45 px-2 py-1.5">
                 <div className="text-[10px] uppercase tracking-wide text-muted-foreground">
                   {t('sessionView.costPill.cacheWrite')}
                 </div>
-                <div className="mt-1 font-mono">
-                  {formatTokens(summary?.cache_write_tokens ?? 0)}
-                </div>
+                <div className="mt-1 font-mono">{formatTokens(cacheWriteTokens)}</div>
               </div>
               <div className="rounded-lg bg-muted/45 px-2 py-1.5">
                 <div className="text-[10px] uppercase tracking-wide text-muted-foreground">
                   {t('sessionView.costPill.cacheRead')}
                 </div>
-                <div className="mt-1 font-mono">
-                  {formatTokens(summary?.cache_read_tokens ?? 0)}
-                </div>
+                <div className="mt-1 font-mono">{formatTokens(cacheReadTokens)}</div>
               </div>
             </div>
           ) : null}

--- a/src/renderer/src/components/sessions/SessionTabs.tsx
+++ b/src/renderer/src/components/sessions/SessionTabs.tsx
@@ -95,6 +95,7 @@ interface SessionTabProps {
   name: string
   isActive: boolean
   agentSdk: 'opencode' | 'claude-code' | 'codex' | 'terminal'
+  runtimeSessionId: string | null
   color: string | null
   onClick: () => void
   onClose: (e: React.MouseEvent) => void
@@ -111,6 +112,11 @@ interface SessionTabProps {
   onCloseOthers: () => void
   onCloseToRight: () => void
   hintCode?: string
+}
+
+interface SessionTabsProps {
+  variant?: 'default' | 'topbar'
+  className?: string
 }
 
 const SessionTab = memo(function SessionTab({
@@ -131,6 +137,7 @@ const SessionTab = memo(function SessionTab({
   isDragging,
   isDragOver,
   worktreeId: _worktreeId,
+  runtimeSessionId,
   onCloseOthers,
   onCloseToRight,
   hintCode
@@ -214,11 +221,10 @@ const SessionTab = memo(function SessionTab({
           className={cn(
             'group relative flex items-center gap-1 px-3 py-1 text-sm cursor-pointer select-none',
             'rounded-md transition-colors min-w-[100px] max-w-[200px] my-0.5 mx-0.5',
-            !color && (
-              isActive
+            !color &&
+              (isActive
                 ? 'bg-background text-foreground shadow-sm'
-                : 'text-muted-foreground hover:bg-background/50 hover:text-foreground'
-            ),
+                : 'text-muted-foreground hover:bg-background/50 hover:text-foreground'),
             color && isActive && 'shadow-sm',
             isDragging && 'opacity-50',
             isDragOver && 'bg-accent/50'
@@ -304,6 +310,15 @@ const SessionTab = memo(function SessionTab({
         >
           {t('sessionTabs.menu.rename')}
         </ContextMenuItem>
+        {runtimeSessionId && agentSdk !== 'terminal' && (
+          <ContextMenuItem
+            onSelect={() =>
+              copyToClipboard(runtimeSessionId, t('sessionTabs.toasts.runtimeSessionIdCopied'))
+            }
+          >
+            {t('sessionTabs.menu.copyRuntimeSessionId')}
+          </ContextMenuItem>
+        )}
         <ContextMenuSeparator />
         <ContextMenuItem onSelect={(e) => onClose(e as unknown as React.MouseEvent)}>
           {t('sessionTabs.menu.close')}
@@ -334,10 +349,7 @@ const SessionTab = memo(function SessionTab({
             {SESSION_COLOR_PALETTE.map((c) => (
               <ContextMenuItem key={c.label} onSelect={() => onSetColor(c.value)}>
                 <span className="flex items-center gap-2">
-                  <span
-                    className="h-3 w-3 rounded-full"
-                    style={{ backgroundColor: c.swatch }}
-                  />
+                  <span className="h-3 w-3 rounded-full" style={{ backgroundColor: c.swatch }} />
                   {c.label}
                 </span>
               </ContextMenuItem>
@@ -618,7 +630,10 @@ const ConnectionSessionTab = memo(function ConnectionSessionTab({
   )
 })
 
-export function SessionTabs(): React.JSX.Element | null {
+export function SessionTabs({
+  variant = 'default',
+  className
+}: SessionTabsProps = {}): React.JSX.Element | null {
   const { t } = useI18n()
   const tabsContainerRef = useRef<HTMLDivElement>(null)
   const [showLeftArrow, setShowLeftArrow] = useState(false)
@@ -1082,11 +1097,17 @@ export function SessionTabs(): React.JSX.Element | null {
 
   // Determine if a file/diff tab is the active one
   const isFileTabActive = activeFilePath !== null
+  const isTopbar = variant === 'topbar'
 
   return (
     <div
-      className="flex items-center border-b border-border/40 bg-muted/30 px-1"
+      className={cn(
+        'flex min-w-0 items-center',
+        isTopbar ? 'h-10 flex-1 bg-transparent px-0' : 'border-b border-border/40 bg-muted/30 px-1',
+        className
+      )}
       data-testid="session-tabs"
+      data-variant={variant}
     >
       {/* New session button - on the left */}
       {/* Right-click shows provider menu with session type options */}
@@ -1099,7 +1120,10 @@ export function SessionTabs(): React.JSX.Element | null {
         <ContextMenuTrigger asChild>
           <button
             onClick={handleCreateSession}
-            className="p-1.5 rounded-md hover:bg-background/50 transition-colors shrink-0"
+            className={cn(
+              'rounded-md transition-colors shrink-0',
+              isTopbar ? 'h-7 w-7 p-1.5 hover:bg-background/70' : 'p-1.5 hover:bg-background/50'
+            )}
             data-testid="create-session"
             title={t('sessionTabs.actions.createSession')}
           >
@@ -1126,7 +1150,7 @@ export function SessionTabs(): React.JSX.Element | null {
             availableAgentSdks?.claude ||
             availableAgentSdks?.codex) && <ContextMenuSeparator />}
           <ContextMenuItem onSelect={() => handleCreateSessionWithSdk('terminal')}>
-            <TerminalSquare className="h-4 w-4 mr-2 text-emerald-500" />
+            <TerminalSquare className="h-4 w-4 mr-2 text-tech-blue" />
             {t('sessionTabs.actions.newTerminal')}
           </ContextMenuItem>
         </ContextMenuContent>
@@ -1136,7 +1160,7 @@ export function SessionTabs(): React.JSX.Element | null {
         open={newSessionDialogOpen}
         onOpenChange={setNewSessionDialogOpen}
         worktreeId={isConnectionMode ? null : selectedWorktreeId}
-        projectId={isConnectionMode ? null : project?.id ?? null}
+        projectId={isConnectionMode ? null : (project?.id ?? null)}
         connectionId={isConnectionMode ? selectedConnectionId : null}
         defaultIndex={
           isConnectionMode && selectedConnectionId
@@ -1218,6 +1242,7 @@ export function SessionTabs(): React.JSX.Element | null {
                 sessionId={session.id}
                 name={session.name || t('sessionTabs.common.untitled')}
                 agentSdk={session.agent_sdk}
+                runtimeSessionId={session.opencode_session_id}
                 color={session.color ?? null}
                 isActive={
                   session.id === activeSessionId && !isFileTabActive && !inlineConnectionSessionId
@@ -1338,9 +1363,7 @@ export function SessionTabs(): React.JSX.Element | null {
       )}
 
       {/* Global session status indicator (Phase 6) */}
-      <SessionStatusIndicator
-        onJumpToSession={(sid) => handleSessionTabClick(sid)}
-      />
+      <SessionStatusIndicator onJumpToSession={(sid) => handleSessionTabClick(sid)} />
     </div>
   )
 }

--- a/src/renderer/src/components/sessions/ToolCard.tsx
+++ b/src/renderer/src/components/sessions/ToolCard.tsx
@@ -298,7 +298,7 @@ function formatDuration(ms: number): string {
 function getLeftBorderColor(status: ToolStatus): string {
   switch (status) {
     case 'pending':
-      return 'hsl(var(--muted-foreground))'
+      return 'var(--muted-foreground)'
     case 'running':
       return '#3b82f6' // blue-500
     case 'success':
@@ -323,7 +323,7 @@ const TOOL_RENDERERS: Record<string, React.FC<ToolViewProps>> = {
   Bash: BashToolView,
   bash: BashToolView,
   // Token Saver: agent sees Bash via in-process MCP under this name.
-  'mcp__xuanpu__bash': BashToolView,
+  mcp__xuanpu__bash: BashToolView,
   Task: TaskToolView,
   task: TaskToolView,
   mcp_question: QuestionToolView,
@@ -384,9 +384,12 @@ function shortenPath(filePath: string, cwd?: string | null): string {
 }
 
 function resolveToolFilePath(input: Record<string, unknown>): string {
-  const direct =
-    (input.filePath || input.file_path || input.path || input.displayName || input.filename ||
-      '') as string
+  const direct = (input.filePath ||
+    input.file_path ||
+    input.path ||
+    input.displayName ||
+    input.filename ||
+    '') as string
   if (direct) return direct
   const paths = input.paths
   if (Array.isArray(paths) && typeof paths[0] === 'string') return paths[0]

--- a/src/renderer/src/components/settings/SettingsAppearance.tsx
+++ b/src/renderer/src/components/settings/SettingsAppearance.tsx
@@ -1,9 +1,18 @@
-import { Check, Monitor } from 'lucide-react'
+import { useMemo, useState } from 'react'
+import { Check, Loader2, Monitor, RefreshCw } from 'lucide-react'
 import { THEME_PRESETS, type ThemePreset } from '@/lib/themes'
 import { useThemeStore } from '@/stores/useThemeStore'
-import { useSettingsStore, applyFontScale } from '@/stores/useSettingsStore'
+import {
+  useSettingsStore,
+  applyFontFamily,
+  applyFontScale,
+  applyFontWeight
+} from '@/stores/useSettingsStore'
+import type { UiFontFamily, UiFontWeight } from '@/lib/font-size'
 import { cn } from '@/lib/utils'
 import { useI18n } from '@/i18n/useI18n'
+import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
 
 const FONT_SCALE_PRESETS = [
   { labelKey: 'small', scale: 0.9 },
@@ -12,6 +21,54 @@ const FONT_SCALE_PRESETS = [
   { labelKey: 'large', scale: 1.2 },
   { labelKey: 'xlarge', scale: 1.35 }
 ] as const
+
+const FONT_FAMILY_PRESETS: Array<{
+  id: UiFontFamily
+  labelKey: string
+  previewFontFamily?: string
+}> = [
+  { id: 'system', labelKey: 'system' },
+  {
+    id: 'serif',
+    labelKey: 'serif',
+    previewFontFamily: 'Charter, "Iowan Old Style", "Songti SC", Georgia, serif'
+  },
+  {
+    id: 'mono',
+    labelKey: 'mono',
+    previewFontFamily:
+      '"JetBrains Mono", "SF Mono", SFMono-Regular, ui-monospace, Menlo, Monaco, Consolas, monospace'
+  },
+  {
+    id: 'rounded',
+    labelKey: 'rounded',
+    previewFontFamily:
+      '"SF Pro Rounded", "Avenir Next", "PingFang SC", ui-rounded, system-ui, sans-serif'
+  },
+  { id: 'custom', labelKey: 'custom' }
+]
+
+const COMMON_SYSTEM_FONTS = [
+  'SF Pro Text',
+  'SF Pro Display',
+  'PingFang SC',
+  'Hiragino Sans GB',
+  'Helvetica Neue',
+  'Avenir Next',
+  'Menlo',
+  'Monaco',
+  'Songti SC'
+]
+
+const FONT_WEIGHT_PRESETS: Array<{
+  id: UiFontWeight
+  labelKey: string
+  previewWeight: number
+}> = [
+  { id: 'regular', labelKey: 'regular', previewWeight: 400 },
+  { id: 'medium', labelKey: 'medium', previewWeight: 500 },
+  { id: 'semibold', labelKey: 'semibold', previewWeight: 600 }
+]
 
 const ZOOM_PRESETS = [
   { label: '80%', level: -1.22 },
@@ -22,6 +79,61 @@ const ZOOM_PRESETS = [
   { label: '130%', level: 1.44 },
   { label: '150%', level: 2.22 }
 ] as const
+
+type LocalFontData = {
+  family: string
+  fullName?: string
+  postscriptName?: string
+  style?: string
+}
+
+type FontLoadStatus = 'idle' | 'loading' | 'loaded' | 'unavailable' | 'denied' | 'error'
+
+function quoteFontFamily(family: string): string {
+  const trimmed = family.trim()
+  if (!trimmed) return ''
+  if (/^[a-zA-Z0-9_-]+$/.test(trimmed)) return trimmed
+  return `"${trimmed.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`
+}
+
+function buildSystemFontStack(family: string): string {
+  return `${quoteFontFamily(family)}, system-ui, sans-serif`
+}
+
+function getQueryLocalFonts(): (() => Promise<LocalFontData[]>) | null {
+  const maybeWindow = window as Window & {
+    queryLocalFonts?: () => Promise<LocalFontData[]>
+  }
+  return typeof maybeWindow.queryLocalFonts === 'function'
+    ? maybeWindow.queryLocalFonts.bind(maybeWindow)
+    : null
+}
+
+function normalizeFontName(value: string): string {
+  return value
+    .trim()
+    .replace(/^['"]|['"]$/g, '')
+    .toLowerCase()
+}
+
+function getSelectedSystemFont(customFontFamily: string, systemFonts: string[]): string | null {
+  const trimmed = customFontFamily.trim()
+  if (!trimmed) return null
+
+  return (
+    systemFonts.find((family) => {
+      const quoted = quoteFontFamily(family)
+      const normalizedFamily = normalizeFontName(family)
+      return (
+        trimmed === buildSystemFontStack(family) ||
+        trimmed === quoted ||
+        trimmed === family ||
+        trimmed.startsWith(`${quoted},`) ||
+        normalizeFontName(trimmed.split(',')[0] ?? '') === normalizedFamily
+      )
+    }) ?? null
+  )
+}
 
 function findClosestPreset<T extends { scale?: number; level?: number }>(
   presets: readonly T[],
@@ -99,19 +211,95 @@ export function SettingsAppearance(): React.JSX.Element {
   const followSystem = useThemeStore((s) => s.followSystem)
   const setFollowSystem = useThemeStore((s) => s.setFollowSystem)
   const uiFontScale = useSettingsStore((s) => s.uiFontScale)
+  const uiFontFamily = useSettingsStore((s) => s.uiFontFamily)
+  const uiCustomFontFamily = useSettingsStore((s) => s.uiCustomFontFamily)
+  const uiFontWeight = useSettingsStore((s) => s.uiFontWeight)
   const uiZoomLevel = useSettingsStore((s) => s.uiZoomLevel)
   const updateSetting = useSettingsStore((s) => s.updateSetting)
   const { t } = useI18n()
+  const [localFontFamilies, setLocalFontFamilies] = useState<string[]>([])
+  const [fontLoadStatus, setFontLoadStatus] = useState<FontLoadStatus>('idle')
 
   const darkThemes = THEME_PRESETS.filter((p) => p.type === 'dark')
   const lightThemes = THEME_PRESETS.filter((p) => p.type === 'light')
 
   const activeFontPreset = findClosestPreset(FONT_SCALE_PRESETS, uiFontScale, 'scale')
   const activeZoomPreset = findClosestPreset(ZOOM_PRESETS, uiZoomLevel, 'level')
+  const systemFontOptions = useMemo(() => {
+    const families = [...COMMON_SYSTEM_FONTS, ...localFontFamilies]
+    return Array.from(new Set(families.map((family) => family.trim()).filter(Boolean))).sort(
+      (a, b) => a.localeCompare(b)
+    )
+  }, [localFontFamilies])
+  const selectedSystemFont =
+    uiFontFamily === 'custom' ? getSelectedSystemFont(uiCustomFontFamily, systemFontOptions) : null
+  const fontSelectValue =
+    uiFontFamily === 'custom'
+      ? selectedSystemFont
+        ? `system:${selectedSystemFont}`
+        : 'preset:custom'
+      : `preset:${uiFontFamily}`
+
+  const handleFontFamilyChange = (family: UiFontFamily): void => {
+    applyFontFamily(family, uiCustomFontFamily)
+    updateSetting('uiFontFamily', family)
+  }
+
+  const loadSystemFonts = async (): Promise<void> => {
+    if (fontLoadStatus === 'loading') return
+
+    const queryLocalFonts = getQueryLocalFonts()
+    if (!queryLocalFonts) {
+      setFontLoadStatus('unavailable')
+      return
+    }
+
+    setFontLoadStatus('loading')
+    try {
+      const fonts = await queryLocalFonts()
+      const families = Array.from(
+        new Set(fonts.map((font) => font.family.trim()).filter(Boolean))
+      ).sort((a, b) => a.localeCompare(b))
+      setLocalFontFamilies(families)
+      setFontLoadStatus('loaded')
+    } catch (error) {
+      const name = error instanceof DOMException ? error.name : ''
+      setFontLoadStatus(name === 'NotAllowedError' ? 'denied' : 'error')
+    }
+  }
+
+  const handleFontSelectChange = (value: string): void => {
+    if (value.startsWith('system:')) {
+      const family = value.slice('system:'.length)
+      const fontStack = buildSystemFontStack(family)
+      applyFontFamily('custom', fontStack)
+      updateSetting('uiCustomFontFamily', fontStack)
+      updateSetting('uiFontFamily', 'custom')
+      return
+    }
+
+    const family = value.replace('preset:', '') as UiFontFamily
+    if (family === 'custom') {
+      applyFontFamily('custom', uiCustomFontFamily)
+      updateSetting('uiFontFamily', 'custom')
+      return
+    }
+    handleFontFamilyChange(family)
+  }
+
+  const handleCustomFontFamilyChange = (fontFamily: string): void => {
+    applyFontFamily('custom', fontFamily)
+    updateSetting('uiCustomFontFamily', fontFamily)
+  }
 
   const handleFontScaleChange = (scale: number): void => {
     applyFontScale(scale)
     updateSetting('uiFontScale', scale)
+  }
+
+  const handleFontWeightChange = (weight: UiFontWeight): void => {
+    applyFontWeight(weight)
+    updateSetting('uiFontWeight', weight)
   }
 
   const handleZoomChange = (level: number): void => {
@@ -168,7 +356,12 @@ export function SettingsAppearance(): React.JSX.Element {
             : 'border-border/50 bg-card/50 hover:border-border'
         )}
       >
-        <Monitor className={cn('h-4 w-4 shrink-0', followSystem ? 'text-primary' : 'text-muted-foreground')} />
+        <Monitor
+          className={cn(
+            'h-4 w-4 shrink-0',
+            followSystem ? 'text-primary' : 'text-muted-foreground'
+          )}
+        />
         <div className="flex-1 min-w-0">
           <div className="text-sm font-medium">跟随系统</div>
           <div className="text-xs text-muted-foreground">自动跟随操作系统的浅色/深色模式</div>
@@ -212,6 +405,128 @@ export function SettingsAppearance(): React.JSX.Element {
                 data-testid={`font-scale-${preset.labelKey}`}
               >
                 {t(`settings.appearance.fontSize.presets.${preset.labelKey}`)}
+              </button>
+            )
+          })}
+        </div>
+      </div>
+
+      {/* Font Family */}
+      <div>
+        <h3 className="text-sm font-medium text-foreground mb-1">
+          {t('settings.appearance.fontFamily.title')}
+        </h3>
+        <p className="text-xs text-muted-foreground mb-3">
+          {t('settings.appearance.fontFamily.description')}
+        </p>
+        <div className="flex flex-col gap-2" data-testid="font-family-picker">
+          <div className="flex gap-2">
+            <select
+              value={fontSelectValue}
+              onChange={(event) => handleFontSelectChange(event.target.value)}
+              onFocus={() => {
+                if (fontLoadStatus === 'idle') {
+                  void loadSystemFonts()
+                }
+              }}
+              className="h-9 min-w-0 flex-1 rounded-lg border border-border bg-background px-3 text-sm text-foreground outline-none transition-colors hover:bg-muted/45 focus:border-primary focus:ring-2 focus:ring-primary/20"
+              data-testid="font-family-select"
+            >
+              <optgroup label={t('settings.appearance.fontFamily.presetsGroup')}>
+                {FONT_FAMILY_PRESETS.map((preset) => (
+                  <option key={preset.id} value={`preset:${preset.id}`}>
+                    {t(`settings.appearance.fontFamily.presets.${preset.labelKey}`)}
+                  </option>
+                ))}
+              </optgroup>
+              <optgroup label={t('settings.appearance.fontFamily.systemGroup')}>
+                {systemFontOptions.map((family) => (
+                  <option key={family} value={`system:${family}`}>
+                    {family}
+                  </option>
+                ))}
+              </optgroup>
+            </select>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className="h-9 shrink-0 rounded-lg px-3 text-xs"
+              onClick={() => void loadSystemFonts()}
+              disabled={fontLoadStatus === 'loading'}
+              data-testid="load-system-fonts"
+            >
+              {fontLoadStatus === 'loading' ? (
+                <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+              ) : (
+                <RefreshCw className="mr-1.5 h-3.5 w-3.5" />
+              )}
+              {t('settings.appearance.fontFamily.loadSystemFonts')}
+            </Button>
+          </div>
+          <div className="flex min-h-5 items-center justify-between gap-2">
+            <div
+              className="truncate text-xs text-muted-foreground"
+              data-testid="font-family-preview"
+              style={{
+                fontFamily:
+                  uiFontFamily === 'custom'
+                    ? uiCustomFontFamily
+                    : FONT_FAMILY_PRESETS.find((preset) => preset.id === uiFontFamily)
+                        ?.previewFontFamily
+              }}
+            >
+              {t('settings.appearance.fontFamily.preview')}
+            </div>
+            <div className="shrink-0 text-[11px] text-muted-foreground">
+              {fontLoadStatus === 'loaded' &&
+                t('settings.appearance.fontFamily.systemFontsLoaded', {
+                  count: localFontFamilies.length
+                })}
+              {fontLoadStatus === 'unavailable' &&
+                t('settings.appearance.fontFamily.systemFontsUnavailable')}
+              {fontLoadStatus === 'denied' && t('settings.appearance.fontFamily.systemFontsDenied')}
+              {fontLoadStatus === 'error' && t('settings.appearance.fontFamily.systemFontsError')}
+            </div>
+          </div>
+        </div>
+        {uiFontFamily === 'custom' && (
+          <div className="mt-3" data-testid="custom-font-family-row">
+            <Input
+              value={uiCustomFontFamily}
+              onChange={(event) => handleCustomFontFamilyChange(event.target.value)}
+              placeholder={t('settings.appearance.fontFamily.customPlaceholder')}
+              data-testid="custom-font-family-input"
+            />
+          </div>
+        )}
+      </div>
+
+      {/* Font Weight */}
+      <div>
+        <h3 className="text-sm font-medium text-foreground mb-1">
+          {t('settings.appearance.fontWeight.title')}
+        </h3>
+        <p className="text-xs text-muted-foreground mb-3">
+          {t('settings.appearance.fontWeight.description')}
+        </p>
+        <div className="flex flex-wrap gap-2" data-testid="font-weight-presets">
+          {FONT_WEIGHT_PRESETS.map((preset) => {
+            const isActive = uiFontWeight === preset.id
+            return (
+              <button
+                key={preset.id}
+                onClick={() => handleFontWeightChange(preset.id)}
+                className={cn(
+                  'rounded-md border px-3 py-1.5 text-xs transition-colors',
+                  isActive
+                    ? 'border-primary bg-primary text-primary-foreground'
+                    : 'border-border bg-background text-foreground hover:bg-muted'
+                )}
+                data-testid={`font-weight-${preset.id}`}
+                style={{ fontWeight: preset.previewWeight }}
+              >
+                {t(`settings.appearance.fontWeight.presets.${preset.labelKey}`)}
               </button>
             )
           })}

--- a/src/renderer/src/components/terminal/TerminalTabBar.tsx
+++ b/src/renderer/src/components/terminal/TerminalTabBar.tsx
@@ -1,7 +1,7 @@
 import { useState, useRef, useEffect, useCallback } from 'react'
 import { Plus, X } from 'lucide-react'
 import { cn } from '@/lib/utils'
-import { useBottomTerminalStore } from '@/stores/useBottomTerminalStore'
+import { useBottomTerminalStore, type BottomTerminalTab } from '@/stores/useBottomTerminalStore'
 import { useTerminalStore } from '@/stores/useTerminalStore'
 import { useLayoutStore } from '@/stores/useLayoutStore'
 import {
@@ -17,6 +17,8 @@ interface TerminalTabBarProps {
   worktreeId: string
   worktreeCwd: string
 }
+
+const EMPTY_TABS: BottomTerminalTab[] = []
 
 function StatusDot({ tabId }: { tabId: string }): React.JSX.Element {
   const status = useTerminalStore((s) => s.terminals.get(tabId)?.status ?? 'creating')
@@ -37,7 +39,7 @@ export function TerminalTabBar({
   worktreeId,
   worktreeCwd
 }: TerminalTabBarProps): React.JSX.Element {
-  const tabs = useBottomTerminalStore((s) => s.getTabsForWorktree(worktreeId))
+  const tabs = useBottomTerminalStore((s) => s.tabsByWorktree.get(worktreeId) ?? EMPTY_TABS)
   const activeTabId = useBottomTerminalStore((s) => s.getActiveTabId(worktreeId))
   const { createTab, closeTab, closeOtherTabs, setActiveTab, renameTab } =
     useBottomTerminalStore()

--- a/src/renderer/src/components/worktrees/WorktreeItem.tsx
+++ b/src/renderer/src/components/worktrees/WorktreeItem.tsx
@@ -152,8 +152,9 @@ export function WorktreeItem({
     (state) => state.lastMessageTimeByWorktree[worktree.id] ?? null
   )
   // Show last activity time: prefer last message time, fallback to last_accessed_at
-  const displayTime = lastMessageTime
-    ?? (worktree.last_accessed_at ? new Date(worktree.last_accessed_at).getTime() : null)
+  const displayTime =
+    lastMessageTime ??
+    (worktree.last_accessed_at ? new Date(worktree.last_accessed_at).getTime() : null)
   const liveBranch = useGitStore((s) => s.branchInfoByWorktree.get(worktree.path))
   const activeBranchName = liveBranch?.name ?? worktree.branch_name
   const displayName = liveBranch?.name ?? worktree.name
@@ -530,8 +531,8 @@ export function WorktreeItem({
       <>
         <div
           className={cn(
-            'group flex items-center gap-2 pl-8 pr-1.5 py-2 rounded-lg cursor-pointer transition-colors',
-            isChecked ? 'bg-accent/30' : 'hover:bg-accent/50',
+            'group flex items-center gap-2 pl-8 pr-1.5 py-2.5 rounded-lg cursor-pointer transition-colors',
+            isChecked ? 'crisp-active-row' : 'crisp-hover-row',
             isSource && isChecked && 'bg-accent/20',
             isArchiving && 'opacity-50 pointer-events-none'
           )}
@@ -589,10 +590,8 @@ export function WorktreeItem({
       <ContextMenuTrigger asChild>
         <div
           className={cn(
-            'group flex items-center gap-2.5 pl-6 pr-2 py-2 rounded-lg cursor-pointer transition-colors',
-            isSelected
-              ? 'bg-sidebar-accent text-sidebar-accent-foreground ring-1 ring-sidebar-border/60 shadow-sm'
-              : 'hover:bg-sidebar-accent/70',
+            'group flex items-center gap-2.5 pl-6 pr-2 py-2.5 rounded-lg cursor-pointer transition-colors',
+            isSelected ? 'crisp-active-row pl-7' : 'crisp-hover-row',
             isArchiving && 'opacity-50 pointer-events-none',
             isDragging && 'opacity-50',
             isDragOver && 'border-t-2 border-primary'

--- a/src/renderer/src/hooks/useKeyboardShortcuts.ts
+++ b/src/renderer/src/hooks/useKeyboardShortcuts.ts
@@ -343,8 +343,13 @@ function getShortcutHandlers(
         } else {
           store.createTab(worktreeId, worktreePath ?? '/')
         }
-        // Ensure the bottom panel is showing the terminal tab
-        useLayoutStore.getState().setBottomPanelTab('terminal')
+        const layout = useLayoutStore.getState()
+        // Ensure the terminal surface is visible in its current dock.
+        layout.setBottomPanelTab('terminal')
+        if (layout.terminalDock === 'right') {
+          layout.setRightSidebarCollapsed(false)
+          layout.setRightContextTab('terminal')
+        }
       }
     },
     {

--- a/src/renderer/src/hooks/useVimNavigation.ts
+++ b/src/renderer/src/hooks/useVimNavigation.ts
@@ -256,7 +256,11 @@ export function useVimNavigation(): void {
           u: 'run',
           t: 'terminal'
         }
-        layout.setBottomPanelTab(tabMap[event.key])
+        const nextTab = tabMap[event.key]
+        layout.setBottomPanelTab(nextTab)
+        if (nextTab === 'terminal' && layout.terminalDock === 'right') {
+          layout.setRightContextTab('terminal')
+        }
         event.preventDefault()
         return
       }
@@ -279,33 +283,49 @@ export function useVimNavigation(): void {
         const btn = document.querySelector<HTMLElement>('[data-testid="review-button"]')
         if (btn) {
           btn.click()
-          event.preventDefault()
-          return
+        } else {
+          const layout = useLayoutStore.getState()
+          layout.setRightSidebarCollapsed(false)
+          layout.setRightContextTab('review')
         }
+        event.preventDefault()
+        return
       }
       if (event.key === 'p') {
         const btn = document.querySelector<HTMLElement>('[data-testid="pr-button"]')
         if (btn) {
           btn.click()
-          event.preventDefault()
-          return
+        } else {
+          const layout = useLayoutStore.getState()
+          layout.setRightSidebarCollapsed(false)
+          layout.setRightContextTab('review')
         }
+        event.preventDefault()
+        return
       }
       if (event.key === 'm') {
         const btn = document.querySelector<HTMLElement>('[data-testid="pr-merge-button"]')
         if (btn) {
           btn.click()
-          event.preventDefault()
-          return
+        } else {
+          const layout = useLayoutStore.getState()
+          layout.setRightSidebarCollapsed(false)
+          layout.setRightContextTab('review')
         }
+        event.preventDefault()
+        return
       }
       if (event.key === 'a') {
         const btn = document.querySelector<HTMLElement>('[data-testid="pr-archive-button"]')
         if (btn) {
           btn.click()
-          event.preventDefault()
-          return
+        } else {
+          const layout = useLayoutStore.getState()
+          layout.setRightSidebarCollapsed(false)
+          layout.setRightContextTab('review')
         }
+        event.preventDefault()
+        return
       }
 
       // --- Hint dispatch: idle mode → uppercase starts pending ---

--- a/src/renderer/src/i18n/messages.ts
+++ b/src/renderer/src/i18n/messages.ts
@@ -1800,8 +1800,42 @@ export const messages: Record<AppLocale, MessageTree> = {
       ariaLabel: 'Projects and worktrees'
     },
     rightSidebar: {
-      ariaLabel: 'File sidebar',
-      fileSidebarError: 'File sidebar error'
+      ariaLabel: 'Context panel',
+      fileSidebarError: 'Context panel error'
+    },
+    contextPanel: {
+      tabs: {
+        overview: 'Overview',
+        review: 'Review',
+        files: 'Files',
+        tasks: 'Tasks',
+        goal: 'Goal'
+      },
+      overview: {
+        cost: 'Cost',
+        tokens: 'Tokens',
+        input: 'Input',
+        output: 'Output',
+        cacheRead: 'Cache Read',
+        cacheWrite: 'Cache Write',
+        contextLimit: '{used} / {limit}',
+        worktree: 'Worktree'
+      },
+      tasks: {
+        emptyTitle: 'No tasks yet',
+        emptyDescription: 'Agent todo updates will appear here after the session emits a task list.'
+      },
+      goal: {
+        emptyTitle: 'No goal set',
+        emptyDescription:
+          'Start a goal-mode session to keep objective, status, and criteria visible here.'
+      },
+      empty: {
+        noSessionTitle: 'No active session',
+        noSessionDescription:
+          'Open or start a session to show worktree, usage, tasks, and goal context.',
+        noWorktree: 'No worktree selected'
+      }
     },
     reasoningBlock: {
       thinking: 'Thinking...'
@@ -4591,8 +4625,40 @@ export const messages: Record<AppLocale, MessageTree> = {
       ariaLabel: '项目和 worktree'
     },
     rightSidebar: {
-      ariaLabel: '文件侧边栏',
-      fileSidebarError: '文件侧边栏出错'
+      ariaLabel: '上下文面板',
+      fileSidebarError: '上下文面板出错'
+    },
+    contextPanel: {
+      tabs: {
+        overview: '概览',
+        review: '审查',
+        files: '文件',
+        tasks: '任务',
+        goal: '目标'
+      },
+      overview: {
+        cost: '花费',
+        tokens: 'Tokens',
+        input: '输入',
+        output: '输出',
+        cacheRead: '缓存读取',
+        cacheWrite: '缓存写入',
+        contextLimit: '{used} / {limit}',
+        worktree: 'Worktree'
+      },
+      tasks: {
+        emptyTitle: '暂无任务',
+        emptyDescription: 'Agent 输出任务列表后，会在这里展示 todo 进度。'
+      },
+      goal: {
+        emptyTitle: '暂无目标',
+        emptyDescription: '开启目标模式会在这里展示目标、状态和成功标准。'
+      },
+      empty: {
+        noSessionTitle: '暂无活跃会话',
+        noSessionDescription: '打开或创建会话后，这里会展示 worktree、用量、任务和目标上下文。',
+        noWorktree: '未选择 worktree'
+      }
     },
     reasoningBlock: {
       thinking: '思考中...'

--- a/src/renderer/src/i18n/messages.ts
+++ b/src/renderer/src/i18n/messages.ts
@@ -44,6 +44,36 @@ export const messages: Record<AppLocale, MessageTree> = {
             xlarge: 'X-Large'
           }
         },
+        fontFamily: {
+          title: 'Font Family',
+          description:
+            'Choose the primary UI font. System font access may require permission; custom values use CSS font-family syntax.',
+          customPlaceholder: 'e.g. "LXGW WenKai", "SF Pro Text"',
+          presetsGroup: 'Presets',
+          systemGroup: 'System Fonts',
+          loadSystemFonts: 'Load Fonts',
+          preview: 'Xuanpu Aa 123 · 玄圃开发工作台',
+          systemFontsLoaded: '{count} system fonts loaded',
+          systemFontsUnavailable: 'System font list is unavailable in this environment',
+          systemFontsDenied: 'System font access was denied',
+          systemFontsError: 'Failed to load system fonts',
+          presets: {
+            system: 'System',
+            serif: 'Serif',
+            mono: 'Mono',
+            rounded: 'Rounded',
+            custom: 'Custom'
+          }
+        },
+        fontWeight: {
+          title: 'Default Weight',
+          description: 'Tune the default text weight for normal UI copy.',
+          presets: {
+            regular: 'Regular',
+            medium: 'Medium',
+            semibold: 'Semi-bold'
+          }
+        },
         uiScale: {
           title: 'UI Scale',
           description:
@@ -874,6 +904,8 @@ export const messages: Record<AppLocale, MessageTree> = {
     },
     codeBlock: {
       copyButton: 'Copy code',
+      expand: 'Expand',
+      collapse: 'Collapse',
       toasts: {
         copied: 'Code copied to clipboard',
         copyError: 'Failed to copy code'
@@ -1554,6 +1586,7 @@ export const messages: Record<AppLocale, MessageTree> = {
           error: 'Error',
           materializing: 'Starting'
         },
+        context: 'Context',
         tokens: 'tokens',
         compressingContext: 'Compressing context...'
       },
@@ -1732,6 +1765,7 @@ export const messages: Record<AppLocale, MessageTree> = {
         close: 'Close',
         closeOthers: 'Close Others',
         closeToRight: 'Close Others to the Right',
+        copyRuntimeSessionId: 'Copy Resume ID',
         copyRelativePath: 'Copy Relative Path',
         copyAbsolutePath: 'Copy Absolute Path',
         setColor: 'Set Color',
@@ -1752,7 +1786,8 @@ export const messages: Record<AppLocale, MessageTree> = {
         label: 'Context'
       },
       toasts: {
-        copied: 'Copied to clipboard'
+        copied: 'Copied to clipboard',
+        runtimeSessionIdCopied: 'Resume ID copied to clipboard'
       },
       errors: {
         createSession: 'Failed to create session',
@@ -1818,8 +1853,11 @@ export const messages: Record<AppLocale, MessageTree> = {
         output: 'Output',
         cacheRead: 'Cache Read',
         cacheWrite: 'Cache Write',
+        sessions: 'Sessions',
+        sessionCount: '{count} sessions in this {scope}',
         contextLimit: '{used} / {limit}',
-        worktree: 'Worktree'
+        worktree: 'Worktree',
+        connection: 'Connection'
       },
       tasks: {
         emptyTitle: 'No tasks yet',
@@ -1829,6 +1867,15 @@ export const messages: Record<AppLocale, MessageTree> = {
         emptyTitle: 'No goal set',
         emptyDescription:
           'Start a goal-mode session to keep objective, status, and criteria visible here.'
+      },
+      terminal: {
+        emptyDescription: 'Dock the terminal to the right sidebar to show it in this panel.'
+      },
+      review: {
+        startReview: 'AI Review',
+        startReviewTitle: 'Start an AI review session for this diff',
+        sessionHint:
+          'Review opens a dedicated agent session and preloads the selected branch comparison.'
       },
       empty: {
         noSessionTitle: 'No active session',
@@ -1953,6 +2000,7 @@ export const messages: Record<AppLocale, MessageTree> = {
       observedSection: 'Observed (Episodic)',
       semanticSection: 'Semantic',
       regenerate: 'Regenerate',
+      refresh: 'Refresh',
       clear: 'Clear',
       open: 'Open',
       create: 'Create',
@@ -2903,6 +2951,36 @@ export const messages: Record<AppLocale, MessageTree> = {
             xlarge: '最大'
           }
         },
+        fontFamily: {
+          title: '界面字体',
+          description:
+            '选择玄圃界面的主要字体。系统字体读取可能需要授权；自定义值使用 CSS font-family 写法。',
+          customPlaceholder: '例如 "霞鹜文楷", "SF Pro Text"',
+          presetsGroup: '预设',
+          systemGroup: '系统字体',
+          loadSystemFonts: '加载字体',
+          preview: '玄圃开发工作台 · Xuanpu Aa 123',
+          systemFontsLoaded: '已加载 {count} 个系统字体',
+          systemFontsUnavailable: '当前环境不支持读取系统字体列表',
+          systemFontsDenied: '系统字体读取授权已拒绝',
+          systemFontsError: '系统字体加载失败',
+          presets: {
+            system: '系统默认',
+            serif: '衬线',
+            mono: '等宽',
+            rounded: '圆体',
+            custom: '自定义'
+          }
+        },
+        fontWeight: {
+          title: '默认字重',
+          description: '调整普通界面文字的默认粗细。',
+          presets: {
+            regular: '常规',
+            medium: '中等',
+            semibold: '半粗体'
+          }
+        },
         uiScale: {
           title: '界面缩放',
           description: '等比缩放整体界面，包括图标和间距。也可使用 Cmd+/Cmd- 快捷键。'
@@ -3709,6 +3787,8 @@ export const messages: Record<AppLocale, MessageTree> = {
     },
     codeBlock: {
       copyButton: '复制代码',
+      expand: '展开',
+      collapse: '收起',
       toasts: {
         copied: '代码已复制到剪贴板',
         copyError: '复制代码失败'
@@ -4379,6 +4459,7 @@ export const messages: Record<AppLocale, MessageTree> = {
           error: '错误',
           materializing: '启动中'
         },
+        context: '上下文',
         tokens: 'tokens',
         compressingContext: '正在压缩上下文...'
       },
@@ -4557,6 +4638,7 @@ export const messages: Record<AppLocale, MessageTree> = {
         close: '关闭',
         closeOthers: '关闭其他标签',
         closeToRight: '关闭右侧其他标签',
+        copyRuntimeSessionId: '复制恢复 ID',
         copyRelativePath: '复制相对路径',
         copyAbsolutePath: '复制绝对路径',
         setColor: '设置颜色',
@@ -4577,7 +4659,8 @@ export const messages: Record<AppLocale, MessageTree> = {
         label: '上下文'
       },
       toasts: {
-        copied: '已复制到剪贴板'
+        copied: '已复制到剪贴板',
+        runtimeSessionIdCopied: '恢复 ID 已复制到剪贴板'
       },
       errors: {
         createSession: '创建会话失败',
@@ -4643,8 +4726,11 @@ export const messages: Record<AppLocale, MessageTree> = {
         output: '输出',
         cacheRead: '缓存读取',
         cacheWrite: '缓存写入',
+        sessions: '会话数',
+        sessionCount: '此{scope}下 {count} 个会话',
         contextLimit: '{used} / {limit}',
-        worktree: 'Worktree'
+        worktree: 'Worktree',
+        connection: '连接'
       },
       tasks: {
         emptyTitle: '暂无任务',
@@ -4653,6 +4739,14 @@ export const messages: Record<AppLocale, MessageTree> = {
       goal: {
         emptyTitle: '暂无目标',
         emptyDescription: '开启目标模式会在这里展示目标、状态和成功标准。'
+      },
+      terminal: {
+        emptyDescription: '将终端停靠到右侧后，会在这里展示终端面板。'
+      },
+      review: {
+        startReview: 'AI 审查此差异',
+        startReviewTitle: '为当前差异创建一个 AI 审查会话',
+        sessionHint: '审查会创建独立的 Agent 会话，并预置当前选择的分支对比提示。'
       },
       empty: {
         noSessionTitle: '暂无活跃会话',
@@ -4776,6 +4870,7 @@ export const messages: Record<AppLocale, MessageTree> = {
       observedSection: '观察记忆（Episodic）',
       semanticSection: '语义记忆（Semantic）',
       regenerate: '重新压缩',
+      refresh: '刷新',
       clear: '清空',
       open: '打开',
       create: '创建',

--- a/src/renderer/src/lib/font-size.ts
+++ b/src/renderer/src/lib/font-size.ts
@@ -18,6 +18,25 @@ const BASE_TEXT_SIZES: Record<string, number> = {
 
 const ALL_FONT_VARS = Object.keys(BASE_TEXT_SIZES)
 
+export type UiFontFamily = 'system' | 'serif' | 'mono' | 'rounded' | 'custom'
+export type UiFontWeight = 'regular' | 'medium' | 'semibold'
+
+const UI_FONT_FAMILY_VAR = '--xuanpu-ui-font-family'
+const UI_FONT_WEIGHT_VAR = '--xuanpu-ui-font-weight'
+
+const UI_FONT_FAMILY_STACKS: Record<Exclude<UiFontFamily, 'custom'>, string> = {
+  system: '',
+  serif: 'Charter, "Iowan Old Style", "Songti SC", Georgia, serif',
+  mono: '"JetBrains Mono", "SF Mono", SFMono-Regular, ui-monospace, Menlo, Monaco, Consolas, monospace',
+  rounded: '"SF Pro Rounded", "Avenir Next", "PingFang SC", ui-rounded, system-ui, sans-serif'
+}
+
+const UI_FONT_WEIGHT_VALUES: Record<UiFontWeight, string> = {
+  regular: '400',
+  medium: '500',
+  semibold: '600'
+}
+
 /**
  * Apply a font scale multiplier by overriding Tailwind's --text-* CSS variables.
  * scale = 1 removes all overrides (restores Tailwind defaults).
@@ -32,5 +51,53 @@ export function applyFontScale(scale: number): void {
   }
   for (const [key, base] of Object.entries(BASE_TEXT_SIZES)) {
     root.style.setProperty(key, `${(base * scale).toFixed(4)}rem`)
+  }
+}
+
+export function applyFontFamily(family: UiFontFamily, customFamily = ''): void {
+  const root = document.documentElement
+
+  if (family === 'custom') {
+    const trimmed = customFamily.trim()
+    if (trimmed) {
+      root.style.setProperty(UI_FONT_FAMILY_VAR, trimmed)
+    } else {
+      root.style.removeProperty(UI_FONT_FAMILY_VAR)
+    }
+    return
+  }
+
+  const stack = UI_FONT_FAMILY_STACKS[family]
+  if (stack) {
+    root.style.setProperty(UI_FONT_FAMILY_VAR, stack)
+  } else {
+    root.style.removeProperty(UI_FONT_FAMILY_VAR)
+  }
+}
+
+export function applyFontWeight(weight: UiFontWeight): void {
+  const root = document.documentElement
+  const value = UI_FONT_WEIGHT_VALUES[weight]
+  if (!value || weight === 'regular') {
+    root.style.removeProperty(UI_FONT_WEIGHT_VAR)
+    return
+  }
+  root.style.setProperty(UI_FONT_WEIGHT_VAR, value)
+}
+
+export function applyTypographySettings(settings: {
+  uiFontScale?: number
+  uiFontFamily?: UiFontFamily
+  uiCustomFontFamily?: string
+  uiFontWeight?: UiFontWeight
+}): void {
+  if (typeof settings.uiFontScale === 'number') {
+    applyFontScale(settings.uiFontScale)
+  }
+  if (settings.uiFontFamily) {
+    applyFontFamily(settings.uiFontFamily, settings.uiCustomFontFamily)
+  }
+  if (settings.uiFontWeight) {
+    applyFontWeight(settings.uiFontWeight)
   }
 }

--- a/src/renderer/src/lib/session-tasks.ts
+++ b/src/renderer/src/lib/session-tasks.ts
@@ -1,0 +1,35 @@
+import { isTodoWriteTool } from '@/components/sessions/tools/todo-utils'
+import type { TimelineMessage } from '@shared/lib/timeline-types'
+
+export type SessionTaskStatus = 'pending' | 'in_progress' | 'completed' | 'error'
+
+export interface SessionTask {
+  id: string
+  content: string
+  status: SessionTaskStatus
+}
+
+export function extractMissionTasks(messages: TimelineMessage[]): SessionTask[] {
+  // Scan from end to find the latest todo-like tool snapshot.
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const msg = messages[i]
+    if (msg.role !== 'assistant') continue
+
+    for (const part of msg.parts ?? []) {
+      if (part.type !== 'tool_use' || !part.toolUse) continue
+      const toolName = part.toolUse.name?.toLowerCase() ?? ''
+      if (!isTodoWriteTool(toolName)) continue
+
+      const todos = part.toolUse.input?.todos
+      if (!Array.isArray(todos)) continue
+
+      return todos.map((t: Record<string, unknown>, idx: number) => ({
+        id: String(t.id ?? `todo-${idx}`),
+        content: String(t.content ?? t.subject ?? t.activeForm ?? ''),
+        status: (t.status as SessionTaskStatus) ?? 'pending'
+      }))
+    }
+  }
+
+  return []
+}

--- a/src/renderer/src/lib/themes.ts
+++ b/src/renderer/src/lib/themes.ts
@@ -7,84 +7,128 @@ export interface ThemePreset {
 
 export const THEME_PRESETS: ThemePreset[] = [
   // =====================
-  // DARK THEME — Catppuccin Mocha
-  // https://github.com/catppuccin/catppuccin
+  // DARK THEME — Nordic Night Tech
   // =====================
   {
     id: 'mocha',
-    name: 'Mocha',
+    name: 'Nordic Night',
     type: 'dark',
     colors: {
-      background: 'hsl(240 21% 15%)',         // Base
-      foreground: 'hsl(226 64% 88%)',          // Text
-      card: 'hsl(240 21% 12%)',                // Mantle
-      'card-foreground': 'hsl(226 64% 88%)',   // Text
-      popover: 'hsl(240 21% 12%)',             // Mantle
-      'popover-foreground': 'hsl(226 64% 88%)',// Text
-      primary: 'hsl(232 97% 85%)',             // Lavender
-      'primary-foreground': 'hsl(240 23% 9%)', // Crust
-      secondary: 'hsl(237 16% 23%)',           // Surface0
-      'secondary-foreground': 'hsl(228 24% 72%)', // Subtext0
-      muted: 'hsl(237 16% 23%)',               // Surface0
-      'muted-foreground': 'hsl(230 13% 55%)',  // Overlay1
-      accent: 'hsl(237 16% 23%)',              // Surface0
-      'accent-foreground': 'hsl(226 64% 88%)', // Text
-      destructive: 'hsl(343 81% 75%)',         // Red
-      'destructive-foreground': 'hsl(240 23% 9%)', // Crust
-      border: 'hsl(234 13% 31%)',              // Surface1
-      input: 'hsl(234 13% 31%)',               // Surface1
-      ring: 'hsl(232 97% 85%)',                // Lavender
-      sidebar: 'hsl(240 23% 9%)',              // Crust
-      'sidebar-foreground': 'hsl(228 24% 72%)',// Subtext0
-      'sidebar-primary': 'hsl(232 97% 85%)',   // Lavender
-      'sidebar-primary-foreground': 'hsl(240 23% 9%)', // Crust
-      'sidebar-accent': 'hsl(237 16% 23%)',    // Surface0
-      'sidebar-accent-foreground': 'hsl(226 64% 88%)', // Text
-      'sidebar-border': 'hsl(234 13% 31%)',    // Surface1
-      'sidebar-ring': 'hsl(232 97% 85%)',      // Lavender
-      celadon: 'hsl(170 57% 73%)',             // Teal
-      'celadon-foreground': 'hsl(240 23% 9%)'  // Crust
+      background: '#101827',
+      foreground: '#C3CBE0',
+      card: '#151F2F',
+      'card-foreground': '#C3CBE0',
+      popover: '#151F2F',
+      'popover-foreground': '#C3CBE0',
+      primary: '#7AA7FF',
+      'primary-foreground': '#08111F',
+      secondary: '#1A2436',
+      'secondary-foreground': '#A9B3C8',
+      muted: '#1A2436',
+      'muted-foreground': '#8994AA',
+      accent: '#22304A',
+      'accent-foreground': '#C3CBE0',
+      destructive: '#FB7185',
+      'destructive-foreground': '#2A0712',
+      border: '#2A364A',
+      input: '#334155',
+      ring: '#7AA7FF',
+      sidebar: '#0F1724',
+      'sidebar-foreground': '#A9B3C8',
+      'sidebar-primary': '#7AA7FF',
+      'sidebar-primary-foreground': '#08111F',
+      'sidebar-accent': '#151F2F',
+      'sidebar-accent-foreground': '#C3CBE0',
+      'sidebar-border': '#263247',
+      'sidebar-ring': '#7AA7FF',
+      celadon: '#2DD4BF',
+      'celadon-foreground': '#08111F',
+      'agent-canvas': '#101827',
+      'agent-sheet': '#121C2B',
+      'agent-card': '#151F2F',
+      'agent-card-muted': '#1A2436',
+      'agent-hover': '#253247',
+      'agent-shadow-rgb': '0 0 0',
+      'code-block-bg': '#131C2B',
+      'code-block-header': '#101827',
+      'code-block-border': '#263247',
+      'code-block-text': '#CBD5E1',
+      'code-block-muted': '#8492A8',
+      'code-block-accent': '#8BC7FF',
+      'code-block-warm': '#F6D36B',
+      ink: '#C3CBE0',
+      steel: '#8994AA',
+      'tech-blue': '#7AA7FF',
+      'tech-blue-soft': '#172A48',
+      'neon-mint': '#2DD4BF',
+      'neon-mint-soft': '#123834',
+      'neon-pink': '#FB7185',
+      'neon-pink-soft': '#3F1725',
+      'neon-violet': '#B29DFF',
+      'neon-violet-soft': '#30294B'
     }
   },
 
   // =====================
-  // LIGHT THEME — Catppuccin Latte
-  // https://github.com/catppuccin/catppuccin
+  // LIGHT THEME — Nordic Crisp Tech
   // =====================
   {
     id: 'latte',
-    name: 'Latte',
+    name: 'Nordic',
     type: 'light',
     colors: {
-      background: 'hsl(220 23% 95%)',          // Base
-      foreground: 'hsl(234 16% 35%)',          // Text
-      card: 'hsl(220 22% 92%)',                // Mantle
-      'card-foreground': 'hsl(234 16% 35%)',   // Text
-      popover: 'hsl(220 22% 92%)',             // Mantle
-      'popover-foreground': 'hsl(234 16% 35%)',// Text
-      primary: 'hsl(231 97% 72%)',             // Lavender
-      'primary-foreground': 'hsl(220 23% 95%)',// Base
-      secondary: 'hsl(223 16% 83%)',           // Surface0
-      'secondary-foreground': 'hsl(233 10% 47%)', // Subtext0
-      muted: 'hsl(223 16% 83%)',               // Surface0
-      'muted-foreground': 'hsl(231 10% 59%)',  // Overlay1
-      accent: 'hsl(223 16% 83%)',              // Surface0
-      'accent-foreground': 'hsl(234 16% 35%)', // Text
-      destructive: 'hsl(347 87% 44%)',         // Red
-      'destructive-foreground': 'hsl(220 23% 95%)', // Base
-      border: 'hsl(225 14% 77%)',              // Surface1
-      input: 'hsl(225 14% 77%)',               // Surface1
-      ring: 'hsl(231 97% 72%)',                // Lavender
-      sidebar: 'hsl(220 21% 89%)',             // Crust
-      'sidebar-foreground': 'hsl(233 10% 47%)',// Subtext0
-      'sidebar-primary': 'hsl(231 97% 72%)',   // Lavender
-      'sidebar-primary-foreground': 'hsl(220 23% 95%)', // Base
-      'sidebar-accent': 'hsl(223 16% 83%)',    // Surface0
-      'sidebar-accent-foreground': 'hsl(234 16% 35%)', // Text
-      'sidebar-border': 'hsl(225 14% 77%)',    // Surface1
-      'sidebar-ring': 'hsl(231 97% 72%)',      // Lavender
-      celadon: 'hsl(183 74% 35%)',             // Teal
-      'celadon-foreground': 'hsl(220 23% 95%)' // Base
+      background: '#F1F5F9', // Soft slate canvas, less glare than white
+      foreground: '#4B526B', // Soft slate-lavender ink
+      card: '#FFFFFF', // Floating sheet
+      'card-foreground': '#4B526B',
+      popover: '#FFFFFF',
+      'popover-foreground': '#4B526B',
+      primary: '#2563EB', // Calmer electric blue
+      'primary-foreground': '#FFFFFF',
+      secondary: '#F8FAFC',
+      'secondary-foreground': '#5C657A',
+      muted: '#F1F5F9',
+      'muted-foreground': '#6B7488',
+      accent: '#EFF6FF',
+      'accent-foreground': '#4B526B',
+      destructive: '#E11D48', // Instrument red, readable without glare
+      'destructive-foreground': '#FFFFFF',
+      border: '#E2E8F0',
+      input: '#CBD5E1',
+      ring: '#2563EB',
+      sidebar: '#F1F5F9',
+      'sidebar-foreground': '#5C657A',
+      'sidebar-primary': '#2563EB',
+      'sidebar-primary-foreground': '#FFFFFF',
+      'sidebar-accent': '#FFFFFF',
+      'sidebar-accent-foreground': '#4B526B',
+      'sidebar-border': '#E2E8F0',
+      'sidebar-ring': '#2563EB',
+      celadon: '#0FBEA7',
+      'celadon-foreground': '#FFFFFF',
+      'agent-canvas': '#F1F5F9',
+      'agent-sheet': '#FFFFFF',
+      'agent-card': '#FFFFFF',
+      'agent-card-muted': '#F8FAFC',
+      'agent-hover': '#E8EEF7',
+      'agent-shadow-rgb': '15 23 42',
+      'code-block-bg': '#1E293B',
+      'code-block-header': '#172033',
+      'code-block-border': '#334155',
+      'code-block-text': '#E2E8F0',
+      'code-block-muted': '#94A3B8',
+      'code-block-accent': '#7DD3FC',
+      'code-block-warm': '#FCD34D',
+      ink: '#4B526B',
+      steel: '#6B7488',
+      'tech-blue': '#2563EB',
+      'tech-blue-soft': '#EFF6FF',
+      'neon-mint': '#0FBEA7',
+      'neon-mint-soft': '#E9FBF7',
+      'neon-pink': '#E11D48',
+      'neon-pink-soft': '#FFEBF0',
+      'neon-violet': '#6D5BD0',
+      'neon-violet-soft': '#F1EDFF'
     }
   }
 ]

--- a/src/renderer/src/main.tsx
+++ b/src/renderer/src/main.tsx
@@ -2,21 +2,23 @@ import './styles/globals.css'
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App'
-import { applyFontScale } from '@/lib/font-size'
+import { applyTypographySettings } from '@/lib/font-size'
 
-// Apply persisted font scale from localStorage before first paint to avoid flash.
+// Apply persisted typography settings from localStorage before first paint to avoid flash.
 // (Zoom is already applied in preload via webFrame.setZoomFactor.)
 try {
   const stored = localStorage.getItem('hive-settings')
   if (stored) {
     const parsed = JSON.parse(stored)
-    const scale = parsed?.state?.uiFontScale
-    if (typeof scale === 'number' && scale !== 1) {
-      applyFontScale(scale)
-    }
+    applyTypographySettings({
+      uiFontScale: parsed?.state?.uiFontScale,
+      uiFontFamily: parsed?.state?.uiFontFamily,
+      uiCustomFontFamily: parsed?.state?.uiCustomFontFamily,
+      uiFontWeight: parsed?.state?.uiFontWeight
+    })
   }
 } catch {
-  // Ignore — default font sizes will be used
+  // Ignore — default typography will be used
 }
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(

--- a/src/renderer/src/stores/useContextStore.ts
+++ b/src/renderer/src/stores/useContextStore.ts
@@ -58,18 +58,31 @@ const EMPTY_TOKENS: TokenInfo = {
   cacheWrite: 0
 }
 
+const DEFAULT_MODEL_CONTEXT_LIMITS: Record<string, number> = {
+  opus: 200_000,
+  sonnet: 200_000,
+  haiku: 200_000
+}
+
 function resolveModelLimit(
   modelLimits: Record<string, number>,
   model?: SessionModelRef
 ): number | undefined {
   if (!model) return undefined
 
-  for (const alias of getModelAliases(model.modelID)) {
+  const aliases = getModelAliases(model.modelID)
+
+  for (const alias of aliases) {
     const exact = modelLimits[getModelLimitKey(alias, model.providerID)]
     if (typeof exact === 'number' && exact > 0) return exact
 
     const wildcard = modelLimits[getModelLimitKey(alias)]
     if (typeof wildcard === 'number' && wildcard > 0) return wildcard
+  }
+
+  for (const alias of aliases) {
+    const defaultLimit = DEFAULT_MODEL_CONTEXT_LIMITS[alias]
+    if (typeof defaultLimit === 'number' && defaultLimit > 0) return defaultLimit
   }
 
   return undefined

--- a/src/renderer/src/stores/useLayoutStore.ts
+++ b/src/renderer/src/stores/useLayoutStore.ts
@@ -3,6 +3,8 @@ import { persist, createJSONStorage } from 'zustand/middleware'
 
 export type BottomPanelTab = 'setup' | 'run' | 'terminal'
 export type TerminalDock = 'right' | 'bottom'
+export type RightContextTab = 'overview' | 'review' | 'files' | 'tasks' | 'goal'
+export type RightReviewTab = 'changes' | 'diffs' | 'comments'
 
 const LEFT_SIDEBAR_DEFAULT = 240
 const LEFT_SIDEBAR_MIN = 200
@@ -25,6 +27,8 @@ interface LayoutState {
   rightSidebarWidth: number
   rightSidebarCollapsed: boolean
   bottomPanelTab: BottomPanelTab
+  rightContextTab: RightContextTab
+  rightReviewTab: RightReviewTab
   terminalDock: TerminalDock
   bottomDockHeight: number
   ghosttyOverlaySuppressed: boolean
@@ -36,6 +40,8 @@ interface LayoutState {
   toggleRightSidebar: () => void
   setRightSidebarCollapsed: (collapsed: boolean) => void
   setBottomPanelTab: (tab: BottomPanelTab) => void
+  setRightContextTab: (tab: RightContextTab) => void
+  setRightReviewTab: (tab: RightReviewTab) => void
   setTerminalDock: (dock: TerminalDock) => void
   setBottomDockHeight: (height: number) => void
   setGhosttyOverlaySuppressed: (suppressed: boolean) => void
@@ -52,6 +58,8 @@ export const useLayoutStore = create<LayoutState>()(
       rightSidebarWidth: RIGHT_SIDEBAR_DEFAULT,
       rightSidebarCollapsed: false,
       bottomPanelTab: 'terminal' as BottomPanelTab,
+      rightContextTab: 'overview' as RightContextTab,
+      rightReviewTab: 'changes' as RightReviewTab,
       terminalDock: 'right' as TerminalDock,
       bottomDockHeight: BOTTOM_DOCK_HEIGHT_DEFAULT,
       ghosttyOverlaySuppressed: false,
@@ -84,6 +92,14 @@ export const useLayoutStore = create<LayoutState>()(
 
       setBottomPanelTab: (tab: BottomPanelTab) => {
         set({ bottomPanelTab: tab })
+      },
+
+      setRightContextTab: (tab: RightContextTab) => {
+        set({ rightContextTab: tab })
+      },
+
+      setRightReviewTab: (tab: RightReviewTab) => {
+        set({ rightReviewTab: tab })
       },
 
       setTerminalDock: (dock: TerminalDock) => {
@@ -129,6 +145,8 @@ export const useLayoutStore = create<LayoutState>()(
         leftSidebarCollapsed: state.leftSidebarCollapsed,
         rightSidebarWidth: state.rightSidebarWidth,
         rightSidebarCollapsed: state.rightSidebarCollapsed,
+        rightContextTab: state.rightContextTab,
+        rightReviewTab: state.rightReviewTab,
         splitFractionByEntity: state.splitFractionByEntity,
         terminalDock: state.terminalDock,
         bottomDockHeight: state.bottomDockHeight

--- a/src/renderer/src/stores/useLayoutStore.ts
+++ b/src/renderer/src/stores/useLayoutStore.ts
@@ -3,7 +3,7 @@ import { persist, createJSONStorage } from 'zustand/middleware'
 
 export type BottomPanelTab = 'setup' | 'run' | 'terminal'
 export type TerminalDock = 'right' | 'bottom'
-export type RightContextTab = 'overview' | 'review' | 'files' | 'tasks' | 'goal'
+export type RightContextTab = 'overview' | 'review' | 'files' | 'tasks' | 'goal' | 'terminal'
 export type RightReviewTab = 'changes' | 'diffs' | 'comments'
 
 const LEFT_SIDEBAR_DEFAULT = 240

--- a/src/renderer/src/stores/useSessionRuntimeStore.ts
+++ b/src/renderer/src/stores/useSessionRuntimeStore.ts
@@ -17,6 +17,7 @@ import type {
   SharedAgentRuntimeId
 } from '@shared/types/agent-protocol'
 import type { StreamingPart } from '@shared/lib/timeline-types'
+import type { SessionTask } from '@/lib/session-tasks'
 
 // ---------------------------------------------------------------------------
 // Types
@@ -746,6 +747,8 @@ interface SessionRuntimeStoreState {
   interruptQueues: Map<string, InterruptItem[]>
   /** Per-session pending message queue (Phase 5 — composer state machine). */
   pendingMessages: Map<string, PendingMessage[]>
+  /** Per-session latest task snapshot for the right-side context panel. */
+  sessionTasks: Map<string, SessionTask[]>
 }
 
 interface SessionRuntimeStoreActions {
@@ -780,6 +783,11 @@ interface SessionRuntimeStoreActions {
   getInterruptsByType(sessionId: string, type: InterruptType): InterruptItem[]
   clearSessionInterrupts(sessionId: string): void
 
+  // Task snapshot
+  setSessionTasks(sessionId: string, tasks: SessionTask[]): void
+  getSessionTasks(sessionId: string): SessionTask[]
+  clearSessionTasks(sessionId: string): void
+
   // Per-session event dispatch (for SessionView streaming)
   subscribeToSessionEvents(sessionId: string, cb: EventCallback): () => void
   dispatchToSession(sessionId: string, event: CanonicalAgentEvent): void
@@ -806,6 +814,7 @@ export type SessionRuntimeStore = SessionRuntimeStoreState & SessionRuntimeStore
 // references on every call, which would cause useSyncExternalStore (#185) loops.
 const EMPTY_INTERRUPT_QUEUE: InterruptItem[] = []
 const EMPTY_PENDING_MESSAGES: PendingMessage[] = []
+const EMPTY_SESSION_TASKS: SessionTask[] = []
 
 function getDurablePendingMessageApi(): Window['db']['sessionPendingMessage'] | null {
   if (typeof window === 'undefined') return null
@@ -917,6 +926,7 @@ export const useSessionRuntimeStore = create<SessionRuntimeStore>()((set, get) =
   dismissedGoalSignatures: new Map(),
   interruptQueues: new Map(),
   pendingMessages: new Map(),
+  sessionTasks: new Map(),
 
   // -- Session state --
   getSession(sessionId) {
@@ -1104,6 +1114,35 @@ export const useSessionRuntimeStore = create<SessionRuntimeStore>()((set, get) =
       if (!queues.has(sessionId)) return state
       queues.delete(sessionId)
       return { interruptQueues: queues }
+    })
+  },
+
+  // -- Task snapshot --
+  setSessionTasks(sessionId, tasks) {
+    set((state) => {
+      const sessionTasks = new Map(state.sessionTasks)
+      if (tasks.length === 0) {
+        sessionTasks.delete(sessionId)
+      } else {
+        sessionTasks.set(
+          sessionId,
+          tasks.map((task) => ({ ...task }))
+        )
+      }
+      return { sessionTasks }
+    })
+  },
+
+  getSessionTasks(sessionId) {
+    return get().sessionTasks.get(sessionId) ?? EMPTY_SESSION_TASKS
+  },
+
+  clearSessionTasks(sessionId) {
+    set((state) => {
+      if (!state.sessionTasks.has(sessionId)) return state
+      const sessionTasks = new Map(state.sessionTasks)
+      sessionTasks.delete(sessionId)
+      return { sessionTasks }
     })
   },
 
@@ -1385,17 +1424,20 @@ export const useSessionRuntimeStore = create<SessionRuntimeStore>()((set, get) =
       const dismissedGoalSignatures = new Map(state.dismissedGoalSignatures)
       const queues = new Map(state.interruptQueues)
       const pending = new Map(state.pendingMessages)
+      const sessionTasks = new Map(state.sessionTasks)
       sessions.delete(sessionId)
       goals.delete(sessionId)
       dismissedGoalSignatures.delete(sessionId)
       queues.delete(sessionId)
       pending.delete(sessionId)
+      sessionTasks.delete(sessionId)
       return {
         sessions,
         goals,
         dismissedGoalSignatures,
         interruptQueues: queues,
-        pendingMessages: pending
+        pendingMessages: pending,
+        sessionTasks
       }
     })
     _sessionEventCallbacks.delete(sessionId)

--- a/src/renderer/src/stores/useSessionRuntimeStore.ts
+++ b/src/renderer/src/stores/useSessionRuntimeStore.ts
@@ -636,6 +636,7 @@ export interface SessionEventGuardResult {
 }
 
 const _sessionEventGuards = new Map<string, SessionEventGuardState>()
+const _sessionEventGuardIds = new Map<string, { runEpoch: number; eventIds: Set<string> }>()
 const DEFAULT_EVENT_GUARD_STATE: Readonly<SessionEventGuardState> = {
   activeRunEpoch: 0,
   lastAppliedSequence: -1
@@ -647,11 +648,14 @@ export function getSessionEventGuardState(sessionId: string): SessionEventGuardS
 }
 
 export function acceptSessionEvent(
-  event: Pick<CanonicalAgentEvent, 'sessionId' | 'runEpoch' | 'sessionSequence'>
+  event: Pick<CanonicalAgentEvent, 'sessionId' | 'runEpoch' | 'sessionSequence'> & {
+    eventId?: string
+  }
 ): SessionEventGuardResult {
   const current = _sessionEventGuards.get(event.sessionId) ?? DEFAULT_EVENT_GUARD_STATE
   const nextRunEpoch = event.runEpoch
   const nextSequence = event.sessionSequence
+  const nextEventId = event.eventId
 
   if (nextRunEpoch < current.activeRunEpoch) {
     return {
@@ -667,10 +671,23 @@ export function acceptSessionEvent(
       lastAppliedSequence: nextSequence
     }
     _sessionEventGuards.set(event.sessionId, nextState)
+    _sessionEventGuardIds.set(event.sessionId, {
+      runEpoch: nextRunEpoch,
+      eventIds: nextEventId ? new Set([nextEventId]) : new Set()
+    })
     return {
       accepted: true,
       advancedRun: true,
       state: { ...nextState }
+    }
+  }
+
+  const guardIds = _sessionEventGuardIds.get(event.sessionId)
+  if (nextEventId && guardIds?.runEpoch === nextRunEpoch && guardIds.eventIds.has(nextEventId)) {
+    return {
+      accepted: false,
+      advancedRun: false,
+      state: { ...current }
     }
   }
 
@@ -687,6 +704,16 @@ export function acceptSessionEvent(
     lastAppliedSequence: nextSequence
   }
   _sessionEventGuards.set(event.sessionId, nextState)
+  if (nextEventId) {
+    if (guardIds?.runEpoch === nextRunEpoch) {
+      guardIds.eventIds.add(nextEventId)
+    } else {
+      _sessionEventGuardIds.set(event.sessionId, {
+        runEpoch: nextRunEpoch,
+        eventIds: new Set([nextEventId])
+      })
+    }
+  }
   return {
     accepted: true,
     advancedRun: false,
@@ -696,10 +723,12 @@ export function acceptSessionEvent(
 
 export function clearSessionEventGuard(sessionId: string): void {
   _sessionEventGuards.delete(sessionId)
+  _sessionEventGuardIds.delete(sessionId)
 }
 
 export function resetSessionEventGuardsForTests(): void {
   _sessionEventGuards.clear()
+  _sessionEventGuardIds.clear()
 }
 
 // ---------------------------------------------------------------------------
@@ -1374,6 +1403,7 @@ export const useSessionRuntimeStore = create<SessionRuntimeStore>()((set, get) =
     _emptyStreamingBufferSnapshots.delete(sessionId)
     _pendingStreamingBufferFlushes.delete(sessionId)
     _sessionEventGuards.delete(sessionId)
+    _sessionEventGuardIds.delete(sessionId)
     if (hadPending) {
       for (const id of cancelledIds) {
         persistPendingMessageCancel(id)

--- a/src/renderer/src/stores/useSettingsStore.ts
+++ b/src/renderer/src/stores/useSettingsStore.ts
@@ -9,7 +9,7 @@ import {
   type VoiceInputSettings
 } from '@shared/types/voice'
 import { DEFAULT_LOCALE, type AppLocale } from '@/i18n/messages'
-import { applyFontScale } from '@/lib/font-size'
+import { applyTypographySettings, type UiFontFamily, type UiFontWeight } from '@/lib/font-size'
 
 // ==========================================
 // Migration helpers
@@ -31,7 +31,12 @@ export function migrateSettingsShape(raw: Record<string, any>): Record<string, a
 }
 
 // Re-export for convenience
-export { applyFontScale } from '@/lib/font-size'
+export {
+  applyFontScale,
+  applyFontFamily,
+  applyFontWeight,
+  applyTypographySettings
+} from '@/lib/font-size'
 
 // ==========================================
 // Types
@@ -158,6 +163,9 @@ export interface AppSettings {
   // Appearance
   uiZoomLevel: number
   uiFontScale: number
+  uiFontFamily: UiFontFamily
+  uiCustomFontFamily: string
+  uiFontWeight: UiFontWeight
 
   // Voice input
   voiceInput: VoiceInputSettings
@@ -229,9 +237,19 @@ const DEFAULT_SETTINGS: AppSettings = {
   keepAwakeEnabled: false,
   uiZoomLevel: 0,
   uiFontScale: 1,
+  uiFontFamily: 'system',
+  uiCustomFontFamily: '',
+  uiFontWeight: 'regular',
   voiceInput: DEFAULT_VOICE_INPUT_SETTINGS,
   sessionUiV2Enabled: true
 }
+
+const TYPOGRAPHY_SETTING_KEYS = new Set<keyof AppSettings>([
+  'uiFontScale',
+  'uiFontFamily',
+  'uiCustomFontFamily',
+  'uiFontWeight'
+])
 
 function samePatternSet(left: string[], right: string[]): boolean {
   if (left.length !== right.length) return false
@@ -407,6 +425,9 @@ function extractSettings(state: SettingsState): AppSettings {
     keepAwakeEnabled: state.keepAwakeEnabled,
     uiZoomLevel: state.uiZoomLevel,
     uiFontScale: state.uiFontScale,
+    uiFontFamily: state.uiFontFamily,
+    uiCustomFontFamily: state.uiCustomFontFamily,
+    uiFontWeight: state.uiFontWeight,
     voiceInput: state.voiceInput,
     sessionUiV2Enabled: state.sessionUiV2Enabled
   }
@@ -456,6 +477,9 @@ export const useSettingsStore = create<SettingsState>()(
 
       updateSetting: <K extends keyof AppSettings>(key: K, value: AppSettings[K]) => {
         set({ [key]: value } as Partial<SettingsState>)
+        if (TYPOGRAPHY_SETTING_KEYS.has(key)) {
+          applyTypographySettings({ ...get(), [key]: value } as SettingsState)
+        }
         // Persist to database
         const settings = extractSettings({ ...get(), [key]: value } as SettingsState)
         saveToDatabase(settings)
@@ -558,6 +582,7 @@ export const useSettingsStore = create<SettingsState>()(
 
       resetToDefaults: () => {
         set({ ...DEFAULT_SETTINGS })
+        applyTypographySettings(DEFAULT_SETTINGS)
         saveToDatabase(DEFAULT_SETTINGS)
       },
 
@@ -627,6 +652,9 @@ export const useSettingsStore = create<SettingsState>()(
         keepAwakeEnabled: state.keepAwakeEnabled,
         uiZoomLevel: state.uiZoomLevel,
         uiFontScale: state.uiFontScale,
+        uiFontFamily: state.uiFontFamily,
+        uiCustomFontFamily: state.uiCustomFontFamily,
+        uiFontWeight: state.uiFontWeight,
         voiceInput: state.voiceInput,
         sessionUiV2Enabled: state.sessionUiV2Enabled
       }),
@@ -658,11 +686,8 @@ if (typeof window !== 'undefined') {
           window.systemOps.setZoomLevel(zoomLevel)
         }
 
-        // Apply saved font scale (Tailwind CSS variable override)
-        const fontScale = useSettingsStore.getState().uiFontScale
-        if (fontScale !== 1) {
-          applyFontScale(fontScale)
-        }
+        // Apply saved typography settings after DB settings replace persisted cache.
+        applyTypographySettings(useSettingsStore.getState())
       })
   }, 200)
 

--- a/src/renderer/src/styles/globals.css
+++ b/src/renderer/src/styles/globals.css
@@ -33,6 +33,21 @@
   --color-sidebar-ring: var(--sidebar-ring);
   --color-celadon: var(--celadon);
   --color-celadon-foreground: var(--celadon-foreground);
+  --color-agent-canvas: var(--agent-canvas);
+  --color-agent-sheet: var(--agent-sheet);
+  --color-agent-card: var(--agent-card);
+  --color-agent-card-muted: var(--agent-card-muted);
+  --color-agent-hover: var(--agent-hover);
+  --color-ink: var(--ink);
+  --color-steel: var(--steel);
+  --color-tech-blue: var(--tech-blue);
+  --color-tech-blue-soft: var(--tech-blue-soft);
+  --color-neon-mint: var(--neon-mint);
+  --color-neon-mint-soft: var(--neon-mint-soft);
+  --color-neon-pink: var(--neon-pink);
+  --color-neon-pink-soft: var(--neon-pink-soft);
+  --color-neon-violet: var(--neon-violet);
+  --color-neon-violet-soft: var(--neon-violet-soft);
   --radius-sm: calc(var(--radius) - 4px);
   --radius-md: calc(var(--radius) - 2px);
   --radius-lg: var(--radius);
@@ -41,104 +56,150 @@
 
 :root {
   --radius: 0.5rem;
-  /* Light theme defaults — Catppuccin Latte */
-  --background: hsl(220 23% 95%);
-  --foreground: hsl(234 16% 35%);
-  --card: hsl(220 22% 92%);
-  --card-foreground: hsl(234 16% 35%);
-  --popover: hsl(220 22% 92%);
-  --popover-foreground: hsl(234 16% 35%);
-  --primary: hsl(231 97% 72%);
-  --primary-foreground: hsl(220 23% 95%);
-  --secondary: hsl(223 16% 83%);
-  --secondary-foreground: hsl(233 10% 47%);
-  --muted: hsl(223 16% 83%);
-  --muted-foreground: hsl(231 10% 59%);
-  --accent: hsl(223 16% 83%);
-  --accent-foreground: hsl(234 16% 35%);
-  --destructive: hsl(347 87% 44%);
-  --destructive-foreground: hsl(220 23% 95%);
-  --border: hsl(225 14% 77%);
-  --input: hsl(225 14% 77%);
-  --ring: hsl(231 97% 72%);
+  /* Light theme defaults — Nordic Crisp Tech */
+  --background: #f1f5f9;
+  --foreground: #4b526b;
+  --card: #ffffff;
+  --card-foreground: #4b526b;
+  --popover: #ffffff;
+  --popover-foreground: #4b526b;
+  --primary: #2563eb;
+  --primary-foreground: #ffffff;
+  --secondary: #f8fafc;
+  --secondary-foreground: #5c657a;
+  --muted: #f1f5f9;
+  --muted-foreground: #6b7488;
+  --accent: #eff6ff;
+  --accent-foreground: #4b526b;
+  --destructive: #e11d48;
+  --destructive-foreground: #ffffff;
+  --border: #e2e8f0;
+  --input: #cbd5e1;
+  --ring: #2563eb;
   --chart-1: oklch(64.62% 0.171 250.71);
   --chart-2: oklch(60.04% 0.118 184.7);
   --chart-3: oklch(39.87% 0.07 227.39);
   --chart-4: oklch(74.37% 0.144 85.12);
   --chart-5: oklch(64.47% 0.222 41.12);
-  --sidebar: hsl(220 21% 89%);
-  --sidebar-foreground: hsl(233 10% 47%);
-  --sidebar-primary: hsl(231 97% 72%);
-  --sidebar-primary-foreground: hsl(220 23% 95%);
-  --sidebar-accent: hsl(223 16% 83%);
-  --sidebar-accent-foreground: hsl(234 16% 35%);
-  --sidebar-border: hsl(225 14% 77%);
-  --sidebar-ring: hsl(231 97% 72%);
+  --sidebar: #f1f5f9;
+  --sidebar-foreground: #5c657a;
+  --sidebar-primary: #2563eb;
+  --sidebar-primary-foreground: #ffffff;
+  --sidebar-accent: #ffffff;
+  --sidebar-accent-foreground: #4b526b;
+  --sidebar-border: #e2e8f0;
+  --sidebar-ring: #2563eb;
+  --agent-canvas: #f1f5f9;
+  --agent-sheet: #ffffff;
+  --agent-card: #ffffff;
+  --agent-card-muted: #f8fafc;
+  --agent-hover: #e8eef7;
+  --agent-shadow-rgb: 15 23 42;
+  --code-block-bg: #1e293b;
+  --code-block-header: #172033;
+  --code-block-border: #334155;
+  --code-block-text: #e2e8f0;
+  --code-block-muted: #94a3b8;
+  --code-block-accent: #7dd3fc;
+  --code-block-warm: #fcd34d;
+  --ink: #4b526b;
+  --steel: #6b7488;
+  --tech-blue: #2563eb;
+  --tech-blue-soft: #eff6ff;
+  --neon-mint: #0fbea7;
+  --neon-mint-soft: #e9fbf7;
+  --neon-pink: #e11d48;
+  --neon-pink-soft: #ffebf0;
+  --neon-violet: #6d5bd0;
+  --neon-violet-soft: #f1edff;
 }
 
 .dark {
-  /* Dark theme defaults — Catppuccin Mocha */
-  --background: hsl(240 21% 15%);
-  --foreground: hsl(226 64% 88%);
-  --card: hsl(240 21% 12%);
-  --card-foreground: hsl(226 64% 88%);
-  --popover: hsl(240 21% 12%);
-  --popover-foreground: hsl(226 64% 88%);
-  --primary: hsl(232 97% 85%);
-  --primary-foreground: hsl(240 23% 9%);
-  --secondary: hsl(237 16% 23%);
-  --secondary-foreground: hsl(228 24% 72%);
-  --muted: hsl(237 16% 23%);
-  --muted-foreground: hsl(230 13% 55%);
-  --accent: hsl(237 16% 23%);
-  --accent-foreground: hsl(226 64% 88%);
-  --destructive: hsl(343 81% 75%);
-  --destructive-foreground: hsl(240 23% 9%);
-  --border: hsl(234 13% 31%);
-  --input: hsl(234 13% 31%);
-  --ring: hsl(232 97% 85%);
+  /* Dark theme defaults — Nordic Night Tech */
+  --background: #101827;
+  --foreground: #c3cbe0;
+  --card: #151f2f;
+  --card-foreground: #c3cbe0;
+  --popover: #151f2f;
+  --popover-foreground: #c3cbe0;
+  --primary: #7aa7ff;
+  --primary-foreground: #08111f;
+  --secondary: #1a2436;
+  --secondary-foreground: #a9b3c8;
+  --muted: #1a2436;
+  --muted-foreground: #8994aa;
+  --accent: #22304a;
+  --accent-foreground: #c3cbe0;
+  --destructive: #fb7185;
+  --destructive-foreground: #2a0712;
+  --border: #2a364a;
+  --input: #334155;
+  --ring: #7aa7ff;
   --chart-1: oklch(70.34% 0.127 227.39);
   --chart-2: oklch(69.26% 0.128 184.7);
   --chart-3: oklch(98.48% 0.001 285.98);
   --chart-4: oklch(74.11% 0.164 68.11);
   --chart-5: oklch(65.91% 0.204 41.12);
-  --sidebar: hsl(240 23% 9%);
-  --sidebar-foreground: hsl(228 24% 72%);
-  --sidebar-primary: hsl(232 97% 85%);
-  --sidebar-primary-foreground: hsl(240 23% 9%);
-  --sidebar-accent: hsl(237 16% 23%);
-  --sidebar-accent-foreground: hsl(226 64% 88%);
-  --sidebar-border: hsl(234 13% 31%);
-  --sidebar-ring: hsl(232 97% 85%);
+  --sidebar: #0f1724;
+  --sidebar-foreground: #a9b3c8;
+  --sidebar-primary: #7aa7ff;
+  --sidebar-primary-foreground: #08111f;
+  --sidebar-accent: #151f2f;
+  --sidebar-accent-foreground: #c3cbe0;
+  --sidebar-border: #263247;
+  --sidebar-ring: #7aa7ff;
+  --agent-canvas: #101827;
+  --agent-sheet: #121c2b;
+  --agent-card: #151f2f;
+  --agent-card-muted: #1a2436;
+  --agent-hover: #253247;
+  --agent-shadow-rgb: 0 0 0;
+  --code-block-bg: #131c2b;
+  --code-block-header: #101827;
+  --code-block-border: #263247;
+  --code-block-text: #cbd5e1;
+  --code-block-muted: #8492a8;
+  --code-block-accent: #8bc7ff;
+  --code-block-warm: #f6d36b;
+  --ink: #c3cbe0;
+  --steel: #8994aa;
+  --tech-blue: #7aa7ff;
+  --tech-blue-soft: #172a48;
+  --neon-mint: #2dd4bf;
+  --neon-mint-soft: #123834;
+  --neon-pink: #fb7185;
+  --neon-pink-soft: #3f1725;
+  --neon-violet: #b29dff;
+  --neon-violet-soft: #30294b;
 }
 
 /* Session-specific semantic tokens */
 :root {
-  --streaming-cursor: hsl(231 97% 72%);
-  --thinking-bg: hsl(223 16% 83%);
-  --tool-bg: hsl(223 16% 83%);
-  --compaction-bg: hsl(35 77% 95%);
-  --compaction-border: hsl(35 77% 75%);
+  --streaming-cursor: var(--tech-blue);
+  --thinking-bg: var(--agent-card-muted);
+  --tool-bg: var(--agent-card-muted);
+  --compaction-bg: #fff7ed;
+  --compaction-border: #fdba74;
   --provider-claude: #fe640b;
   --provider-opencode: #179299;
   --provider-codex: #209fb5;
   --provider-terminal: #8c8fa1;
-  --celadon: hsl(183 74% 35%);
-  --celadon-foreground: hsl(220 23% 95%);
+  --celadon: var(--neon-mint);
+  --celadon-foreground: #001a16;
 }
 
 .dark {
-  --streaming-cursor: hsl(232 97% 85%);
-  --thinking-bg: hsl(237 16% 23%);
-  --tool-bg: hsl(237 16% 23%);
-  --compaction-bg: hsl(41 86% 15%);
-  --compaction-border: hsl(41 86% 25%);
+  --streaming-cursor: var(--tech-blue);
+  --thinking-bg: var(--agent-card-muted);
+  --tool-bg: var(--agent-card-muted);
+  --compaction-bg: #2b2634;
+  --compaction-border: #6f5632;
   --provider-claude: #fab387;
   --provider-opencode: #94e2d5;
   --provider-codex: #74c7ec;
   --provider-terminal: #7f849c;
-  --celadon: hsl(170 57% 73%);
-  --celadon-foreground: hsl(240 23% 9%);
+  --celadon: var(--neon-mint);
+  --celadon-foreground: #08111f;
 }
 
 @layer base {
@@ -147,9 +208,47 @@
   }
   body {
     @apply bg-background text-foreground;
+    background-image:
+      radial-gradient(
+        circle at 12% -8%,
+        color-mix(in srgb, var(--tech-blue-soft) 28%, transparent),
+        transparent 28rem
+      ),
+      radial-gradient(
+        circle at 88% 8%,
+        color-mix(in srgb, var(--neon-mint-soft) 18%, transparent),
+        transparent 24rem
+      ),
+      linear-gradient(180deg, #f5f8fb, var(--background));
+    font-family: var(
+      --xuanpu-ui-font-family,
+      ui-sans-serif,
+      system-ui,
+      -apple-system,
+      BlinkMacSystemFont,
+      'Segoe UI',
+      sans-serif
+    );
+    font-weight: var(--xuanpu-ui-font-weight, 400);
     font-feature-settings:
       'rlig' 1,
       'calt' 1;
+    line-height: 1.55;
+  }
+
+  .dark body {
+    background-image:
+      radial-gradient(
+        circle at 12% -8%,
+        color-mix(in srgb, var(--tech-blue-soft) 24%, transparent),
+        transparent 28rem
+      ),
+      radial-gradient(
+        circle at 88% 8%,
+        color-mix(in srgb, var(--neon-mint-soft) 12%, transparent),
+        transparent 24rem
+      ),
+      linear-gradient(180deg, #101827, var(--agent-canvas));
   }
 
   /* Native-feeling scrollbars — thin, transparent, theme-aware */
@@ -187,6 +286,154 @@
 
   ::-webkit-scrollbar-corner {
     background: transparent;
+  }
+}
+
+@layer components {
+  .crisp-floating-surface {
+    background: color-mix(in srgb, var(--agent-card) 98%, transparent);
+    border: 1px solid color-mix(in srgb, var(--border) 92%, transparent);
+    box-shadow:
+      0 12px 30px -12px rgb(var(--agent-shadow-rgb) / 0.07),
+      0 10px 15px -3px rgb(var(--agent-shadow-rgb) / 0.05),
+      0 4px 6px -4px rgb(var(--agent-shadow-rgb) / 0.05),
+      0 1px 0 rgb(255 255 255 / 0.72) inset;
+  }
+
+  .crisp-panel-surface {
+    background: var(--agent-card);
+    border: 1px solid color-mix(in srgb, var(--border) 90%, transparent);
+    box-shadow: 0 1px 0 rgb(255 255 255 / 0.58) inset;
+  }
+
+  .crisp-subtle-shadow {
+    box-shadow: 0 1px 3px 0 rgb(var(--agent-shadow-rgb) / 0.05);
+  }
+
+  .crisp-status-dot {
+    box-shadow: 0 0 8px color-mix(in srgb, currentColor 70%, transparent);
+  }
+
+  .crisp-soft-border {
+    border-color: color-mix(in srgb, var(--border) 88%, transparent);
+  }
+
+  .crisp-readable {
+    line-height: 1.6;
+  }
+
+  .crisp-strong-title {
+    color: var(--ink);
+    font-weight: 650;
+    letter-spacing: -0.012em;
+  }
+
+  .crisp-active-row {
+    position: relative;
+    background: color-mix(in srgb, var(--tech-blue-soft) 70%, var(--sidebar-accent));
+    color: var(--sidebar-accent-foreground);
+    box-shadow:
+      inset 0 0 0 1px color-mix(in srgb, var(--tech-blue) 12%, var(--sidebar-border)),
+      0 6px 18px -14px color-mix(in srgb, var(--tech-blue) 45%, transparent);
+  }
+
+  .crisp-active-row::before {
+    content: '';
+    position: absolute;
+    left: 0.35rem;
+    top: 0.62rem;
+    bottom: 0.62rem;
+    width: 0.125rem;
+    border-radius: 999px;
+    background: var(--sidebar-primary);
+    box-shadow: 0 0 8px color-mix(in srgb, var(--tech-blue) 44%, transparent);
+  }
+
+  .crisp-parent-active-row {
+    position: relative;
+    background: color-mix(in srgb, var(--tech-blue-soft) 42%, var(--sidebar-accent));
+    color: var(--sidebar-accent-foreground);
+    box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--tech-blue) 8%, var(--sidebar-border));
+  }
+
+  .dark .crisp-floating-surface {
+    background: color-mix(in srgb, var(--agent-card) 92%, transparent);
+    border-color: color-mix(in srgb, var(--border) 62%, transparent);
+    box-shadow:
+      0 14px 36px -26px rgb(0 0 0 / 0.78),
+      0 1px 0 rgb(255 255 255 / 0.03) inset;
+  }
+
+  .dark .crisp-panel-surface {
+    background: color-mix(in srgb, var(--agent-card) 94%, transparent);
+    border-color: color-mix(in srgb, var(--border) 64%, transparent);
+    box-shadow: 0 1px 0 rgb(255 255 255 / 0.024) inset;
+  }
+
+  .dark .crisp-active-row {
+    background: color-mix(in srgb, var(--tech-blue-soft) 46%, var(--sidebar-accent));
+    box-shadow:
+      inset 0 0 0 1px color-mix(in srgb, var(--tech-blue) 14%, var(--sidebar-border)),
+      0 8px 22px -18px color-mix(in srgb, var(--tech-blue) 48%, transparent);
+  }
+
+  .dark .crisp-active-row::before {
+    box-shadow: 0 0 6px color-mix(in srgb, var(--tech-blue) 36%, transparent);
+  }
+
+  .dark .crisp-parent-active-row {
+    background: color-mix(in srgb, var(--tech-blue-soft) 14%, var(--sidebar-accent));
+    box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--tech-blue) 5%, var(--sidebar-border));
+  }
+
+  .crisp-hover-row:hover {
+    background: color-mix(in srgb, var(--agent-hover) 68%, transparent);
+  }
+
+  .dark .crisp-hover-row:hover {
+    background: color-mix(in srgb, var(--agent-hover) 42%, transparent);
+  }
+
+  .crisp-composer-veil {
+    background: linear-gradient(
+      180deg,
+      transparent 0%,
+      color-mix(in srgb, var(--agent-canvas) 42%, transparent) 34%,
+      color-mix(in srgb, var(--agent-canvas) 90%, transparent) 100%
+    );
+    -webkit-backdrop-filter: blur(16px);
+    backdrop-filter: blur(16px);
+    mask-image: linear-gradient(180deg, transparent 0%, black 34%, black 100%);
+  }
+
+  .crisp-voice-surface {
+    border-color: color-mix(in srgb, var(--neon-mint) 48%, var(--border));
+    background: color-mix(in srgb, var(--neon-mint-soft) 42%, var(--agent-card));
+    box-shadow:
+      0 0 0 1px color-mix(in srgb, var(--neon-mint) 18%, transparent),
+      0 0 18px color-mix(in srgb, var(--neon-mint) 16%, transparent);
+  }
+
+  .dark .crisp-voice-surface {
+    border-color: color-mix(in srgb, var(--neon-mint) 28%, var(--border));
+    background: color-mix(in srgb, var(--neon-mint-soft) 24%, var(--agent-card));
+    box-shadow:
+      0 0 0 1px color-mix(in srgb, var(--neon-mint) 10%, transparent),
+      0 0 18px color-mix(in srgb, var(--neon-mint) 9%, transparent);
+  }
+
+  .crisp-voice-aura {
+    background:
+      radial-gradient(
+        circle at 18% 0%,
+        color-mix(in srgb, var(--neon-mint) 18%, transparent),
+        transparent 30%
+      ),
+      radial-gradient(
+        circle at 82% 100%,
+        color-mix(in srgb, var(--tech-blue) 12%, transparent),
+        transparent 34%
+      );
   }
 }
 
@@ -244,24 +491,24 @@
 }
 
 .dark .diff-viewer .d2h-file-header {
-  background-color: hsl(var(--muted));
-  border-color: hsl(var(--border));
+  background-color: var(--muted);
+  border-color: var(--border);
 }
 
 .dark .diff-viewer .d2h-file-header,
 .dark .diff-viewer .d2h-file-name {
-  color: hsl(var(--foreground));
+  color: var(--foreground);
 }
 
 .dark .diff-viewer .d2h-code-line,
 .dark .diff-viewer .d2h-code-side-line {
-  background-color: hsl(var(--background));
+  background-color: var(--background);
 }
 
 .dark .diff-viewer .d2h-code-linenumber {
-  background-color: hsl(var(--muted));
-  color: hsl(var(--muted-foreground));
-  border-color: hsl(var(--border));
+  background-color: var(--muted);
+  color: var(--muted-foreground);
+  border-color: var(--border);
 }
 
 /* Dark mode — added lines: green tinted background (text color from syntax highlighting) */
@@ -298,21 +545,21 @@
 }
 
 .dark .diff-viewer .d2h-info {
-  background-color: hsl(var(--muted));
-  color: hsl(var(--muted-foreground));
-  border-color: hsl(var(--border));
+  background-color: var(--muted);
+  color: var(--muted-foreground);
+  border-color: var(--border);
 }
 
 .dark .diff-viewer .d2h-file-diff {
-  border-color: hsl(var(--border));
+  border-color: var(--border);
 }
 
 .dark .diff-viewer .d2h-diff-table {
-  border-color: hsl(var(--border));
+  border-color: var(--border);
 }
 
 .dark .diff-viewer .d2h-diff-tbody tr {
-  border-color: hsl(var(--border));
+  border-color: var(--border);
 }
 
 /* Ensure line numbers and content align properly */

--- a/src/shared/lib/timeline-types.ts
+++ b/src/shared/lib/timeline-types.ts
@@ -70,6 +70,8 @@ export interface TimelineMessage {
   content: string
   timestamp: string
   steered?: boolean
+  /** Local-only delivery hint for optimistic user messages that are not durable yet. */
+  deliveryStatus?: 'queued' | 'sending' | 'failed'
   parts?: StreamingPart[]
   /** File attachments for user messages (images, PDFs, etc.) */
   attachments?: MessagePart[]

--- a/test/context-panel/context-panel-host-tabs.test.tsx
+++ b/test/context-panel/context-panel-host-tabs.test.tsx
@@ -1,0 +1,119 @@
+import { act, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ContextPanelHost } from '@/components/context-panel/ContextPanelHost'
+import { useLayoutStore } from '@/stores/useLayoutStore'
+import { useSessionStore } from '@/stores/useSessionStore'
+import { useSettingsStore } from '@/stores/useSettingsStore'
+import type { TimelineMessage } from '@shared/lib/timeline-types'
+
+vi.mock('@/components/file-tree/FileTree', () => ({
+  FileTree: () => <div data-testid="file-tree">FileTree</div>
+}))
+
+vi.mock('@/components/file-tree/ChangesView', () => ({
+  ChangesView: () => <div data-testid="changes-view">ChangesView</div>
+}))
+
+vi.mock('@/components/file-tree/BranchDiffView', () => ({
+  BranchDiffView: () => <div data-testid="branch-diff-view">BranchDiffView</div>
+}))
+
+vi.mock('@/components/diff-comments/DiffCommentsViewer', () => ({
+  DiffCommentsViewer: () => <div data-testid="diff-comments-viewer">DiffCommentsViewer</div>
+}))
+
+vi.mock('@/components/pr-review/PrReviewViewer', () => ({
+  PrReviewViewer: () => <div data-testid="pr-review-viewer">PrReviewViewer</div>
+}))
+
+function renderHost(): void {
+  render(<ContextPanelHost worktreePath="/tmp/worktree" onClose={vi.fn()} onFileClick={vi.fn()} />)
+}
+
+function todoTimeline(): TimelineMessage[] {
+  return [
+    {
+      id: 'assistant-1',
+      role: 'assistant',
+      content: '',
+      timestamp: '2026-05-21T00:00:00.000Z',
+      parts: [
+        {
+          type: 'tool_use',
+          toolUse: {
+            id: 'todo-1',
+            name: 'TodoWrite',
+            status: 'success',
+            startTime: 1,
+            input: {
+              todos: [
+                { id: 'task-1', content: 'Move tasks into the context panel', status: 'completed' }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  ]
+}
+
+describe('ContextPanelHost', () => {
+  beforeEach(() => {
+    useLayoutStore.setState({
+      rightContextTab: 'overview',
+      rightReviewTab: 'changes'
+    })
+    useSessionStore.setState({
+      activeSessionId: null,
+      inlineConnectionSessionId: null
+    })
+    useSettingsStore.setState({ vimModeEnabled: true })
+    Object.defineProperty(window, 'agentOps', {
+      configurable: true,
+      writable: true,
+      value: {
+        getTimeline: vi.fn().mockResolvedValue({ messages: [] })
+      }
+    })
+  })
+
+  it('switches between overview, review, and files without owning terminal state', async () => {
+    const user = userEvent.setup()
+    useSessionStore.setState({ activeSessionId: 'sess-overview' })
+    renderHost()
+
+    expect(screen.getByTestId('context-panel-overview')).toBeInTheDocument()
+
+    await user.click(screen.getByTestId('context-panel-tab-review'))
+    expect(screen.getByTestId('changes-view')).toBeInTheDocument()
+
+    await user.click(screen.getByTestId('context-panel-tab-files'))
+    expect(screen.getByTestId('file-tree')).toBeInTheDocument()
+  })
+
+  it('keeps vim right-sidebar tab events compatible with review sub-tabs', () => {
+    renderHost()
+
+    act(() => {
+      window.dispatchEvent(new CustomEvent('hive:right-sidebar-tab', { detail: { tab: 'diffs' } }))
+    })
+
+    expect(screen.getByTestId('branch-diff-view')).toBeInTheDocument()
+    expect(useLayoutStore.getState().rightContextTab).toBe('review')
+    expect(useLayoutStore.getState().rightReviewTab).toBe('diffs')
+  })
+
+  it('renders latest session tasks from the shared timeline extraction helper', async () => {
+    const user = userEvent.setup()
+    useSessionStore.setState({ activeSessionId: 'sess-1' })
+    window.agentOps.getTimeline = vi.fn().mockResolvedValue({ messages: todoTimeline() })
+
+    renderHost()
+    await user.click(screen.getByTestId('context-panel-tab-tasks'))
+
+    await waitFor(() => {
+      expect(screen.getByText('Move tasks into the context panel')).toBeInTheDocument()
+    })
+  })
+})

--- a/test/context-panel/context-panel-host-tabs.test.tsx
+++ b/test/context-panel/context-panel-host-tabs.test.tsx
@@ -7,7 +7,11 @@ import { useSessionStore } from '@/stores/useSessionStore'
 import { useSettingsStore } from '@/stores/useSettingsStore'
 import { useContextStore } from '@/stores/useContextStore'
 import { useSessionRuntimeStore } from '@/stores/useSessionRuntimeStore'
+import { useProjectStore } from '@/stores/useProjectStore'
+import { useWorktreeStore } from '@/stores/useWorktreeStore'
+import { useGitStore } from '@/stores/useGitStore'
 import type { TimelineMessage } from '@shared/lib/timeline-types'
+import type React from 'react'
 
 vi.mock('@/components/file-tree/FileTree', () => ({
   FileTree: () => <div data-testid="file-tree">FileTree</div>
@@ -29,8 +33,16 @@ vi.mock('@/components/pr-review/PrReviewViewer', () => ({
   PrReviewViewer: () => <div data-testid="pr-review-viewer">PrReviewViewer</div>
 }))
 
-function renderHost(): void {
-  render(<ContextPanelHost worktreePath="/tmp/worktree" onClose={vi.fn()} onFileClick={vi.fn()} />)
+function renderHost(options: { terminalPanel?: React.ReactNode } = {}): void {
+  render(
+    <ContextPanelHost
+      worktreePath="/tmp/worktree"
+      scopeId="wt-1"
+      onClose={vi.fn()}
+      onFileClick={vi.fn()}
+      terminalPanel={options.terminalPanel}
+    />
+  )
 }
 
 function todoTimeline(): TimelineMessage[] {
@@ -71,6 +83,25 @@ describe('ContextPanelHost', () => {
       inlineConnectionSessionId: null
     })
     useSettingsStore.setState({ vimModeEnabled: true })
+    useProjectStore.setState({
+      projects: [],
+      selectedProjectId: null
+    })
+    useWorktreeStore.setState({
+      selectedWorktreeId: null,
+      worktreesByProject: new Map()
+    })
+    useGitStore.setState({
+      remoteInfo: new Map(),
+      prTargetBranch: new Map(),
+      reviewTargetBranch: new Map(),
+      prCreation: new Map(),
+      attachedPR: new Map(),
+      branchInfoByWorktree: new Map(),
+      fileStatusesByWorktree: new Map(),
+      isPushing: false,
+      isPulling: false
+    })
     useContextStore.setState({
       tokensBySession: {},
       modelBySession: {},
@@ -101,6 +132,33 @@ describe('ContextPanelHost', () => {
         fetchSessionSummary: vi.fn().mockResolvedValue({ success: false })
       }
     })
+    Object.defineProperty(window, 'db', {
+      configurable: true,
+      writable: true,
+      value: {
+        session: {
+          getByWorktree: vi.fn().mockResolvedValue([]),
+          getByConnection: vi.fn().mockResolvedValue([])
+        }
+      }
+    })
+    Object.defineProperty(window, 'gitOps', {
+      configurable: true,
+      writable: true,
+      value: {
+        listBranchesWithStatus: vi.fn().mockResolvedValue({ success: true, branches: [] }),
+        listPRs: vi.fn().mockResolvedValue({ success: true, prs: [] }),
+        getPRState: vi.fn().mockResolvedValue({ success: false }),
+        prMerge: vi.fn().mockResolvedValue({ success: true })
+      }
+    })
+    Object.defineProperty(window, 'fileOps', {
+      configurable: true,
+      writable: true,
+      value: {
+        readPrompt: vi.fn().mockResolvedValue({ success: false })
+      }
+    })
   })
 
   it('switches between overview, review, and files without owning terminal state', async () => {
@@ -117,6 +175,52 @@ describe('ContextPanelHost', () => {
     expect(screen.getByTestId('file-tree')).toBeInTheDocument()
   })
 
+  it('keeps the content area on the left and the vertical rail on the right', () => {
+    useSessionStore.setState({ activeSessionId: 'sess-overview' })
+    renderHost()
+
+    const host = screen.getByTestId('context-panel-host')
+    expect(host.children[0]).toBe(screen.getByTestId('context-panel-content'))
+    expect(host.children[1]).toBe(screen.getByTestId('context-panel-rail'))
+    expect(screen.getByTestId('context-panel-tab-overview')).toHaveAttribute(
+      'aria-label',
+      'Overview'
+    )
+  })
+
+  it('shows the terminal entry only when a right-docked terminal panel is provided', async () => {
+    const user = userEvent.setup()
+    renderHost({ terminalPanel: <div data-testid="context-panel-terminal">Terminal panel</div> })
+
+    await user.click(screen.getByTestId('context-panel-tab-terminal'))
+
+    expect(screen.getByTestId('context-panel-terminal')).toBeInTheDocument()
+  })
+
+  it('keeps the terminal panel mounted while switching away and back', async () => {
+    const user = userEvent.setup()
+    renderHost({ terminalPanel: <div data-testid="context-panel-terminal">Terminal panel</div> })
+
+    await user.click(screen.getByTestId('context-panel-tab-terminal'))
+
+    const terminalContent = screen.getByTestId('context-panel-terminal-content')
+    expect(screen.getByTestId('context-panel-terminal')).toBeInTheDocument()
+    expect(terminalContent).not.toHaveClass('hidden')
+    expect(terminalContent).toHaveAttribute('aria-hidden', 'false')
+
+    await user.click(screen.getByTestId('context-panel-tab-overview'))
+
+    expect(screen.getByTestId('context-panel-terminal')).toBeInTheDocument()
+    expect(terminalContent).toHaveClass('hidden')
+    expect(terminalContent).toHaveAttribute('aria-hidden', 'true')
+
+    await user.click(screen.getByTestId('context-panel-tab-terminal'))
+
+    expect(screen.getByTestId('context-panel-terminal')).toBeInTheDocument()
+    expect(terminalContent).not.toHaveClass('hidden')
+    expect(terminalContent).toHaveAttribute('aria-hidden', 'false')
+  })
+
   it('keeps vim right-sidebar tab events compatible with review sub-tabs', () => {
     renderHost()
 
@@ -127,6 +231,82 @@ describe('ContextPanelHost', () => {
     expect(screen.getByTestId('branch-diff-view')).toBeInTheDocument()
     expect(useLayoutStore.getState().rightContextTab).toBe('review')
     expect(useLayoutStore.getState().rightReviewTab).toBe('diffs')
+  })
+
+  it('keeps AI review and PR actions inside the review context panel', async () => {
+    const user = userEvent.setup()
+    useProjectStore.setState({
+      projects: [
+        {
+          id: 'proj-1',
+          name: 'Project',
+          path: '/tmp/project',
+          description: null,
+          tags: null,
+          language: null,
+          custom_icon: null,
+          setup_script: null,
+          run_script: null,
+          archive_script: null,
+          auto_assign_port: false,
+          sort_order: 0,
+          created_at: '2026-05-21T00:00:00.000Z',
+          last_accessed_at: '2026-05-21T00:00:00.000Z'
+        }
+      ],
+      selectedProjectId: 'proj-1'
+    })
+    useWorktreeStore.setState({
+      selectedWorktreeId: 'wt-1',
+      worktreesByProject: new Map([
+        [
+          'proj-1',
+          [
+            {
+              id: 'wt-1',
+              project_id: 'proj-1',
+              name: 'feature',
+              branch_name: 'feature',
+              path: '/tmp/worktree',
+              status: 'active',
+              is_default: false,
+              branch_renamed: 0,
+              last_message_at: null,
+              session_titles: '[]',
+              last_model_provider_id: null,
+              last_model_id: null,
+              last_model_variant: null,
+              created_at: '2026-05-21T00:00:00.000Z',
+              last_accessed_at: '2026-05-21T00:00:00.000Z',
+              github_pr_number: null,
+              github_pr_url: null
+            }
+          ]
+        ]
+      ])
+    })
+    useGitStore.setState({
+      remoteInfo: new Map([
+        ['wt-1', { hasRemote: true, isGitHub: true, url: 'git@github.com:org/repo.git' }]
+      ]),
+      branchInfoByWorktree: new Map([
+        ['/tmp/worktree', { name: 'feature', tracking: 'origin/main', ahead: 0, behind: 0 }]
+      ])
+    })
+    window.gitOps.listBranchesWithStatus = vi.fn().mockResolvedValue({
+      success: true,
+      branches: [{ name: 'origin/main', isRemote: true }]
+    })
+
+    renderHost()
+    await user.click(screen.getByTestId('context-panel-tab-review'))
+
+    expect(screen.getByTestId('context-panel-review-actions')).toBeInTheDocument()
+    expect(screen.getByTestId('review-button')).toHaveTextContent('AI Review')
+    expect(screen.getByTestId('review-target-branch-trigger')).toHaveTextContent('origin/main')
+    expect(screen.getByTestId('pr-section')).toBeInTheDocument()
+    expect(screen.getByTestId('pr-button')).toBeInTheDocument()
+    expect(screen.getByTestId('pr-target-branch-trigger')).toHaveTextContent('origin/main')
   })
 
   it('renders latest session tasks from the shared timeline extraction helper', async () => {
@@ -185,34 +365,80 @@ describe('ContextPanelHost', () => {
     })
   })
 
-  it('shows cumulative usage summary in the overview panel', async () => {
-    useSessionStore.setState({ activeSessionId: 'sess-usage' })
-    window.usageAnalyticsOps.fetchSessionSummary = vi.fn().mockResolvedValue({
-      success: true,
-      data: {
-        session_id: 'sess-usage',
-        engine: 'codex',
-        total_cost: 0.0234,
-        total_tokens: 12_000,
-        input_tokens: 3_000,
-        output_tokens: 7_000,
-        cache_write_tokens: 500,
-        cache_read_tokens: 1_500,
-        duration_seconds: 120,
-        last_used_at: '2026-05-21T00:00:00.000Z',
-        model_labels: [],
-        latest_model_label: null,
-        partial: false
+  it('shows worktree-wide cumulative usage summary in the overview panel', async () => {
+    const sessions = ['sess-usage-a', 'sess-usage-b'].map((id, index) => ({
+      id,
+      worktree_id: 'wt-1',
+      project_id: 'proj-1',
+      connection_id: null,
+      name: `Session ${index + 1}`,
+      status: 'active' as const,
+      opencode_session_id: `runtime-${index + 1}`,
+      agent_sdk: 'codex' as const,
+      mode: 'build' as const,
+      model_provider_id: null,
+      model_id: null,
+      model_variant: null,
+      first_message_at: null,
+      created_at: '2026-05-21T00:00:00.000Z',
+      updated_at: '2026-05-21T00:00:00.000Z',
+      completed_at: null
+    }))
+    useSessionStore.setState({
+      activeSessionId: 'sess-usage-a',
+      activeWorktreeId: 'wt-1',
+      sessionsByWorktree: new Map([['wt-1', sessions]]),
+      tabOrderByWorktree: new Map([['wt-1', sessions.map((session) => session.id)]])
+    })
+    window.db.session.getByWorktree = vi.fn().mockResolvedValue(sessions)
+    window.usageAnalyticsOps.fetchSessionSummary = vi.fn(async (sessionId: string) => {
+      const dataBySession = {
+        'sess-usage-a': {
+          session_id: 'sess-usage-a',
+          engine: 'codex',
+          total_cost: 0.0234,
+          total_tokens: 12_000,
+          input_tokens: 3_000,
+          output_tokens: 7_000,
+          cache_write_tokens: 500,
+          cache_read_tokens: 1_500
+        },
+        'sess-usage-b': {
+          session_id: 'sess-usage-b',
+          engine: 'codex',
+          total_cost: 0.033,
+          total_tokens: 5_500,
+          input_tokens: 1_100,
+          output_tokens: 2_200,
+          cache_write_tokens: 700,
+          cache_read_tokens: 1_500
+        }
+      } as const
+      const data = dataBySession[sessionId as keyof typeof dataBySession]
+      return {
+        success: !!data,
+        data: data
+          ? {
+              ...data,
+              duration_seconds: 120,
+              last_used_at: '2026-05-21T00:00:00.000Z',
+              model_labels: [],
+              latest_model_label: null,
+              partial: false
+            }
+          : undefined
       }
     })
 
     renderHost()
 
     await waitFor(() => {
-      expect(screen.getByText('$0.02')).toBeInTheDocument()
-      expect(screen.getByText('12.0K')).toBeInTheDocument()
+      expect(screen.getByText('$0.06')).toBeInTheDocument()
+      expect(screen.getByText('17.5K')).toBeInTheDocument()
+      expect(screen.getByText('4.1K')).toBeInTheDocument()
+      expect(screen.getByText('9.2K')).toBeInTheDocument()
       expect(screen.getByText('3.0K')).toBeInTheDocument()
-      expect(screen.getByText('1.5K')).toBeInTheDocument()
+      expect(screen.getByText('2 sessions in this Worktree')).toBeInTheDocument()
     })
   })
 })

--- a/test/context-panel/context-panel-host-tabs.test.tsx
+++ b/test/context-panel/context-panel-host-tabs.test.tsx
@@ -5,6 +5,8 @@ import { ContextPanelHost } from '@/components/context-panel/ContextPanelHost'
 import { useLayoutStore } from '@/stores/useLayoutStore'
 import { useSessionStore } from '@/stores/useSessionStore'
 import { useSettingsStore } from '@/stores/useSettingsStore'
+import { useContextStore } from '@/stores/useContextStore'
+import { useSessionRuntimeStore } from '@/stores/useSessionRuntimeStore'
 import type { TimelineMessage } from '@shared/lib/timeline-types'
 
 vi.mock('@/components/file-tree/FileTree', () => ({
@@ -69,11 +71,34 @@ describe('ContextPanelHost', () => {
       inlineConnectionSessionId: null
     })
     useSettingsStore.setState({ vimModeEnabled: true })
+    useContextStore.setState({
+      tokensBySession: {},
+      modelBySession: {},
+      contextSnapshotsBySession: {},
+      costBySession: {},
+      costEventKeysBySession: {},
+      modelLimits: {}
+    })
+    useSessionRuntimeStore.setState({
+      sessions: new Map(),
+      goals: new Map(),
+      dismissedGoalSignatures: new Map(),
+      interruptQueues: new Map(),
+      pendingMessages: new Map(),
+      sessionTasks: new Map()
+    })
     Object.defineProperty(window, 'agentOps', {
       configurable: true,
       writable: true,
       value: {
         getTimeline: vi.fn().mockResolvedValue({ messages: [] })
+      }
+    })
+    Object.defineProperty(window, 'usageAnalyticsOps', {
+      configurable: true,
+      writable: true,
+      value: {
+        fetchSessionSummary: vi.fn().mockResolvedValue({ success: false })
       }
     })
   })
@@ -114,6 +139,80 @@ describe('ContextPanelHost', () => {
 
     await waitFor(() => {
       expect(screen.getByText('Move tasks into the context panel')).toBeInTheDocument()
+    })
+  })
+
+  it('prefers live task snapshots over the persisted timeline in the tasks panel', async () => {
+    const user = userEvent.setup()
+    useSessionStore.setState({ activeSessionId: 'sess-live' })
+    useSessionRuntimeStore.getState().setSessionTasks('sess-live', [
+      {
+        id: 'live-task',
+        content: 'Live task from streaming update',
+        status: 'in_progress'
+      }
+    ])
+    window.agentOps.getTimeline = vi.fn().mockResolvedValue({ messages: todoTimeline() })
+
+    renderHost()
+    await user.click(screen.getByTestId('context-panel-tab-tasks'))
+
+    expect(screen.getByText('Live task from streaming update')).toBeInTheDocument()
+    expect(screen.queryByText('Move tasks into the context panel')).not.toBeInTheDocument()
+  })
+
+  it('renders and dismisses completed goals from the right goal panel', async () => {
+    const user = userEvent.setup()
+    useSessionStore.setState({ activeSessionId: 'sess-goal' })
+    useSessionRuntimeStore.getState().setSessionGoal('sess-goal', {
+      threadId: 'thread-1',
+      objective: 'Ship infra polish',
+      successCriteria: 'Tasks, goal, and overview live in the context panel',
+      status: 'completed',
+      createdAt: 10,
+      updatedAt: 20
+    })
+
+    renderHost()
+    await user.click(screen.getByTestId('context-panel-tab-goal'))
+
+    expect(screen.getByTestId('goal-status-card')).toHaveTextContent('Ship infra polish')
+    await user.click(screen.getByTestId('goal-dismiss-button'))
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('goal-status-card')).not.toBeInTheDocument()
+      expect(screen.getByText('No goal set')).toBeInTheDocument()
+    })
+  })
+
+  it('shows cumulative usage summary in the overview panel', async () => {
+    useSessionStore.setState({ activeSessionId: 'sess-usage' })
+    window.usageAnalyticsOps.fetchSessionSummary = vi.fn().mockResolvedValue({
+      success: true,
+      data: {
+        session_id: 'sess-usage',
+        engine: 'codex',
+        total_cost: 0.0234,
+        total_tokens: 12_000,
+        input_tokens: 3_000,
+        output_tokens: 7_000,
+        cache_write_tokens: 500,
+        cache_read_tokens: 1_500,
+        duration_seconds: 120,
+        last_used_at: '2026-05-21T00:00:00.000Z',
+        model_labels: [],
+        latest_model_label: null,
+        partial: false
+      }
+    })
+
+    renderHost()
+
+    await waitFor(() => {
+      expect(screen.getByText('$0.02')).toBeInTheDocument()
+      expect(screen.getByText('12.0K')).toBeInTheDocument()
+      expect(screen.getByText('3.0K')).toBeInTheDocument()
+      expect(screen.getByText('1.5K')).toBeInTheDocument()
     })
   })
 })

--- a/test/context-panel/session-task-extraction.test.ts
+++ b/test/context-panel/session-task-extraction.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, test } from 'vitest'
+import { extractMissionTasks } from '@/lib/session-tasks'
+import type { TimelineMessage, ToolUseInfo } from '@shared/lib/timeline-types'
+
+function toolUse(name: string, input: Record<string, unknown>): ToolUseInfo {
+  return {
+    id: `${name}-1`,
+    name,
+    input,
+    status: 'success',
+    startTime: 1
+  }
+}
+
+function message(
+  id: string,
+  role: TimelineMessage['role'],
+  toolName: string,
+  input: Record<string, unknown>
+): TimelineMessage {
+  return {
+    id,
+    role,
+    content: '',
+    timestamp: '2026-05-21T00:00:00.000Z',
+    parts: [
+      {
+        type: 'tool_use',
+        toolUse: toolUse(toolName, input)
+      }
+    ]
+  }
+}
+
+describe('extractMissionTasks', () => {
+  test('extracts tasks from the latest assistant TodoWrite snapshot', () => {
+    const messages: TimelineMessage[] = [
+      message('old', 'assistant', 'TodoWrite', {
+        todos: [{ id: 'old-1', content: 'Old task', status: 'completed' }]
+      }),
+      message('latest', 'assistant', 'mcp_todowrite', {
+        todos: [
+          { id: 'task-1', content: 'Read current implementation', status: 'completed' },
+          { id: 'task-2', content: 'Extract helper', status: 'in_progress' }
+        ]
+      })
+    ]
+
+    expect(extractMissionTasks(messages)).toEqual([
+      { id: 'task-1', content: 'Read current implementation', status: 'completed' },
+      { id: 'task-2', content: 'Extract helper', status: 'in_progress' }
+    ])
+  })
+
+  test('supports update_plan and existing fallback fields', () => {
+    const messages: TimelineMessage[] = [
+      message('plan', 'assistant', 'update_plan', {
+        todos: [
+          { subject: 'Subject fallback', status: 'pending' },
+          { activeForm: 'Active form fallback' }
+        ]
+      })
+    ]
+
+    expect(extractMissionTasks(messages)).toEqual([
+      { id: 'todo-0', content: 'Subject fallback', status: 'pending' },
+      { id: 'todo-1', content: 'Active form fallback', status: 'pending' }
+    ])
+  })
+
+  test('ignores non-assistant and non-TodoWrite tool parts', () => {
+    const messages: TimelineMessage[] = [
+      message('user-tool', 'user', 'TodoWrite', {
+        todos: [{ id: 'user-task', content: 'Ignore user role', status: 'pending' }]
+      }),
+      message('write', 'assistant', 'Write', {
+        todos: [{ id: 'write-task', content: 'Ignore write tool', status: 'pending' }]
+      })
+    ]
+
+    expect(extractMissionTasks(messages)).toEqual([])
+  })
+
+  test('continues scanning when the latest TodoWrite has no todos array', () => {
+    const messages: TimelineMessage[] = [
+      message('valid', 'assistant', 'todo_write', {
+        todos: [{ id: 'valid-task', content: 'Use older valid snapshot', status: 'completed' }]
+      }),
+      message('invalid', 'assistant', 'TodoWrite', {
+        todos: null
+      })
+    ]
+
+    expect(extractMissionTasks(messages)).toEqual([
+      { id: 'valid-task', content: 'Use older valid snapshot', status: 'completed' }
+    ])
+  })
+})

--- a/test/phase-11/session-9/file-sidebar-tabs.test.ts
+++ b/test/phase-11/session-9/file-sidebar-tabs.test.ts
@@ -25,13 +25,16 @@ describe('Session 9: File Sidebar Tabs', () => {
       expect(content).toBeTruthy()
     })
 
-    test('renders two tabs: Changes and Files', () => {
+    test('renders file/review tabs through i18n labels', () => {
       const content = readFile('FileSidebar.tsx')
       expect(content).toContain("'changes'")
       expect(content).toContain("'files'")
-      // Tab text content inside button elements
-      expect(content).toMatch(/>\s*Changes\s*/)
-      expect(content).toMatch(/>\s*Files\s*/)
+      expect(content).toContain("'diffs'")
+      expect(content).toContain("'comments'")
+      expect(content).toContain("t('fileTree.sidebar.changes')")
+      expect(content).toContain("t('fileTree.sidebar.files')")
+      expect(content).toContain("t('fileTree.sidebar.diffs')")
+      expect(content).toContain("t('fileTree.sidebar.comments')")
       expect(content).toContain("setActiveTab('changes')")
       expect(content).toContain("setActiveTab('files')")
     })
@@ -39,7 +42,7 @@ describe('Session 9: File Sidebar Tabs', () => {
     test('defaults to Changes tab', () => {
       const content = readFile('FileSidebar.tsx')
       // useState defaults to 'changes'
-      expect(content).toContain("useState<'changes' | 'files'>('changes')")
+      expect(content).toContain("useState<'changes' | 'files' | 'diffs' | 'comments'>('changes')")
     })
 
     test('Changes tab embeds ChangesView', () => {
@@ -73,13 +76,12 @@ describe('Session 9: File Sidebar Tabs', () => {
       const content = readFile('FileSidebar.tsx')
       expect(content).toContain('onClose')
       expect(content).toContain('<X')
-      expect(content).toContain('aria-label="Close sidebar"')
+      expect(content).toContain("aria-label={t('fileTree.sidebar.closeSidebar')}")
     })
 
-    test('active tab has underline indicator', () => {
+    test('active tab has selected sidebar accent styles', () => {
       const content = readFile('FileSidebar.tsx')
-      // Active tab should have a bottom border indicator
-      expect(content).toContain('h-0.5 bg-primary')
+      expect(content).toContain('bg-sidebar-accent text-sidebar-accent-foreground')
     })
   })
 
@@ -132,11 +134,11 @@ describe('Session 9: File Sidebar Tabs', () => {
   })
 
   describe('RightSidebar integration', () => {
-    test('RightSidebar uses FileSidebar as the entire top half', () => {
+    test('RightSidebar hosts file views through ContextPanelHost', () => {
       const rightSidebarPath = path.join(fileTreeDir, '..', 'layout', 'RightSidebar.tsx')
       const content = fs.readFileSync(rightSidebarPath, 'utf-8')
-      expect(content).toContain('FileSidebar')
-      expect(content).toContain('<FileSidebar')
+      expect(content).toContain('ContextPanelHost')
+      expect(content).toContain('<ContextPanelHost')
       // Should NOT directly render FileTree or GitStatusPanel anymore
       expect(content).not.toContain('<FileTree')
       expect(content).not.toContain('<GitStatusPanel')

--- a/test/phase-13/session-1/markdown-codeblock.test.ts
+++ b/test/phase-13/session-1/markdown-codeblock.test.ts
@@ -80,17 +80,16 @@ describe('Session 1: Markdown Code Block Fix', () => {
   })
 
   describe('inline code is unaffected', () => {
-    test('inline code renders with bg-muted styling', () => {
+    test('inline code renders with neutral card-muted styling', () => {
       const content = readMarkdownRenderer()
-      expect(content).toContain(
-        '<code className="bg-muted px-1.5 py-0.5 rounded text-sm font-mono">'
-      )
+      expect(content).toContain('bg-agent-card-muted')
+      expect(content).toContain('font-mono text-sm text-ink')
     })
 
     test('inline code uses children directly (not content variable)', () => {
       const content = readMarkdownRenderer()
       // The inline code path should still render {children} directly
-      expect(content).toContain('rounded text-sm font-mono">{children}</code>')
+      expect(content).toContain('{children}')
     })
   })
 
@@ -133,7 +132,14 @@ describe('Session 1: Markdown Code Block Fix', () => {
       // And CodeBlock preserves whitespace via <pre> tag
       const codeBlock = readCodeBlock()
       expect(codeBlock).toContain('<pre')
-      expect(codeBlock).toContain('<code>{containsAnsi(code) ? <Ansi>{code}</Ansi> : code}</code>')
+      expect(codeBlock).toContain('<code>{renderCodeContent(code, language)}</code>')
+    })
+
+    test('shell code receives lightweight command highlighting', () => {
+      const codeBlock = readCodeBlock()
+      expect(codeBlock).toContain('const SHELL_LANGUAGES')
+      expect(codeBlock).toContain('function renderShellCode')
+      expect(codeBlock).toContain('text-[var(--code-block-accent)]')
     })
   })
 })

--- a/test/phase-13/session-9/integration-verification.test.ts
+++ b/test/phase-13/session-9/integration-verification.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, beforeAll, beforeEach, vi, afterEach } from 'vitest'
+import { describe, test, expect, vi, afterEach } from 'vitest'
 import { render, screen, cleanup } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import React from 'react'
@@ -44,14 +44,15 @@ describe('Session 9: Integration & Verification', () => {
     test('inline code is unaffected by the fix', () => {
       const source = readSource('src/renderer/src/components/sessions/MarkdownRenderer.tsx')
       // Inline code still uses the simple <code> element
-      expect(source).toContain('bg-muted px-1.5 py-0.5 rounded text-sm font-mono')
-      expect(source).toContain('{children}</code>')
+      expect(source).toContain('bg-agent-card-muted')
+      expect(source).toContain('font-mono text-sm text-ink')
+      expect(source).toContain('{children}')
     })
 
     test('CodeBlock component preserves whitespace with pre tag', () => {
       const source = readSource('src/renderer/src/components/sessions/CodeBlock.tsx')
       expect(source).toContain('<pre')
-      expect(source).toContain('<code>')
+      expect(source).toContain('<code>{renderCodeContent(code, language)}</code>')
       expect(source).toContain('data-testid="code-block"')
     })
   })
@@ -209,15 +210,15 @@ describe('Session 9: Integration & Verification', () => {
   describe('S5: Refresh project context menu', () => {
     test('ProjectItem has Refresh Project menu item', () => {
       const source = readSource('src/renderer/src/components/projects/ProjectItem.tsx')
-      expect(source).toContain('Refresh Project')
+      expect(source).toContain('projectItem.menu.refreshProject')
       expect(source).toContain('handleRefreshProject')
-      expect(source).toContain("toast.success('Project refreshed')")
+      expect(source).toContain("toast.success(t('projectItem.toasts.refreshed'))")
     })
 
     test('Refresh Project appears after Refresh Language', () => {
       const source = readSource('src/renderer/src/components/projects/ProjectItem.tsx')
-      const langIndex = source.indexOf('Refresh Language')
-      const projectIndex = source.indexOf('Refresh Project')
+      const langIndex = source.indexOf('projectItem.menu.refreshLanguage')
+      const projectIndex = source.indexOf('projectItem.menu.refreshProject')
       expect(langIndex).toBeGreaterThan(-1)
       expect(projectIndex).toBeGreaterThan(-1)
       expect(projectIndex).toBeGreaterThan(langIndex)
@@ -233,9 +234,9 @@ describe('Session 9: Integration & Verification', () => {
   // ─── S6: Quick Action Buttons ──────────────────────────────────────────────
 
   describe('S6: Quick actions are all accessible', () => {
-    test('has four individual buttons with data-testid attributes', () => {
+    test('has individual buttons with data-testid attributes', () => {
       const source = readSource('src/renderer/src/components/layout/QuickActions.tsx')
-      expect(source).toContain('data-testid="quick-action-cursor"')
+      expect(source).toContain('data-testid="quick-action-editor"')
       expect(source).toContain('data-testid="quick-action-terminal"')
       expect(source).toContain('data-testid="quick-action-copy-path"')
       expect(source).toContain('data-testid="quick-action-finder"')
@@ -249,9 +250,9 @@ describe('Session 9: Integration & Verification', () => {
       expect(source).not.toContain('ChevronDown')
     })
 
-    test('Cursor button has label and terminal label is dynamic', () => {
+    test('editor and terminal labels are dynamic', () => {
       const source = readSource('src/renderer/src/components/layout/QuickActions.tsx')
-      expect(source).toContain('<span>Cursor</span>')
+      expect(source).toContain('<span>{editorLabel}</span>')
       expect(source).toContain('<span>{terminalLabel}</span>')
     })
 
@@ -302,9 +303,10 @@ describe('Session 9: Integration & Verification', () => {
       expect(source).toMatch(/>Xuanpu<\/span>/)
     })
 
-    test('header layout includes QuickActions in center', () => {
+    test('header layout uses merged topbar tabs instead of legacy QuickActions slot', () => {
       const source = readSource('src/renderer/src/components/layout/Header.tsx')
-      expect(source).toContain('<QuickActions')
+      expect(source).toContain('<SessionTabs variant="topbar" />')
+      expect(source).not.toContain('<QuickActions')
     })
 
     test('long names are truncated', () => {
@@ -397,8 +399,10 @@ describe('Session 9: Integration & Verification', () => {
 
     test('git:init IPC handler exists in project-handlers', () => {
       const source = readSource('src/main/ipc/project-handlers.ts')
+      const serviceSource = readSource('src/main/services/project-ops.ts')
       expect(source).toContain("'git:init'")
-      expect(source).toContain('git init --initial-branch=main')
+      expect(source).toContain('return initRepository(path)')
+      expect(serviceSource).toContain('git init --initial-branch=main')
     })
 
     test('initRepository is exposed in preload bridge', () => {
@@ -446,10 +450,11 @@ describe('Session 9: Integration & Verification', () => {
   })
 
   describe('Cross-feature: Quick Actions + Header layout', () => {
-    test('QuickActions is rendered inside Header', () => {
+    test('QuickActions is no longer rendered inside the merged Header topbar', () => {
       const source = readSource('src/renderer/src/components/layout/Header.tsx')
-      expect(source).toContain('<QuickActions')
-      expect(source).toContain("import { QuickActions } from './QuickActions'")
+      expect(source).toContain('<SessionTabs variant="topbar" />')
+      expect(source).not.toContain('<QuickActions')
+      expect(source).not.toContain("import { QuickActions } from './QuickActions'")
     })
 
     test('QuickActions uses same worktree store as Header', () => {

--- a/test/phase-18/session-11/pr-github-frontend.test.tsx
+++ b/test/phase-18/session-11/pr-github-frontend.test.tsx
@@ -2,7 +2,7 @@
  * Session 11: PR to GitHub — Frontend Tests
  *
  * Testing criteria from phase-18.md:
- * - PR button visible when isGitHub is true
+ * - PR button visible in the Review context panel when isGitHub is true
  * - PR button hidden when isGitHub is false
  * - handleCreatePR creates session with correct prompt
  * - Target branch dropdown shows remote branches
@@ -12,9 +12,31 @@
 import { describe, test, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { useGitStore } from '../../../src/renderer/src/stores/useGitStore'
+import { useLayoutStore } from '../../../src/renderer/src/stores/useLayoutStore'
+import { useProjectStore } from '../../../src/renderer/src/stores/useProjectStore'
 import { useWorktreeStore } from '../../../src/renderer/src/stores/useWorktreeStore'
 import { useSessionStore } from '../../../src/renderer/src/stores/useSessionStore'
-import { GitPushPull } from '../../../src/renderer/src/components/git/GitPushPull'
+import { ContextPanelHost } from '../../../src/renderer/src/components/context-panel/ContextPanelHost'
+
+vi.mock('../../../src/renderer/src/components/file-tree/FileTree', () => ({
+  FileTree: () => <div data-testid="file-tree">FileTree</div>
+}))
+
+vi.mock('../../../src/renderer/src/components/file-tree/ChangesView', () => ({
+  ChangesView: () => <div data-testid="changes-view">ChangesView</div>
+}))
+
+vi.mock('../../../src/renderer/src/components/file-tree/BranchDiffView', () => ({
+  BranchDiffView: () => <div data-testid="branch-diff-view">BranchDiffView</div>
+}))
+
+vi.mock('../../../src/renderer/src/components/diff-comments/DiffCommentsViewer', () => ({
+  DiffCommentsViewer: () => <div data-testid="diff-comments-viewer">DiffCommentsViewer</div>
+}))
+
+vi.mock('../../../src/renderer/src/components/pr-review/PrReviewViewer', () => ({
+  PrReviewViewer: () => <div data-testid="pr-review-viewer">PrReviewViewer</div>
+}))
 
 const mockWorktree = {
   id: 'wt-1',
@@ -27,12 +49,54 @@ const mockWorktree = {
   branch_renamed: 0,
   last_message_at: null,
   session_titles: '[]',
+  last_model_provider_id: null,
+  last_model_id: null,
+  last_model_variant: null,
+  last_agent_sdk: null,
+  attachments: '[]',
+  pinned: 0,
+  context: null,
+  github_pr_number: null,
+  github_pr_url: null,
   created_at: '2025-01-01T00:00:00.000Z',
   last_accessed_at: '2025-01-01T00:00:00.000Z'
 }
 
+const mockProject = {
+  id: 'proj-1',
+  name: 'Project',
+  path: '/test/project',
+  description: null,
+  tags: null,
+  language: null,
+  custom_icon: null,
+  setup_script: null,
+  run_script: null,
+  archive_script: null,
+  auto_assign_port: false,
+  sort_order: 0,
+  created_at: '2025-01-01T00:00:00.000Z',
+  last_accessed_at: '2025-01-01T00:00:00.000Z'
+}
+
+function renderReviewPanel(): void {
+  render(<ContextPanelHost worktreePath="/test/path" onClose={vi.fn()} onFileClick={vi.fn()} />)
+}
+
 beforeEach(() => {
   // Reset stores
+  useLayoutStore.setState({
+    rightContextTab: 'review',
+    rightReviewTab: 'changes'
+  })
+  useProjectStore.setState({
+    projects: [mockProject],
+    selectedProjectId: 'proj-1'
+  })
+  useWorktreeStore.setState({
+    selectedWorktreeId: 'wt-1',
+    worktreesByProject: new Map([['proj-1', [mockWorktree]]])
+  })
   useGitStore.setState({
     remoteInfo: new Map(),
     prTargetBranch: new Map(),
@@ -59,7 +123,19 @@ beforeEach(() => {
       }),
       push: vi.fn().mockResolvedValue({ success: true }),
       pull: vi.fn().mockResolvedValue({ success: true }),
-      merge: vi.fn().mockResolvedValue({ success: true })
+      merge: vi.fn().mockResolvedValue({ success: true }),
+      listPRs: vi.fn().mockResolvedValue({ success: true, prs: [] }),
+      getPRState: vi.fn().mockResolvedValue({ success: false }),
+      prMerge: vi.fn().mockResolvedValue({ success: true })
+    }
+  })
+
+  Object.defineProperty(window, 'fileOps', {
+    writable: true,
+    configurable: true,
+    value: {
+      ...window.fileOps,
+      readPrompt: vi.fn().mockResolvedValue({ success: false })
     }
   })
 })
@@ -67,8 +143,9 @@ beforeEach(() => {
 describe('Session 11: PR to GitHub Frontend', () => {
   describe('PR button visibility', () => {
     test('PR button visible when isGitHub is true', () => {
-      useWorktreeStore.setState({ selectedWorktreeId: 'wt-1' })
       useGitStore.setState({
+        prCreation: new Map(),
+        attachedPR: new Map(),
         remoteInfo: new Map([
           ['wt-1', { hasRemote: true, isGitHub: true, url: 'git@github.com:org/repo.git' }]
         ]),
@@ -77,20 +154,19 @@ describe('Session 11: PR to GitHub Frontend', () => {
         ])
       })
 
-      render(<GitPushPull worktreePath="/test/path" />)
+      renderReviewPanel()
 
       expect(screen.getByTestId('pr-button')).toBeInTheDocument()
     })
 
     test('PR button hidden when isGitHub is false', () => {
-      useWorktreeStore.setState({ selectedWorktreeId: 'wt-1' })
       useGitStore.setState({
         remoteInfo: new Map([
           ['wt-1', { hasRemote: true, isGitHub: false, url: 'https://gitlab.com/org/repo.git' }]
         ])
       })
 
-      render(<GitPushPull worktreePath="/test/path" />)
+      renderReviewPanel()
 
       expect(screen.queryByTestId('pr-button')).not.toBeInTheDocument()
     })
@@ -101,28 +177,27 @@ describe('Session 11: PR to GitHub Frontend', () => {
         remoteInfo: new Map()
       })
 
-      render(<GitPushPull worktreePath="/test/path" />)
+      renderReviewPanel()
 
       expect(screen.queryByTestId('pr-button')).not.toBeInTheDocument()
     })
 
     test('PR button hidden when no worktree selected', () => {
-      useWorktreeStore.setState({ selectedWorktreeId: null })
+      useWorktreeStore.setState({ selectedWorktreeId: null, worktreesByProject: new Map() })
 
-      render(<GitPushPull worktreePath="/test/path" />)
+      renderReviewPanel()
 
       expect(screen.queryByTestId('pr-button')).not.toBeInTheDocument()
     })
 
     test('PR section has correct data-testid', () => {
-      useWorktreeStore.setState({ selectedWorktreeId: 'wt-1' })
       useGitStore.setState({
         remoteInfo: new Map([
           ['wt-1', { hasRemote: true, isGitHub: true, url: 'git@github.com:org/repo.git' }]
         ])
       })
 
-      render(<GitPushPull worktreePath="/test/path" />)
+      renderReviewPanel()
 
       expect(screen.getByTestId('pr-section')).toBeInTheDocument()
     })
@@ -130,8 +205,9 @@ describe('Session 11: PR to GitHub Frontend', () => {
 
   describe('Target branch dropdown', () => {
     test('displays default target branch from tracking', () => {
-      useWorktreeStore.setState({ selectedWorktreeId: 'wt-1' })
       useGitStore.setState({
+        prCreation: new Map(),
+        attachedPR: new Map(),
         remoteInfo: new Map([
           ['wt-1', { hasRemote: true, isGitHub: true, url: 'git@github.com:org/repo.git' }]
         ]),
@@ -140,15 +216,16 @@ describe('Session 11: PR to GitHub Frontend', () => {
         ])
       })
 
-      render(<GitPushPull worktreePath="/test/path" />)
+      renderReviewPanel()
 
       const trigger = screen.getByTestId('pr-target-branch-trigger')
       expect(trigger.textContent).toContain('origin/develop')
     })
 
     test('displays custom target branch when set', () => {
-      useWorktreeStore.setState({ selectedWorktreeId: 'wt-1' })
       useGitStore.setState({
+        prCreation: new Map(),
+        attachedPR: new Map(),
         remoteInfo: new Map([
           ['wt-1', { hasRemote: true, isGitHub: true, url: 'git@github.com:org/repo.git' }]
         ]),
@@ -158,14 +235,13 @@ describe('Session 11: PR to GitHub Frontend', () => {
         ])
       })
 
-      render(<GitPushPull worktreePath="/test/path" />)
+      renderReviewPanel()
 
       const trigger = screen.getByTestId('pr-target-branch-trigger')
       expect(trigger.textContent).toContain('origin/release')
     })
 
     test('displays fallback origin/main when no tracking branch', () => {
-      useWorktreeStore.setState({ selectedWorktreeId: 'wt-1' })
       useGitStore.setState({
         remoteInfo: new Map([
           ['wt-1', { hasRemote: true, isGitHub: true, url: 'git@github.com:org/repo.git' }]
@@ -175,7 +251,7 @@ describe('Session 11: PR to GitHub Frontend', () => {
         ])
       })
 
-      render(<GitPushPull worktreePath="/test/path" />)
+      renderReviewPanel()
 
       const trigger = screen.getByTestId('pr-target-branch-trigger')
       expect(trigger.textContent).toContain('origin/main')
@@ -217,7 +293,7 @@ describe('Session 11: PR to GitHub Frontend', () => {
         ])
       })
 
-      render(<GitPushPull worktreePath="/test/path" />)
+      renderReviewPanel()
 
       const prButton = screen.getByTestId('pr-button')
       fireEvent.click(prButton)
@@ -227,7 +303,7 @@ describe('Session 11: PR to GitHub Frontend', () => {
       })
 
       await waitFor(() => {
-        expect(updateSessionNameMock).toHaveBeenCalledWith('new-session-1', 'PR → origin/main')
+        expect(updateSessionNameMock).toHaveBeenCalledWith('new-session-1', 'PR -> origin/main')
       })
 
       await waitFor(() => {
@@ -236,6 +312,11 @@ describe('Session 11: PR to GitHub Frontend', () => {
           expect.stringContaining('gh pr create')
         )
       })
+
+      await waitFor(() => {
+        expect(useGitStore.getState().prCreation.get('wt-1')?.creating).toBe(true)
+      })
+      useGitStore.getState().setPrCreation('wt-1', null)
     })
 
     test('prompt includes custom target branch when set', async () => {
@@ -267,13 +348,13 @@ describe('Session 11: PR to GitHub Frontend', () => {
         ])
       })
 
-      render(<GitPushPull worktreePath="/test/path" />)
+      renderReviewPanel()
 
       const prButton = screen.getByTestId('pr-button')
       fireEvent.click(prButton)
 
       await waitFor(() => {
-        expect(updateSessionNameMock).toHaveBeenCalledWith('new-session-2', 'PR → origin/release')
+        expect(updateSessionNameMock).toHaveBeenCalledWith('new-session-2', 'PR -> origin/release')
       })
 
       await waitFor(() => {
@@ -282,13 +363,18 @@ describe('Session 11: PR to GitHub Frontend', () => {
           expect.stringContaining('origin/release')
         )
       })
+
+      await waitFor(() => {
+        expect(useGitStore.getState().prCreation.get('wt-1')?.creating).toBe(true)
+      })
+      useGitStore.getState().setPrCreation('wt-1', null)
     })
 
     test('PR button not shown when no worktree selected', () => {
       useWorktreeStore.setState({ selectedWorktreeId: null })
 
       // When no selectedWorktreeId, isGitHub will be false, so button won't render
-      render(<GitPushPull worktreePath="/test/path" />)
+      renderReviewPanel()
 
       expect(screen.queryByTestId('pr-button')).not.toBeInTheDocument()
     })
@@ -320,7 +406,7 @@ describe('Session 11: PR to GitHub Frontend', () => {
         ])
       })
 
-      render(<GitPushPull worktreePath="/test/path" />)
+      renderReviewPanel()
 
       const prButton = screen.getByTestId('pr-button')
       fireEvent.click(prButton)
@@ -368,9 +454,9 @@ describe('Session 11: PR to GitHub Frontend', () => {
 
     test('session name includes target branch', () => {
       const targetBranch = 'origin/main'
-      const sessionName = `PR → ${targetBranch}`
+      const sessionName = `PR -> ${targetBranch}`
 
-      expect(sessionName).toBe('PR → origin/main')
+      expect(sessionName).toBe('PR -> origin/main')
     })
   })
 })

--- a/test/phase-19/session-8/tab-context-ui.test.tsx
+++ b/test/phase-19/session-8/tab-context-ui.test.tsx
@@ -12,7 +12,7 @@ import { SessionTabs } from '../../../src/renderer/src/components/sessions/Sessi
  * Session 8: Tab Context Menus — UI
  *
  * Tests verify:
- * 1. Session tab context menu has Close, Close Others, Close Others to the Right
+ * 1. Session tab context menu has Rename, Copy Resume ID, Close, Close Others, Close Others to the Right
  * 2. File tab context menu has close actions + Copy Relative Path, Copy Absolute Path
  * 3. Diff tab context menu has same items as file tabs
  * 4. Context menu actions call the correct store methods
@@ -79,7 +79,8 @@ function setupStores({
     project_id: projectId,
     name: `Session ${i + 1}`,
     status: 'active' as const,
-    opencode_session_id: null,
+    opencode_session_id: `runtime-${i + 1}`,
+    agent_sdk: 'claude-code' as const,
     mode: 'build' as const,
     model_provider_id: null,
     model_id: null,
@@ -204,24 +205,30 @@ describe('Session 8: Tab Context Menus UI', () => {
 
       await waitFor(() => {
         expect(screen.getByText('Rename')).toBeInTheDocument()
+        expect(screen.getByText('Copy Resume ID')).toBeInTheDocument()
         expect(screen.getByText('Close')).toBeInTheDocument()
         expect(screen.getByText('Close Others')).toBeInTheDocument()
         expect(screen.getByText('Close Others to the Right')).toBeInTheDocument()
       })
     })
 
-    test('session tab context menu does NOT have copy path items', async () => {
+    test('Copy Resume ID copies the runtime session id', async () => {
       render(<SessionTabs />)
 
       const tab = screen.getByTestId('session-tab-s1')
       fireEvent.contextMenu(tab)
 
       await waitFor(() => {
-        expect(screen.getByText('Close')).toBeInTheDocument()
+        expect(screen.getByText('Copy Resume ID')).toBeInTheDocument()
       })
-
       expect(screen.queryByText('Copy Relative Path')).not.toBeInTheDocument()
       expect(screen.queryByText('Copy Absolute Path')).not.toBeInTheDocument()
+
+      fireEvent.click(screen.getByText('Copy Resume ID'))
+
+      await waitFor(() => {
+        expect(navigator.clipboard.writeText).toHaveBeenCalledWith('runtime-1')
+      })
     })
 
     test('double-click opens inline edit input and saves new session name', async () => {

--- a/test/phase-23/agent-event-bridge-run-epoch.test.ts
+++ b/test/phase-23/agent-event-bridge-run-epoch.test.ts
@@ -197,6 +197,30 @@ function makePartEvent(
   }
 }
 
+function makeMessageUpdatedEvent(
+  sessionId: string,
+  runEpoch: number,
+  sessionSequence: number,
+  eventId: string
+): CanonicalAgentEvent {
+  return {
+    type: 'message.updated',
+    sessionId,
+    runEpoch,
+    sessionSequence,
+    eventId,
+    sourceChannel: 'agent:stream',
+    data: {
+      info: {
+        id: eventId,
+        time: {
+          completed: Date.now()
+        }
+      }
+    }
+  } as unknown as CanonicalAgentEvent
+}
+
 function makeGoalEvent(
   type: 'session.goal_updated' | 'session.goal_cleared',
   data: Record<string, unknown> = {}
@@ -254,6 +278,33 @@ describe('session event run guard', () => {
     expect(getSessionEventGuardState('sess-3')).toEqual({
       activeRunEpoch: 2,
       lastAppliedSequence: 4
+    })
+  })
+
+  test('rejects replayed eventId even if the replay has a higher sequence', () => {
+    const first = acceptSessionEvent(makePartEvent('sess-1', 1, 1, 'same-event'))
+    const replay = acceptSessionEvent(makePartEvent('sess-1', 1, 2, 'same-event'))
+    const next = acceptSessionEvent(makePartEvent('sess-1', 1, 3, 'next-event'))
+
+    expect(first.accepted).toBe(true)
+    expect(replay.accepted).toBe(false)
+    expect(next.accepted).toBe(true)
+    expect(getSessionEventGuardState('sess-1')).toEqual({
+      activeRunEpoch: 1,
+      lastAppliedSequence: 3
+    })
+  })
+
+  test('resets eventId dedupe when a newer runEpoch starts', () => {
+    const firstRun = acceptSessionEvent(makePartEvent('sess-1', 1, 1, 'same-event'))
+    const nextRun = acceptSessionEvent(makePartEvent('sess-1', 2, 2, 'same-event'))
+
+    expect(firstRun.accepted).toBe(true)
+    expect(nextRun.accepted).toBe(true)
+    expect(nextRun.advancedRun).toBe(true)
+    expect(getSessionEventGuardState('sess-1')).toEqual({
+      activeRunEpoch: 2,
+      lastAppliedSequence: 2
     })
   })
 })
@@ -331,25 +382,57 @@ describe('useAgentEventBridge runEpoch guard', () => {
     }
   })
 
+  test('does not duplicate streaming text or callbacks for replayed event ids', () => {
+    const received: string[] = []
+    const unsubscribe = useSessionRuntimeStore
+      .getState()
+      .subscribeToSessionEvents('sess-1', (event) => {
+        received.push(`${event.type}:${event.eventId}`)
+      })
+
+    renderHook(() => useAgentEventBridge())
+    expect(streamCallback).not.toBeNull()
+
+    streamCallback!(makePartEvent('sess-1', 1, 1, 'part-replayed'))
+    streamCallback!(makePartEvent('sess-1', 1, 2, 'part-replayed'))
+    streamCallback!(makeMessageUpdatedEvent('sess-1', 1, 3, 'message-replayed'))
+    streamCallback!(makeMessageUpdatedEvent('sess-1', 1, 4, 'message-replayed'))
+
+    expect(getStreamingBuffer('sess-1')).toMatchObject({
+      activeRunEpoch: 1,
+      lastAppliedSequence: 3,
+      streamingContent: 'part-replayed',
+      isStreaming: true
+    })
+    expect(received).toEqual([
+      'message.part.updated:part-replayed',
+      'message.updated:message-replayed'
+    ])
+
+    unsubscribe()
+  })
+
   test('updates and clears renderer goal state from goal events', () => {
     renderHook(() => useAgentEventBridge())
     expect(streamCallback).not.toBeNull()
 
-    streamCallback!(makeGoalEvent('session.goal_updated', {
-      goal: {
-        threadId: 'thread-1',
-        objective: 'Build the goal foundation',
+    streamCallback!(
+      makeGoalEvent('session.goal_updated', {
+        goal: {
+          threadId: 'thread-1',
+          objective: 'Build the goal foundation',
+          status: 'active',
+          tokenBudget: null,
+          tokensUsed: 42,
+          timeUsedSeconds: 12,
+          createdAt: 100,
+          updatedAt: 200
+        },
         status: 'active',
-        tokenBudget: null,
-        tokensUsed: 42,
-        timeUsedSeconds: 12,
-        createdAt: 100,
-        updatedAt: 200
-      },
-      status: 'active',
-      threadId: 'thread-1',
-      source: 'codex'
-    }))
+        threadId: 'thread-1',
+        source: 'codex'
+      })
+    )
 
     expect(useSessionRuntimeStore.getState().getSessionGoal('sess-1')).toEqual({
       threadId: 'thread-1',

--- a/test/phase-23/agent-timeline-connector.test.tsx
+++ b/test/phase-23/agent-timeline-connector.test.tsx
@@ -143,6 +143,41 @@ describe('AgentTimeline connector rendering', () => {
     expect(onDismissSessionGoal).toHaveBeenCalledTimes(1)
   })
 
+  it('renders queued optimistic user messages with their attachments', () => {
+    render(
+      <AgentTimeline
+        timelineMessages={[
+          {
+            id: 'queued-1',
+            role: 'user',
+            content: 'Review this screenshot next',
+            timestamp: '2026-04-17T14:34:59.000Z',
+            deliveryStatus: 'queued',
+            attachments: [
+              {
+                type: 'file',
+                mime: 'image/png',
+                url: 'data:image/png;base64,queued-image',
+                filename: 'queued.png'
+              }
+            ]
+          }
+        ]}
+        streamingContent=""
+        streamingParts={[]}
+        isStreaming={false}
+        lifecycle="busy"
+      />
+    )
+
+    expect(screen.getByText('QUEUED')).toBeInTheDocument()
+    expect(screen.getByText('Review this screenshot next')).toBeInTheDocument()
+    expect(screen.getByAltText('queued.png')).toHaveAttribute(
+      'src',
+      'data:image/png;base64,queued-image'
+    )
+  })
+
   it('routes token-saver MCP bash tools to the Bash card in committed messages', () => {
     render(
       <AgentTimeline

--- a/test/phase-23/agent-timeline-connector.test.tsx
+++ b/test/phase-23/agent-timeline-connector.test.tsx
@@ -1,5 +1,4 @@
 import { render, screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
 import { AgentTimeline } from '../../src/renderer/src/components/session-hq/AgentTimeline'
 import type { TimelineMessage } from '../../src/shared/lib/timeline-types'
 
@@ -19,30 +18,7 @@ vi.mock('../../src/renderer/src/components/session-hq/cards', () => ({
   TextCard: ({ content, isStreaming = false }: { content: string; isStreaming?: boolean }) => (
     <div data-testid={isStreaming ? 'streaming-text-card' : 'text-card'}>{content}</div>
   ),
-  TodoCard: () => <div>TodoCard</div>,
-  GoalStatusCard: ({
-    goal,
-    onDismiss
-  }: {
-    goal: {
-      objective: string
-      successCriteria?: string
-      tokensUsed?: number
-      tokenBudget?: number | null
-    }
-    onDismiss?: () => void
-  }) => (
-    <div data-testid="goal-status-card">
-      {goal.objective}
-      {goal.successCriteria}
-      {goal.tokensUsed === 1200 && goal.tokenBudget === 50000 ? '1.2K / 50K tokens' : null}
-      {onDismiss ? (
-        <button type="button" data-testid="goal-status-dismiss" onClick={onDismiss}>
-          dismiss
-        </button>
-      ) : null}
-    </div>
-  )
+  TodoCard: () => <div>TodoCard</div>
 }))
 
 function makeAssistantTextMessage(id: string, content: string): TimelineMessage {
@@ -86,61 +62,6 @@ describe('AgentTimeline connector rendering', () => {
     )
 
     expect(screen.queryByTestId('goal-status-card')).not.toBeInTheDocument()
-  })
-
-  it('renders a goal card above the timeline when a goal is present', () => {
-    render(
-      <AgentTimeline
-        timelineMessages={[makeAssistantTextMessage('a-3', 'final assistant reply')]}
-        streamingContent=""
-        streamingParts={[]}
-        isStreaming={false}
-        lifecycle="idle"
-        sessionGoal={{
-          threadId: 'thread-1',
-          objective: 'Build the goal foundation',
-          successCriteria: 'Focused tests pass',
-          status: 'active',
-          tokenBudget: 50000,
-          tokensUsed: 1200,
-          timeUsedSeconds: 90,
-          createdAt: 10,
-          updatedAt: 20
-        }}
-      />
-    )
-
-    expect(screen.getByTestId('goal-status-sticky')).toContainElement(
-      screen.getByTestId('goal-status-card')
-    )
-    expect(screen.getByTestId('goal-status-card')).toHaveTextContent('Build the goal foundation')
-    expect(screen.getByTestId('goal-status-card')).toHaveTextContent('Focused tests pass')
-    expect(screen.getByTestId('goal-status-card')).toHaveTextContent('1.2K / 50K tokens')
-  })
-
-  it('passes the goal dismiss callback through to the sticky goal card', async () => {
-    const user = userEvent.setup()
-    const onDismissSessionGoal = vi.fn()
-
-    render(
-      <AgentTimeline
-        timelineMessages={[makeAssistantTextMessage('a-3b', 'final assistant reply')]}
-        streamingContent=""
-        streamingParts={[]}
-        isStreaming={false}
-        lifecycle="idle"
-        sessionGoal={{
-          threadId: 'thread-1',
-          objective: 'Build the goal foundation',
-          successCriteria: 'Focused tests pass',
-          status: 'completed'
-        }}
-        onDismissSessionGoal={onDismissSessionGoal}
-      />
-    )
-
-    await user.click(screen.getByTestId('goal-status-dismiss'))
-    expect(onDismissSessionGoal).toHaveBeenCalledTimes(1)
   })
 
   it('renders queued optimistic user messages with their attachments', () => {

--- a/test/phase-23/composer-bar.test.tsx
+++ b/test/phase-23/composer-bar.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { act, render, screen } from '@testing-library/react'
+import { act, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { ComposerBar } from '../../src/renderer/src/components/session-hq/ComposerBar'
 
@@ -53,6 +53,14 @@ beforeEach(() => {
       sendAudioChunk: vi.fn().mockResolvedValue(undefined)
     }
   })
+
+  Object.defineProperty(window, 'fileOps', {
+    writable: true,
+    configurable: true,
+    value: {
+      getPathForFile: vi.fn().mockReturnValue('/tmp/note.txt')
+    }
+  })
 })
 
 describe('ComposerBar', () => {
@@ -75,6 +83,45 @@ describe('ComposerBar', () => {
     await user.click(screen.getByTestId('composer-primary-action'))
 
     expect(onAction).toHaveBeenCalledWith('queue', 'Follow up after this run', expect.any(Array))
+  })
+
+  it('restores attachments when an action is not consumed', async () => {
+    const user = userEvent.setup()
+    const onAction = vi.fn().mockResolvedValue(false)
+
+    render(
+      <ComposerBar
+        sessionId="sess-1"
+        lifecycle="idle"
+        pendingCount={0}
+        firstInterrupt={null}
+        onAction={onAction}
+        isConnected={true}
+      />
+    )
+
+    await user.upload(
+      screen.getByTestId('attachment-file-input'),
+      new File(['hello'], 'note.txt', { type: 'text/plain' })
+    )
+    await user.type(screen.getByRole('textbox'), 'Run with attachment')
+    await user.click(screen.getByTestId('composer-primary-action'))
+
+    await waitFor(() => {
+      expect(screen.getByRole('textbox')).toHaveValue('Run with attachment')
+    })
+    expect(screen.getByTestId('attachment-preview')).toHaveTextContent('note.txt')
+    expect(onAction).toHaveBeenCalledWith(
+      'send',
+      'Run with attachment',
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: 'path',
+          name: 'note.txt',
+          filePath: '/tmp/note.txt'
+        })
+      ])
+    )
   })
 
   it('uses steer as the primary busy action when the runtime prefers active-turn steering', async () => {

--- a/test/phase-23/header-pr-title.test.tsx
+++ b/test/phase-23/header-pr-title.test.tsx
@@ -1,22 +1,30 @@
 import { render, screen, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, test, vi } from 'vitest'
-import { Header } from '@/components/layout/Header'
-import { useConnectionStore } from '@/stores/useConnectionStore'
+import { ContextPanelHost } from '@/components/context-panel/ContextPanelHost'
 import { useGitStore } from '@/stores/useGitStore'
+import { useLayoutStore } from '@/stores/useLayoutStore'
 import { useProjectStore } from '@/stores/useProjectStore'
 import { useSettingsStore } from '@/stores/useSettingsStore'
 import { useWorktreeStore } from '@/stores/useWorktreeStore'
 
-vi.mock('@/hooks/usePRDetection', () => ({
-  usePRDetection: vi.fn()
+vi.mock('@/components/file-tree/FileTree', () => ({
+  FileTree: () => <div data-testid="file-tree">FileTree</div>
 }))
 
-vi.mock('@/lib/platform', () => ({
-  isMac: () => false
+vi.mock('@/components/file-tree/ChangesView', () => ({
+  ChangesView: () => <div data-testid="changes-view">ChangesView</div>
 }))
 
-vi.mock('@/assets/icon.png', () => ({
-  default: 'mock-icon.png'
+vi.mock('@/components/file-tree/BranchDiffView', () => ({
+  BranchDiffView: () => <div data-testid="branch-diff-view">BranchDiffView</div>
+}))
+
+vi.mock('@/components/diff-comments/DiffCommentsViewer', () => ({
+  DiffCommentsViewer: () => <div data-testid="diff-comments-viewer">DiffCommentsViewer</div>
+}))
+
+vi.mock('@/components/pr-review/PrReviewViewer', () => ({
+  PrReviewViewer: () => <div data-testid="pr-review-viewer">PrReviewViewer</div>
 }))
 
 const listBranchesWithStatusMock = vi.fn()
@@ -57,7 +65,7 @@ const worktree = {
   last_accessed_at: '2026-05-09T00:00:00.000Z'
 }
 
-describe('Header PR title badge', () => {
+describe('Review context panel PR title badge', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     listBranchesWithStatusMock.mockResolvedValue({ success: true, branches: [] })
@@ -78,7 +86,7 @@ describe('Header PR title badge', () => {
     })
 
     useSettingsStore.setState({ locale: 'en', vimModeEnabled: false })
-    useConnectionStore.setState({ connections: [], selectedConnectionId: null })
+    useLayoutStore.setState({ rightContextTab: 'review', rightReviewTab: 'changes' })
     useProjectStore.setState({ projects: [project], selectedProjectId: 'proj-1' })
     useWorktreeStore.setState({
       selectedWorktreeId: 'wt-1',
@@ -105,8 +113,14 @@ describe('Header PR title badge', () => {
     })
   })
 
-  test('loads and shows the attached PR title on the badge', async () => {
-    render(<Header />)
+  test('loads and exposes the attached PR title on the badge', async () => {
+    render(
+      <ContextPanelHost
+        worktreePath="/repos/xuanpu/hive-upstream"
+        onClose={vi.fn()}
+        onFileClick={vi.fn()}
+      />
+    )
 
     await waitFor(() => {
       expect(getPRStateMock).toHaveBeenCalledWith('/repos/xuanpu', 42)
@@ -114,9 +128,9 @@ describe('Header PR title badge', () => {
 
     const badge = screen.getByTestId('pr-badge')
 
+    expect(badge).toHaveTextContent('PR #42')
     await waitFor(() => {
-      expect(badge).toHaveTextContent('Show PR title in notification widget')
+      expect(badge).toHaveAttribute('title', 'PR #42: Show PR title in notification widget')
     })
-    expect(badge).toHaveAttribute('title', 'PR #42: Show PR title in notification widget')
   })
 })

--- a/test/phase-23/session-shell-plan-implement-source.test.ts
+++ b/test/phase-23/session-shell-plan-implement-source.test.ts
@@ -178,8 +178,10 @@ describe('SessionShell plan implement flow (source verification)', () => {
       "if (action === 'send' || action === 'stop_and_send') {\n        resetLiveOverlay(true)"
     )
     expect(source).toContain(
-      "if (action === 'send' || action === 'stop_and_send' || action === 'steer') {\n        // Lock provider/model selectors immediately."
+      "action === 'steer' ||\n        action === 'queue'\n      ) {\n        // Lock provider/model selectors immediately."
     )
+    expect(source).toContain("deliveryStatus: 'queued' as const")
+    expect(source).toContain('attachmentsToMessageParts(attachments)')
     expect(source).toContain(
       "if (action === 'send' || action === 'stop_and_send') {\n          resetLiveOverlay(false)"
     )

--- a/test/phase-23/use-session-runtime-store.test.ts
+++ b/test/phase-23/use-session-runtime-store.test.ts
@@ -39,6 +39,9 @@ beforeEach(() => {
   for (const sessionId of state.pendingMessages.keys()) {
     state.clearPendingMessages(sessionId)
   }
+  for (const sessionId of state.sessionTasks.keys()) {
+    state.clearSessionTasks(sessionId)
+  }
 })
 
 afterEach(() => {
@@ -279,6 +282,33 @@ describe('useSessionRuntimeStore', () => {
       })
 
       expect(store.getDismissedGoalSignature('sess-1')).toBeNull()
+    })
+  })
+
+  describe('session tasks', () => {
+    it('stores defensive task snapshots per session', () => {
+      const store = useSessionRuntimeStore.getState()
+      const tasks = [{ id: 'task-1', content: 'Move task list right', status: 'pending' as const }]
+
+      store.setSessionTasks('sess-1', tasks)
+      tasks[0].content = 'Mutated after write'
+
+      expect(store.getSessionTasks('sess-1')).toEqual([
+        { id: 'task-1', content: 'Move task list right', status: 'pending' }
+      ])
+      expect(store.getSessionTasks('missing')).toEqual([])
+    })
+
+    it('clears task snapshots with their session', () => {
+      const store = useSessionRuntimeStore.getState()
+      store.setSessionTasks('sess-1', [
+        { id: 'task-1', content: 'Move task list right', status: 'completed' }
+      ])
+
+      store.clearSession('sess-1')
+
+      expect(store.getSessionTasks('sess-1')).toEqual([])
+      expect(useSessionRuntimeStore.getState().sessionTasks.has('sess-1')).toBe(false)
     })
   })
 
@@ -1045,6 +1075,7 @@ describe('useSessionRuntimeStore', () => {
       const store = useSessionRuntimeStore.getState()
       store.setLifecycle('sess-1', 'busy')
       store.incrementUnread('sess-1')
+      store.setSessionTasks('sess-1', [{ id: 'task-1', content: 'Task state', status: 'pending' }])
       store.pushInterrupt('sess-1', {
         type: 'question',
         id: 'q-1',
@@ -1056,6 +1087,7 @@ describe('useSessionRuntimeStore', () => {
 
       expect(useSessionRuntimeStore.getState().sessions.has('sess-1')).toBe(false)
       expect(useSessionRuntimeStore.getState().interruptQueues.has('sess-1')).toBe(false)
+      expect(useSessionRuntimeStore.getState().sessionTasks.has('sess-1')).toBe(false)
       // getSession returns default
       expect(useSessionRuntimeStore.getState().getSession('sess-1').lifecycle).toBe('idle')
     })

--- a/test/settings-i18n.test.tsx
+++ b/test/settings-i18n.test.tsx
@@ -7,6 +7,9 @@ const mockUpdateSetting = vi.fn()
 let mockSettingsState: Record<string, unknown> = {}
 
 vi.mock('@/stores/useSettingsStore', () => ({
+  applyFontFamily: vi.fn(),
+  applyFontScale: vi.fn(),
+  applyFontWeight: vi.fn(),
   useSettingsStore: Object.assign(
     (selector?: (state: unknown) => unknown) => {
       return selector ? selector(mockSettingsState) : mockSettingsState
@@ -92,6 +95,11 @@ describe('Settings i18n', () => {
       showModelProvider: false,
       showUsageIndicator: true,
       keepAwakeEnabled: true,
+      uiFontScale: 1,
+      uiFontFamily: 'system',
+      uiCustomFontFamily: '',
+      uiFontWeight: 'regular',
+      uiZoomLevel: 0,
       defaultAgentSdk: 'opencode',
       updateChannel: 'stable',
       stripAtMentions: true,
@@ -111,6 +119,12 @@ describe('Settings i18n', () => {
         getVersion: vi.fn().mockResolvedValue('1.0.71'),
         checkForUpdate: vi.fn().mockResolvedValue(undefined)
       }
+    })
+
+    Object.defineProperty(window, 'queryLocalFonts', {
+      configurable: true,
+      writable: true,
+      value: undefined
     })
   })
 
@@ -152,6 +166,39 @@ describe('Settings i18n', () => {
     expect(screen.getByText('外观')).toBeInTheDocument()
     expect(screen.getByTestId('dark-themes-header')).toHaveTextContent('深色主题')
     expect(screen.getByTestId('light-themes-header')).toHaveTextContent('浅色主题')
+    expect(screen.getByText('界面字体')).toBeInTheDocument()
+    expect(screen.getByTestId('font-family-select')).toHaveTextContent('系统默认')
+    expect(screen.getByTestId('load-system-fonts')).toHaveTextContent('加载字体')
+    expect(screen.getByText('默认字重')).toBeInTheDocument()
+    expect(screen.getByTestId('font-weight-regular')).toHaveTextContent('常规')
+  })
+
+  it('loads and selects a system font in SettingsAppearance', async () => {
+    Object.defineProperty(window, 'queryLocalFonts', {
+      configurable: true,
+      writable: true,
+      value: vi.fn().mockResolvedValue([
+        { family: 'Test Sans', fullName: 'Test Sans Regular' },
+        { family: 'Test Sans', fullName: 'Test Sans Bold' },
+        { family: 'Test Mono', fullName: 'Test Mono Regular' }
+      ])
+    })
+
+    const { SettingsAppearance } = await import('@/components/settings/SettingsAppearance')
+    render(<SettingsAppearance />)
+
+    await userEvent.click(screen.getByTestId('load-system-fonts'))
+    await waitFor(() => {
+      expect(screen.getByText('已加载 2 个系统字体')).toBeInTheDocument()
+    })
+
+    await userEvent.selectOptions(screen.getByTestId('font-family-select'), 'system:Test Sans')
+
+    expect(mockUpdateSetting).toHaveBeenCalledWith(
+      'uiCustomFontFamily',
+      '"Test Sans", system-ui, sans-serif'
+    )
+    expect(mockUpdateSetting).toHaveBeenCalledWith('uiFontFamily', 'custom')
   })
 
   it('renders translated labels in SettingsUpdates', async () => {

--- a/test/settings-typography.test.ts
+++ b/test/settings-typography.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { applyFontFamily, applyFontWeight, applyTypographySettings } from '@/lib/font-size'
+
+describe('typography settings', () => {
+  afterEach(() => {
+    document.documentElement.removeAttribute('style')
+  })
+
+  it('applies built-in and custom UI font families', () => {
+    applyFontFamily('mono')
+    expect(document.documentElement.style.getPropertyValue('--xuanpu-ui-font-family')).toContain(
+      'JetBrains Mono'
+    )
+
+    applyFontFamily('custom', '"LXGW WenKai", "SF Pro Text"')
+    expect(document.documentElement.style.getPropertyValue('--xuanpu-ui-font-family')).toBe(
+      '"LXGW WenKai", "SF Pro Text"'
+    )
+
+    applyFontFamily('system')
+    expect(document.documentElement.style.getPropertyValue('--xuanpu-ui-font-family')).toBe('')
+  })
+
+  it('applies and clears the default UI font weight', () => {
+    applyFontWeight('semibold')
+    expect(document.documentElement.style.getPropertyValue('--xuanpu-ui-font-weight')).toBe('600')
+
+    applyFontWeight('regular')
+    expect(document.documentElement.style.getPropertyValue('--xuanpu-ui-font-weight')).toBe('')
+  })
+
+  it('applies typography settings together', () => {
+    applyTypographySettings({
+      uiFontScale: 1.1,
+      uiFontFamily: 'serif',
+      uiFontWeight: 'medium'
+    })
+
+    expect(document.documentElement.style.getPropertyValue('--text-sm')).toBe('0.9625rem')
+    expect(document.documentElement.style.getPropertyValue('--xuanpu-ui-font-family')).toContain(
+      'Charter'
+    )
+    expect(document.documentElement.style.getPropertyValue('--xuanpu-ui-font-weight')).toBe('500')
+  })
+})

--- a/test/terminal/main-pane-terminal-persistence.test.tsx
+++ b/test/terminal/main-pane-terminal-persistence.test.tsx
@@ -98,10 +98,10 @@ describe('MainPane terminal persistence', () => {
     })
   })
 
-  test('keeps each terminal instance mounted across tab switches and transient session reloads', () => {
+  test('keeps each terminal instance mounted across tab switches and transient session reloads', async () => {
     render(<MainPane />)
 
-    const firstTerminalNode = screen.getByTestId('session-terminal-term-1')
+    const firstTerminalNode = await screen.findByTestId('session-terminal-term-1')
     expect(terminalMounts.get('term-1')).toBe(1)
     expect(terminalMounts.get('term-2')).toBe(1)
 
@@ -133,10 +133,13 @@ describe('MainPane terminal persistence', () => {
     expect(terminalMounts.get('term-2')).toBe(1)
   })
 
-  test('hides terminal surfaces when overlay suppression is enabled', () => {
+  test('hides terminal surfaces when overlay suppression is enabled', async () => {
     render(<MainPane />)
 
-    expect(screen.getByTestId('session-terminal-term-1')).toHaveAttribute('data-visible', 'true')
+    expect(await screen.findByTestId('session-terminal-term-1')).toHaveAttribute(
+      'data-visible',
+      'true'
+    )
 
     act(() => {
       useLayoutStore.getState().pushGhosttySuppression('test-overlay')
@@ -146,11 +149,11 @@ describe('MainPane terminal persistence', () => {
     expect(screen.getByTestId('session-terminal-term-2')).toHaveAttribute('data-visible', 'false')
   })
 
-  test('removes terminal from mounted list when session is closed via store signal', () => {
+  test('removes terminal from mounted list when session is closed via store signal', async () => {
     render(<MainPane />)
 
     // Both terminals are mounted
-    expect(screen.getByTestId('session-terminal-term-1')).toBeInTheDocument()
+    expect(await screen.findByTestId('session-terminal-term-1')).toBeInTheDocument()
     expect(screen.getByTestId('session-terminal-term-2')).toBeInTheDocument()
 
     // Simulate closeSession: remove from sessions map AND signal via closedTerminalSessionIds
@@ -167,11 +170,11 @@ describe('MainPane terminal persistence', () => {
     expect(screen.getByTestId('session-terminal-term-2')).toBeInTheDocument()
   })
 
-  test('preserves terminal state across worktree switches', () => {
+  test('preserves terminal state across worktree switches', async () => {
     render(<MainPane />)
 
     // Both terminals mounted in wt-1
-    expect(screen.getByTestId('session-terminal-term-1')).toBeInTheDocument()
+    expect(await screen.findByTestId('session-terminal-term-1')).toBeInTheDocument()
     expect(screen.getByTestId('session-terminal-term-2')).toBeInTheDocument()
     expect(terminalMounts.get('term-1')).toBe(1)
 
@@ -189,7 +192,7 @@ describe('MainPane terminal persistence', () => {
     })
 
     // term-3 is now mounted, term-1 and term-2 are still mounted (hidden)
-    expect(screen.getByTestId('session-terminal-term-3')).toBeInTheDocument()
+    expect(await screen.findByTestId('session-terminal-term-3')).toBeInTheDocument()
     expect(screen.getByTestId('session-terminal-term-1')).toBeInTheDocument()
     expect(screen.getByTestId('session-terminal-term-2')).toBeInTheDocument()
 

--- a/test/terminal/terminal-tab-bar.test.tsx
+++ b/test/terminal/terminal-tab-bar.test.tsx
@@ -1,0 +1,22 @@
+import { render } from '@testing-library/react'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { TerminalTabBar } from '@/components/terminal/TerminalTabBar'
+import { useBottomTerminalStore } from '@/stores/useBottomTerminalStore'
+
+describe('TerminalTabBar', () => {
+  beforeEach(() => {
+    useBottomTerminalStore.setState({
+      tabsByWorktree: new Map(),
+      activeTabByWorktree: new Map(),
+      counterByWorktree: new Map()
+    })
+  })
+
+  it('renders nothing for a worktree with no terminal tabs without an update loop', () => {
+    const { container } = render(
+      <TerminalTabBar worktreeId="worktree-without-tabs" worktreeCwd="/tmp/worktree" />
+    )
+
+    expect(container).toBeEmptyDOMElement()
+  })
+})

--- a/test/vim-navigation/header-mode-pill.test.tsx
+++ b/test/vim-navigation/header-mode-pill.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
-import { render, screen, cleanup } from '@testing-library/react'
+import { render, screen, cleanup, waitFor } from '@testing-library/react'
 
 // ---------------------------------------------------------------------------
 // Mock ALL stores Header.tsx imports (must be before component import)
@@ -34,7 +34,21 @@ vi.mock('@/stores/useSessionHistoryStore', () => {
   return { useSessionHistoryStore }
 })
 
-const settingsState = { openSettings: vi.fn() }
+const settingsState = {
+  openSettings: vi.fn(),
+  vimModeEnabled: true,
+  keepAwakeEnabled: false,
+  locale: 'en',
+  defaultAgentSdk: 'codex',
+  selectedModel: null,
+  selectedModelByProvider: {},
+  showModelProvider: false,
+  favoriteModels: [] as string[],
+  toggleFavoriteModel: vi.fn(),
+  getModelVariantDefault: vi.fn(() => null),
+  setModelVariantDefault: vi.fn(),
+  setSelectedModelForSdk: vi.fn()
+}
 
 vi.mock('@/stores/useSettingsStore', () => {
   const useSettingsStore = vi.fn((selector?: unknown) =>
@@ -44,7 +58,14 @@ vi.mock('@/stores/useSettingsStore', () => {
   )
   useSettingsStore.getState = vi.fn(() => settingsState)
   useSettingsStore.subscribe = vi.fn(() => () => {})
-  return { useSettingsStore }
+  return {
+    useSettingsStore,
+    resolveModelForSdk: vi.fn(() => ({
+      providerID: 'openai',
+      modelID: 'gpt-5.4',
+      variant: undefined
+    }))
+  }
 })
 
 const projectState = { selectedProjectId: null, projects: [] as unknown[] }
@@ -96,7 +117,12 @@ const sessionState = {
   createSession: vi.fn(),
   updateSessionName: vi.fn(),
   setPendingMessage: vi.fn(),
-  setActiveSession: vi.fn()
+  setActiveSession: vi.fn(),
+  setSessionModel: vi.fn(),
+  activeSessionId: null as string | null,
+  inlineConnectionSessionId: null as string | null,
+  sessionsByWorktree: new Map<string, unknown[]>(),
+  sessionsByConnection: new Map<string, unknown[]>()
 }
 
 vi.mock('@/stores/useSessionStore', () => {
@@ -178,6 +204,7 @@ vi.mock('@/lib/toast', () => ({
 // ---------------------------------------------------------------------------
 
 import { useVimModeStore } from '@/stores/useVimModeStore'
+import { useContextStore } from '@/stores/useContextStore'
 
 // ---------------------------------------------------------------------------
 // Import component under test AFTER mocks
@@ -193,6 +220,18 @@ function resetStores(): void {
   useVimModeStore.setState({
     mode: 'normal',
     helpOverlayOpen: false
+  })
+  sessionState.activeSessionId = null
+  sessionState.inlineConnectionSessionId = null
+  sessionState.sessionsByWorktree = new Map()
+  sessionState.sessionsByConnection = new Map()
+  useContextStore.setState({
+    tokensBySession: {},
+    modelBySession: {},
+    contextSnapshotsBySession: {},
+    costBySession: {},
+    costEventKeysBySession: {},
+    modelLimits: {}
   })
 }
 
@@ -249,5 +288,129 @@ describe('Header mode pill', () => {
     expect(pill.className).toContain('text-primary')
     expect(pill.className).toContain('bg-primary/10')
     expect(pill.className).toContain('border-primary/30')
+  })
+
+  it('keeps the header visible when an active session is present', async () => {
+    Object.defineProperty(window, 'agentOps', {
+      configurable: true,
+      writable: true,
+      value: {
+        ...(window.agentOps ?? {}),
+        listModels: vi.fn().mockResolvedValue({
+          success: true,
+          providers: [
+            {
+              id: 'openai',
+              name: 'OpenAI',
+              models: {
+                'gpt-5.4': { id: 'gpt-5.4', name: 'GPT-5.4' }
+              }
+            }
+          ]
+        })
+      }
+    })
+
+    sessionState.activeSessionId = 'session-1'
+    sessionState.sessionsByWorktree = new Map([
+      [
+        'worktree-1',
+        [
+          {
+            id: 'session-1',
+            name: 'Infra session',
+            agent_sdk: 'codex',
+            model_id: 'gpt-5.4',
+            model_provider_id: 'openai'
+          }
+        ]
+      ]
+    ])
+    useContextStore.setState({
+      tokensBySession: {
+        'session-1': {
+          input: 100_000,
+          output: 20_000,
+          reasoning: 0,
+          cacheRead: 0,
+          cacheWrite: 0
+        }
+      },
+      costBySession: {
+        'session-1': 1.2345
+      },
+      modelLimits: {
+        'openai::gpt-5.4': 200_000
+      }
+    })
+
+    render(<Header />)
+
+    expect(screen.getByTestId('header')).toBeInTheDocument()
+    expect(screen.getByText('Xuanpu')).toBeInTheDocument()
+    await waitFor(() => {
+      expect(screen.getByTestId('header-session-glance')).toBeInTheDocument()
+      expect(screen.getByTestId('model-selector')).toBeInTheDocument()
+    })
+    expect(screen.getByTestId('header-context-meter')).toBeInTheDocument()
+    expect(screen.getByTestId('header-context-meter-fill')).toHaveStyle({ width: '50%' })
+    expect(screen.getByTestId('header-cost-pill')).toHaveTextContent('$1.2345')
+    expect(screen.queryByText(/tokens/i)).not.toBeInTheDocument()
+  })
+
+  it('uses the default Claude context limit when model metadata has not arrived', async () => {
+    Object.defineProperty(window, 'agentOps', {
+      configurable: true,
+      writable: true,
+      value: {
+        ...(window.agentOps ?? {}),
+        listModels: vi.fn().mockResolvedValue({
+          success: true,
+          providers: [
+            {
+              id: 'anthropic',
+              name: 'Anthropic',
+              models: {
+                opus: { id: 'opus', name: 'Opus 4.7' }
+              }
+            }
+          ]
+        })
+      }
+    })
+
+    sessionState.activeSessionId = 'session-claude'
+    sessionState.sessionsByWorktree = new Map([
+      [
+        'worktree-1',
+        [
+          {
+            id: 'session-claude',
+            name: 'Claude session',
+            agent_sdk: 'claude-code',
+            model_id: 'opus',
+            model_provider_id: 'claude-code'
+          }
+        ]
+      ]
+    ])
+    useContextStore.setState({
+      tokensBySession: {
+        'session-claude': {
+          input: 183_100,
+          output: 42_000,
+          reasoning: 0,
+          cacheRead: 0,
+          cacheWrite: 0
+        }
+      }
+    })
+
+    render(<Header />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('header-context-meter')).toBeInTheDocument()
+    })
+    expect(screen.getByTestId('header-context-meter-fill')).toHaveStyle({ width: '92%' })
   })
 })

--- a/test/voice/funasr-client.test.ts
+++ b/test/voice/funasr-client.test.ts
@@ -12,7 +12,10 @@ vi.mock('../../src/main/services/logger', () => ({
   })
 }))
 
-import { FunAsrClient } from '../../src/main/services/voice/funasr-client'
+import {
+  FUNASR_WEBSOCKET_SUBPROTOCOL,
+  FunAsrClient
+} from '../../src/main/services/voice/funasr-client'
 
 const servers: WebSocketServer[] = []
 
@@ -42,9 +45,16 @@ function closeServer(server: WebSocketServer): Promise<void> {
 }
 
 async function createServer(
-  onConnection: (ws: import('ws').WebSocket) => void
+  onConnection: (ws: import('ws').WebSocket) => void,
+  options?: { requireBinarySubprotocol?: boolean }
 ): Promise<{ url: string; close: () => Promise<void> }> {
-  const server = new WebSocketServer({ port: 0 })
+  const server = new WebSocketServer({
+    port: 0,
+    handleProtocols: options?.requireBinarySubprotocol
+      ? (protocols) =>
+          protocols.has(FUNASR_WEBSOCKET_SUBPROTOCOL) ? FUNASR_WEBSOCKET_SUBPROTOCOL : false
+      : undefined
+  })
   servers.push(server)
   server.on('connection', onConnection)
 
@@ -61,6 +71,39 @@ afterEach(async () => {
 })
 
 describe('FunAsrClient', () => {
+  it('uses the FunASR binary subprotocol for health checks', async () => {
+    let observedProtocol = ''
+    const server = await createServer(
+      (ws) => {
+        observedProtocol = ws.protocol
+      },
+      { requireBinarySubprotocol: true }
+    )
+
+    const client = new FunAsrClient()
+    await expect(client.healthCheck(server.url, 1000)).resolves.toBe(true)
+    expect(observedProtocol).toBe(FUNASR_WEBSOCKET_SUBPROTOCOL)
+  })
+
+  it('uses the FunASR binary subprotocol for transcription sessions', async () => {
+    let observedProtocol = ''
+    const server = await createServer(
+      (ws) => {
+        observedProtocol = ws.protocol
+      },
+      { requireBinarySubprotocol: true }
+    )
+
+    const client = new FunAsrClient()
+    const sessionId = await client.connect(defaultOptions(server.url), {
+      onTranscript: vi.fn(),
+      onError: vi.fn()
+    })
+    client.disconnect(sessionId)
+
+    expect(observedProtocol).toBe(FUNASR_WEBSOCKET_SUBPROTOCOL)
+  })
+
   it('rejects when the WebSocket endpoint cannot be reached', async () => {
     const server = await createServer((ws) => ws.close())
     const port = Number(new URL(server.url).port)

--- a/test/voice/managed-funasr-runtime.test.ts
+++ b/test/voice/managed-funasr-runtime.test.ts
@@ -15,7 +15,12 @@ vi.mock('../../src/main/services/logger', () => ({
   })
 }))
 
-import { isManagedFunAsrCommandLine } from '../../src/main/services/voice/managed-funasr-runtime'
+import {
+  MANAGED_FUNASR_REQUIRED_PYTHON_PACKAGES,
+  isManagedFunAsrCommandLine,
+  isSupportedFunAsrPythonVersion,
+  parsePythonVersionOutput
+} from '../../src/main/services/voice/managed-funasr-runtime'
 
 const MANAGED_SERVER_SCRIPT =
   '/Users/tester/.xuanpu/voice/funasr/runtime/FunASR/runtime/python/websocket/funasr_wss_server.py'
@@ -49,5 +54,36 @@ describe('managed FunASR runtime process ownership', () => {
         { hostPort: 10095 }
       )
     ).toBe(false)
+  })
+})
+
+describe('managed FunASR Python runtime selection', () => {
+  it('parses Python version output from stdout or stderr text', () => {
+    expect(parsePythonVersionOutput('Python 3.11.9')).toEqual({
+      major: 3,
+      minor: 11,
+      patch: 9
+    })
+    expect(parsePythonVersionOutput('warning\nPython 3.12.2\n')).toEqual({
+      major: 3,
+      minor: 12,
+      patch: 2
+    })
+    expect(parsePythonVersionOutput('not python')).toBeNull()
+  })
+
+  it('accepts PyTorch-compatible Python versions and rejects 3.14', () => {
+    expect(isSupportedFunAsrPythonVersion(parsePythonVersionOutput('Python 3.10.13'))).toBe(true)
+    expect(isSupportedFunAsrPythonVersion(parsePythonVersionOutput('Python 3.11.9'))).toBe(true)
+    expect(isSupportedFunAsrPythonVersion(parsePythonVersionOutput('Python 3.12.2'))).toBe(true)
+    expect(isSupportedFunAsrPythonVersion(parsePythonVersionOutput('Python 3.9.6'))).toBe(false)
+    expect(isSupportedFunAsrPythonVersion(parsePythonVersionOutput('Python 3.14.5'))).toBe(false)
+  })
+
+  it('pins PyTorch packages required by the FunASR websocket server', () => {
+    expect(MANAGED_FUNASR_REQUIRED_PYTHON_PACKAGES).toContain('torch==2.11.0')
+    expect(MANAGED_FUNASR_REQUIRED_PYTHON_PACKAGES).toContain('torchaudio==2.11.0')
+    expect(MANAGED_FUNASR_REQUIRED_PYTHON_PACKAGES).toContain('funasr==1.3.1')
+    expect(MANAGED_FUNASR_REQUIRED_PYTHON_PACKAGES).toContain('modelscope==1.37.0')
   })
 })

--- a/test/worktree-connection/session-9/session-view-connections.test.tsx
+++ b/test/worktree-connection/session-9/session-view-connections.test.tsx
@@ -45,6 +45,12 @@ vi.mock('@/components/sessions/SessionView', () => ({
   )
 }))
 
+vi.mock('@/components/session-hq/SessionShell', () => ({
+  SessionShell: ({ sessionId }: { sessionId: string }) => (
+    <div data-testid={`session-view-${sessionId}`}>Session: {sessionId}</div>
+  )
+}))
+
 // ---------- Mock FileViewer ----------
 vi.mock('@/components/file-viewer', () => ({
   FileViewer: () => <div data-testid="file-viewer" />
@@ -382,7 +388,7 @@ describe('Session 9: SessionView & MainPane Integration', () => {
       expect(screen.getByText('Select a project or worktree to get started.')).toBeInTheDocument()
     })
 
-    test('renders session tabs when a connection is selected', async () => {
+    test('keeps session tabs out of the main pane when a connection is selected', async () => {
       const connection = makeConnection()
       const session = makeSession()
 
@@ -405,7 +411,8 @@ describe('Session 9: SessionView & MainPane Integration', () => {
         render(<MainPane />)
       })
 
-      expect(screen.getByTestId('session-tabs')).toBeInTheDocument()
+      expect(screen.queryByTestId('session-tabs')).not.toBeInTheDocument()
+      expect(screen.getByTestId('session-view-session-1')).toBeInTheDocument()
     })
 
     test('renders SessionView when connection session is active', async () => {
@@ -496,7 +503,7 @@ describe('Session 9: SessionView & MainPane Integration', () => {
   })
 
   describe('SessionTabs connection mode', () => {
-    test('reads sessions from sessionsByConnection when connection is active', async () => {
+    test('reads sessions from sessionsByConnection in the merged header topbar', async () => {
       const connection = makeConnection()
       const session = makeSession()
 
@@ -515,14 +522,14 @@ describe('Session 9: SessionView & MainPane Integration', () => {
       })
 
       await act(async () => {
-        render(<MainPane />)
+        render(<Header />)
       })
 
       expect(screen.getByTestId('session-tab-session-1')).toBeInTheDocument()
       expect(screen.getByText('Session 1')).toBeInTheDocument()
     })
 
-    test('create button works in connection mode', async () => {
+    test('create button works in connection mode from the merged header topbar', async () => {
       const user = userEvent.setup()
       const connection = makeConnection()
 
@@ -540,7 +547,7 @@ describe('Session 9: SessionView & MainPane Integration', () => {
       })
 
       await act(async () => {
-        render(<MainPane />)
+        render(<Header />)
       })
 
       const createButton = screen.getByTestId('create-session')
@@ -550,7 +557,7 @@ describe('Session 9: SessionView & MainPane Integration', () => {
       expect(mockConnectionOps.get).toHaveBeenCalledWith('conn-1')
     })
 
-    test('shows empty state when connection has no sessions', async () => {
+    test('shows empty state in the merged header topbar when connection has no sessions', async () => {
       const connection = makeConnection()
 
       mockDb.session.getActiveByConnection.mockResolvedValue([])
@@ -567,7 +574,7 @@ describe('Session 9: SessionView & MainPane Integration', () => {
       })
 
       await act(async () => {
-        render(<MainPane />)
+        render(<Header />)
       })
 
       expect(screen.getByTestId('no-sessions')).toBeInTheDocument()
@@ -576,7 +583,7 @@ describe('Session 9: SessionView & MainPane Integration', () => {
   })
 
   describe('Header', () => {
-    test('shows connection name and member projects when connection is selected', () => {
+    test('shows connection name and keeps member projects out of the compact merged topbar', () => {
       const connection = makeConnection()
 
       useConnectionStore.setState({
@@ -592,10 +599,11 @@ describe('Session 9: SessionView & MainPane Integration', () => {
 
       expect(screen.getByTestId('header-connection-info')).toBeInTheDocument()
       expect(screen.getByText('golden-retriever')).toBeInTheDocument()
-      expect(screen.getByText('(Frontend + Backend)')).toBeInTheDocument()
+      expect(screen.queryByText('(Frontend + Backend)')).not.toBeInTheDocument()
+      expect(screen.getByTestId('session-tabs')).toBeInTheDocument()
     })
 
-    test('shows project/branch info when worktree is selected (not connection)', () => {
+    test('shows project name and keeps branch info out of the compact merged topbar', () => {
       useWorktreeStore.setState({
         selectedWorktreeId: 'wt-1',
         worktreesByProject: new Map([['proj-1', [makeWorktree({ branch_name: 'feat/auth' })]]])
@@ -609,7 +617,8 @@ describe('Session 9: SessionView & MainPane Integration', () => {
 
       expect(screen.getByTestId('header-project-info')).toBeInTheDocument()
       expect(screen.getByText('My Project')).toBeInTheDocument()
-      expect(screen.getByText('(feat/auth)')).toBeInTheDocument()
+      expect(screen.queryByText('(feat/auth)')).not.toBeInTheDocument()
+      expect(screen.getByTestId('session-tabs')).toBeInTheDocument()
     })
 
     test('hides git UI (PR, merge, archive) when connection is selected', () => {
@@ -638,7 +647,7 @@ describe('Session 9: SessionView & MainPane Integration', () => {
       expect(screen.queryByTestId('fix-conflicts-button')).not.toBeInTheDocument()
     })
 
-    test('switching from connection to worktree restores git UI', () => {
+    test('switching from connection to worktree restores project identity without header PR UI', () => {
       useWorktreeStore.setState({
         selectedWorktreeId: 'wt-1',
         worktreesByProject: new Map([['proj-1', [makeWorktree()]]])
@@ -663,8 +672,8 @@ describe('Session 9: SessionView & MainPane Integration', () => {
       expect(screen.getByTestId('header-project-info')).toBeInTheDocument()
       expect(screen.queryByTestId('header-connection-info')).not.toBeInTheDocument()
 
-      // PR button should be visible now (worktree mode with GitHub remote)
-      expect(screen.getByTestId('pr-button')).toBeInTheDocument()
+      // PR/review actions now live in the right Review context panel, not Header.
+      expect(screen.queryByTestId('pr-button')).not.toBeInTheDocument()
     })
 
     test('shows Xuanpu text when nothing is selected', () => {


### PR DESCRIPTION
## Summary
- dedupe replayed agent events and preserve queued messages with attachments
- add the right context panel host and rail layout
- move tasks, goals, overview, review, files, and terminal surfaces into the context panel
- refine workbench layout, appearance, and right-side panel behavior

## Stack
Stacked on #63. Review this PR against `infra/hub-mobile-runtime`.

## Verification
Verified on top of the full stack before splitting:
- pnpm vitest run test/context-panel/context-panel-host-tabs.test.tsx test/xfp/audit.test.ts test/xfp/agent-prompt-xfp-policy.test.ts test/xfp/claude-mcp-server.test.ts test/phase-21/field-events/field-handlers.test.ts test/phase-21/session-4/claude-prompt-streaming.test.ts test/phase-22/session-5/codex-prompt-streaming.test.ts
- pnpm vitest run test/xfp
- pnpm lint
- git diff --check
- pnpm build