### PR TITLE
feat: polish session hq and codex timeline

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xuanpu",
-  "version": "1.4.9",
+  "version": "1.4.10-rc2",
   "description": "Xuanpu Workbench - an AI-native workbench for builders",
   "main": "./out/main/index.js",
   "author": "slicenferqin",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xuanpu",
-  "version": "1.4.10-rc2",
+  "version": "1.4.10-rc3",
   "description": "Xuanpu Workbench - an AI-native workbench for builders",
   "main": "./out/main/index.js",
   "author": "slicenferqin",

--- a/src/main/db/database.ts
+++ b/src/main/db/database.ts
@@ -1389,6 +1389,14 @@ export class DatabaseService {
   createSessionMessage(data: SessionMessageCreate): SessionMessage {
     const db = this.getDb()
     const now = data.created_at ?? new Date().toISOString()
+    // Allocate a monotonic per-session sequence number so messages that land in
+    // the same millisecond keep a stable insert order on read.
+    const seqRow = db
+      .prepare(
+        'SELECT COALESCE(MAX(sequence), 0) + 1 AS next_seq FROM session_messages WHERE session_id = ?'
+      )
+      .get(data.session_id) as { next_seq: number } | undefined
+    const nextSequence = seqRow?.next_seq ?? 1
     const message: SessionMessage = {
       id: randomUUID(),
       session_id: data.session_id,
@@ -1398,6 +1406,7 @@ export class DatabaseService {
       opencode_message_json: data.opencode_message_json ?? null,
       opencode_parts_json: data.opencode_parts_json ?? null,
       opencode_timeline_json: data.opencode_timeline_json ?? null,
+      sequence: nextSequence,
       created_at: now
     }
 
@@ -1411,8 +1420,9 @@ export class DatabaseService {
         opencode_message_json,
         opencode_parts_json,
         opencode_timeline_json,
+        sequence,
         created_at
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
     ).run(
       message.id,
       message.session_id,
@@ -1422,6 +1432,7 @@ export class DatabaseService {
       message.opencode_message_json,
       message.opencode_parts_json,
       message.opencode_timeline_json,
+      message.sequence,
       message.created_at
     )
 
@@ -1494,7 +1505,11 @@ export class DatabaseService {
       .prepare(
         `SELECT * FROM session_messages
          WHERE session_id = ? AND opencode_message_id = ?
-         ORDER BY created_at ASC
+         ORDER BY
+           CASE WHEN sequence IS NULL THEN 1 ELSE 0 END,
+           sequence ASC,
+           created_at ASC,
+           id ASC
          LIMIT 1`
       )
       .get(sessionId, opencodeMessageId) as SessionMessage | undefined
@@ -1529,7 +1544,15 @@ export class DatabaseService {
   getSessionMessages(sessionId: string): SessionMessage[] {
     const db = this.getDb()
     return db
-      .prepare('SELECT * FROM session_messages WHERE session_id = ? ORDER BY created_at ASC')
+      .prepare(
+        `SELECT * FROM session_messages
+         WHERE session_id = ?
+         ORDER BY
+           CASE WHEN sequence IS NULL THEN 1 ELSE 0 END,
+           sequence ASC,
+           created_at ASC,
+           id ASC`
+      )
       .all(sessionId) as SessionMessage[]
   }
 

--- a/src/main/db/schema.ts
+++ b/src/main/db/schema.ts
@@ -1,4 +1,4 @@
-export const CURRENT_SCHEMA_VERSION = 23
+export const CURRENT_SCHEMA_VERSION = 24
 
 export const SCHEMA_SQL = `
 -- Projects table
@@ -76,6 +76,7 @@ CREATE TABLE IF NOT EXISTS session_messages (
   opencode_message_json TEXT,
   opencode_parts_json TEXT,
   opencode_timeline_json TEXT,
+  sequence INTEGER,
   created_at TEXT NOT NULL
 );
 
@@ -173,6 +174,8 @@ CREATE INDEX IF NOT EXISTS idx_worktrees_project ON worktrees(project_id);
 CREATE INDEX IF NOT EXISTS idx_sessions_worktree ON sessions(worktree_id);
 CREATE INDEX IF NOT EXISTS idx_sessions_project ON sessions(project_id);
 CREATE INDEX IF NOT EXISTS idx_messages_session ON session_messages(session_id);
+CREATE INDEX IF NOT EXISTS idx_messages_session_seq
+  ON session_messages(session_id, sequence);
 CREATE INDEX IF NOT EXISTS idx_messages_session_opencode
   ON session_messages(session_id, opencode_message_id);
 CREATE UNIQUE INDEX IF NOT EXISTS idx_messages_session_opencode_unique
@@ -857,6 +860,30 @@ export const MIGRATIONS: Migration[] = [
       DROP INDEX IF EXISTS idx_session_pending_messages_updated;
       DROP INDEX IF EXISTS idx_session_pending_messages_session_status;
       DROP TABLE IF EXISTS session_pending_messages;
+    `
+  },
+  {
+    version: 24,
+    name: 'add_session_messages_sequence',
+    up: `
+      ALTER TABLE session_messages ADD COLUMN sequence INTEGER;
+      WITH ordered AS (
+        SELECT id,
+               ROW_NUMBER() OVER (
+                 PARTITION BY session_id
+                 ORDER BY created_at ASC, id ASC
+               ) AS seq
+        FROM session_messages
+      )
+      UPDATE session_messages
+         SET sequence = (SELECT seq FROM ordered WHERE ordered.id = session_messages.id)
+       WHERE sequence IS NULL;
+      CREATE INDEX IF NOT EXISTS idx_messages_session_seq
+        ON session_messages(session_id, sequence);
+    `,
+    down: `
+      DROP INDEX IF EXISTS idx_messages_session_seq;
+      -- SQLite cannot DROP COLUMN reliably across versions; leave the column behind.
     `
   }
 ]

--- a/src/main/db/types.ts
+++ b/src/main/db/types.ts
@@ -143,6 +143,7 @@ export interface SessionMessage {
   opencode_message_json: string | null
   opencode_parts_json: string | null
   opencode_timeline_json: string | null
+  sequence: number | null
   created_at: string
 }
 

--- a/src/main/ipc/agent-handlers.ts
+++ b/src/main/ipc/agent-handlers.ts
@@ -232,6 +232,20 @@ export function registerAgentHandlers(
         }
         const impl = c.runtimeManager.getImplementer(runtimeId)
         const result = await impl.reconnect(worktreePath, runtimeSessionId, hiveSessionId)
+        if (result.success && result.sessionId && result.sessionId !== runtimeSessionId) {
+          try {
+            c.dbService.updateSession(hiveSessionId, {
+              opencode_session_id: result.sessionId
+            })
+          } catch (err) {
+            log.warn('Failed to persist opencode_session_id after reconnect', {
+              hiveSessionId,
+              previousRuntimeSessionId: runtimeSessionId,
+              runtimeSessionId: result.sessionId,
+              error: err instanceof Error ? err.message : String(err)
+            })
+          }
+        }
         // Strip the inner `success` so the wrapper's success envelope wins
         // (adapter returns success:false on reconnect failure — treat as error path)
         const { success: innerSuccess, ...rest } = result

--- a/src/main/ipc/session-timeline-handlers.ts
+++ b/src/main/ipc/session-timeline-handlers.ts
@@ -13,6 +13,104 @@ import { getDatabase } from '../db'
 
 const log = createLogger({ component: 'TimelineHandlers' })
 
+function hasRenderableAssistantMessage(messages: unknown[]): boolean {
+  return messages.some((message) => {
+    if (!message || typeof message !== 'object') return false
+    const record = message as Record<string, unknown>
+    if (record.role !== 'assistant') return false
+
+    if (typeof record.content === 'string' && record.content.trim().length > 0) {
+      return true
+    }
+
+    const parts = Array.isArray(record.parts) ? record.parts : []
+    return parts.some((part) => {
+      if (!part || typeof part !== 'object') return false
+      const partRecord = part as Record<string, unknown>
+      if (partRecord.type === 'text' && typeof partRecord.text === 'string') {
+        return partRecord.text.trim().length > 0
+      }
+      if (partRecord.type === 'reasoning' && typeof partRecord.reasoning === 'string') {
+        return partRecord.reasoning.trim().length > 0
+      }
+      if (partRecord.type === 'reasoning' && typeof partRecord.text === 'string') {
+        return partRecord.text.trim().length > 0
+      }
+      return false
+    })
+  })
+}
+
+function extractTurnIdFromTimelineId(messageId: string | undefined): string | null {
+  if (!messageId) return null
+  const match = messageId.match(/^(.*):(user|assistant|tool)(?::.*)?$/)
+  return match?.[1] ?? null
+}
+
+function hasToolUsePart(record: Record<string, unknown>): boolean {
+  const parts = Array.isArray(record.parts) ? record.parts : []
+  return parts.some((part) => {
+    if (!part || typeof part !== 'object') return false
+    return (part as Record<string, unknown>).type === 'tool_use'
+  })
+}
+
+function hasCodexCollapsedToolOrdering(messages: unknown[]): boolean {
+  const byTurn = new Map<string, { assistantTimes: number[]; toolTimes: number[] }>()
+
+  for (const message of messages) {
+    if (!message || typeof message !== 'object') continue
+    const record = message as Record<string, unknown>
+    const turnId = extractTurnIdFromTimelineId(
+      typeof record.id === 'string' ? record.id : undefined
+    )
+    if (!turnId) continue
+
+    const ts = Date.parse(typeof record.timestamp === 'string' ? record.timestamp : '')
+    if (!Number.isFinite(ts)) continue
+    const bucket = byTurn.get(turnId) ?? { assistantTimes: [], toolTimes: [] }
+
+    if (record.role === 'assistant' && hasToolUsePart(record)) {
+      bucket.toolTimes.push(ts)
+    } else if (record.role === 'assistant' && hasRenderableAssistantMessage([record])) {
+      bucket.assistantTimes.push(ts)
+    }
+
+    byTurn.set(turnId, bucket)
+  }
+
+  for (const bucket of byTurn.values()) {
+    if (bucket.assistantTimes.length < 2 || bucket.toolTimes.length === 0) continue
+    const minAssistant = Math.min(...bucket.assistantTimes)
+    const maxAssistant = Math.max(...bucket.assistantTimes)
+    const minTool = Math.min(...bucket.toolTimes)
+    const maxTool = Math.max(...bucket.toolTimes)
+
+    if (maxAssistant - minAssistant <= 1000 && maxTool - minTool >= 2000 && maxAssistant < minTool) {
+      return true
+    }
+
+    // Older recovery code assigned JSONL timestamps by positional index. When
+    // `thread/read` returned summarized items, later assistant text borrowed
+    // nearby tool-call timestamps, putting text before the matching tool card.
+    const assistantTimesSorted = [...bucket.assistantTimes].sort((left, right) => left - right)
+    const borrowedToolTimestampCount = assistantTimesSorted
+      .slice(1)
+      .filter((assistantTime) =>
+        bucket.toolTimes.some((toolTime) => Math.abs(toolTime - assistantTime) <= 100)
+      ).length
+    if (
+      bucket.assistantTimes.length >= 3 &&
+      bucket.toolTimes.length >= 2 &&
+      borrowedToolTimestampCount >= 2
+    ) {
+      return true
+    }
+  }
+
+  return false
+}
+
 export function registerTimelineHandlers(runtimeManager?: AgentRuntimeManager): void {
   log.info('Registering timeline handlers')
 
@@ -20,13 +118,28 @@ export function registerTimelineHandlers(runtimeManager?: AgentRuntimeManager): 
     try {
       let result = getSessionTimeline(sessionId)
 
-      // If DB returned no messages, try to flush the implementer's in-memory
-      // cache to DB first, then re-read. This handles the case where the user
-      // switches away from a session mid-stream before messages are persisted.
-      if (result.messages.length === 0 && runtimeManager) {
-        const session = getDatabase().getSession(sessionId)
-        if (session && (session.agent_sdk === 'claude-code' || session.agent_sdk === 'opencode')) {
-          const runtimeId = session.agent_sdk === 'claude-code' ? 'claude-code' : 'opencode'
+      // If DB returned no messages, or a Codex timeline has only user/tool
+      // rows, try to flush/recover the implementer's transcript first.
+      // The latter case happens after reconnect/abort paths where the local
+      // user rows persisted but assistant agentMessage rows did not.
+      let needsImplementerRecovery =
+        result.messages.length === 0 || !hasRenderableAssistantMessage(result.messages)
+
+      const session = getDatabase().getSession(sessionId)
+      const forceCodexTimelineRefresh =
+        session?.agent_sdk === 'codex' && hasCodexCollapsedToolOrdering(result.messages)
+      if (forceCodexTimelineRefresh) {
+        needsImplementerRecovery = true
+      }
+
+      if (needsImplementerRecovery && runtimeManager) {
+        if (
+          session &&
+          (session.agent_sdk === 'claude-code' ||
+            session.agent_sdk === 'opencode' ||
+            session.agent_sdk === 'codex')
+        ) {
+          const runtimeId = session.agent_sdk
           try {
             const impl = runtimeManager.getImplementer(runtimeId)
             if (impl && session.opencode_session_id) {
@@ -43,7 +156,13 @@ export function registerTimelineHandlers(runtimeManager?: AgentRuntimeManager): 
 
               if (workPath) {
                 // getMessages triggers in-memory → DB persist as a side effect
-                await impl.getMessages(workPath, session.opencode_session_id)
+                if (forceCodexTimelineRefresh) {
+                  await impl.getMessages(workPath, session.opencode_session_id, {
+                    forceRefresh: true
+                  })
+                } else {
+                  await impl.getMessages(workPath, session.opencode_session_id)
+                }
                 // Re-read from DB after flush
                 result = getSessionTimeline(sessionId)
                 if (result.messages.length > 0) {

--- a/src/main/services/agent-runtime-types.ts
+++ b/src/main/services/agent-runtime-types.ts
@@ -47,6 +47,7 @@ export interface AgentRuntimeAdapter {
     hiveSessionId: string
   ): Promise<{
     success: boolean
+    sessionId?: string
     sessionStatus?: 'idle' | 'busy' | 'retry'
     revertMessageID?: string | null
   }>
@@ -69,7 +70,11 @@ export interface AgentRuntimeAdapter {
     options?: PromptOptions
   ): Promise<void>
   abort(worktreePath: string, agentSessionId: string): Promise<boolean>
-  getMessages(worktreePath: string, agentSessionId: string): Promise<unknown[]>
+  getMessages(
+    worktreePath: string,
+    agentSessionId: string,
+    options?: { forceRefresh?: boolean }
+  ): Promise<unknown[]>
 
   // Models
   getAvailableModels(): Promise<unknown>

--- a/src/main/services/claude-code-implementer.ts
+++ b/src/main/services/claude-code-implementer.ts
@@ -237,7 +237,7 @@ interface InFlightToolDraft {
   blockIdx: number
   inputJson: string
   input?: unknown
-  status: 'pending' | 'running' | 'success' | 'error'
+  status: 'pending' | 'running' | 'success' | 'error' | 'rejected'
   startTime: number
   endTime?: number
 }

--- a/src/main/services/codex-activity-mapper.ts
+++ b/src/main/services/codex-activity-mapper.ts
@@ -33,6 +33,12 @@ function buildActivity(
     (typeof payloadRecord?.turn_id === 'string' && payloadRecord.turn_id) ||
     (typeof (payloadRecord?.turn as Record<string, unknown> | undefined)?.id === 'string'
       ? ((payloadRecord?.turn as Record<string, unknown>).id as string)
+      : null) ||
+    (typeof (payloadRecord?.item as Record<string, unknown> | undefined)?.turnId === 'string'
+      ? ((payloadRecord?.item as Record<string, unknown>).turnId as string)
+      : null) ||
+    (typeof (payloadRecord?.item as Record<string, unknown> | undefined)?.turn_id === 'string'
+      ? ((payloadRecord?.item as Record<string, unknown>).turn_id as string)
       : null)
   const payloadItemId =
     (typeof payloadRecord?.itemId === 'string' && payloadRecord.itemId) ||

--- a/src/main/services/codex-app-server-manager.ts
+++ b/src/main/services/codex-app-server-manager.ts
@@ -804,15 +804,6 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
       threadId: context.session.threadId,
       ...(targetTurnId ? { turnId: targetTurnId } : {})
     })
-
-    this.updateSession(context, {
-      status: 'ready',
-      activeTurnId: null
-    })
-
-    this.emitLifecycleEvent(context, 'turn/interrupted', 'Turn interrupted', {
-      turnId: targetTurnId ?? undefined
-    })
   }
 
   async readThread(threadId: string): Promise<unknown> {
@@ -1001,6 +992,7 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
     }
 
     const route = this.readRouteFields(notification.params)
+    const effectiveTurnId = route.turnId ?? context.session.activeTurnId ?? undefined
 
     // Extract textDelta for streaming text notifications (matches t3code pattern)
     const textDelta =
@@ -1012,10 +1004,10 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
       id: randomUUID(),
       kind: 'notification',
       provider: 'codex',
-      threadId: context.session.threadId ?? '',
+      threadId: context.session.threadId ?? route.threadId ?? '',
       createdAt: new Date().toISOString(),
       method: notification.method,
-      turnId: route.turnId,
+      turnId: effectiveTurnId,
       itemId: route.itemId,
       textDelta,
       payload: notification.params
@@ -1041,10 +1033,40 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
       })
       return
     }
+
+    if (notification.method === 'thread/status/changed') {
+      const params = asObject(notification.params)
+      const statusObj = asObject(params?.status) ?? params
+      const statusType = asString(statusObj?.type)
+
+      if (statusType === 'active' || statusType === 'running' || statusType === 'busy') {
+        this.updateSession(context, {
+          status: 'running',
+          ...(route.turnId ? { activeTurnId: route.turnId } : {})
+        })
+        return
+      }
+
+      if (statusType === 'idle') {
+        this.updateSession(context, {
+          status: 'ready',
+          activeTurnId: null
+        })
+        return
+      }
+
+      if (statusType === 'error') {
+        this.updateSession(context, {
+          status: 'error',
+          activeTurnId: null
+        })
+      }
+    }
   }
 
   private handleServerRequest(context: CodexSessionContext, request: JsonRpcRequest): void {
     const route = this.readRouteFields(request.params)
+    const effectiveTurnId = route.turnId ?? context.session.activeTurnId ?? undefined
     const requestId = randomUUID()
 
     // Track approval requests
@@ -1057,9 +1079,9 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
         requestId,
         jsonRpcId: request.id,
         method: request.method,
-        threadId: context.session.threadId ?? '',
+        threadId: context.session.threadId ?? route.threadId ?? '',
         payload: request.params,
-        ...(route.turnId ? { turnId: route.turnId } : {}),
+        ...(effectiveTurnId ? { turnId: effectiveTurnId } : {}),
         ...(route.itemId ? { itemId: route.itemId } : {})
       })
     }
@@ -1069,8 +1091,8 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
       context.pendingUserInputs.set(requestId, {
         requestId,
         jsonRpcId: request.id,
-        threadId: context.session.threadId ?? '',
-        ...(route.turnId ? { turnId: route.turnId } : {}),
+        threadId: context.session.threadId ?? route.threadId ?? '',
+        ...(effectiveTurnId ? { turnId: effectiveTurnId } : {}),
         ...(route.itemId ? { itemId: route.itemId } : {})
       })
     }
@@ -1079,10 +1101,10 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
       id: randomUUID(),
       kind: 'request',
       provider: 'codex',
-      threadId: context.session.threadId ?? '',
+      threadId: context.session.threadId ?? route.threadId ?? '',
       createdAt: new Date().toISOString(),
       method: request.method,
-      turnId: route.turnId,
+      turnId: effectiveTurnId,
       itemId: route.itemId,
       requestId,
       payload: request.params
@@ -1204,6 +1226,7 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
   // ── Protocol helpers ──────────────────────────────────────────
 
   private readRouteFields(params: unknown): {
+    threadId?: string
     turnId?: string
     itemId?: string
   } {
@@ -1213,10 +1236,18 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
     const turnObj = asObject(paramsObj.turn)
     const itemObj = asObject(paramsObj.item)
 
-    const turnId = asString(paramsObj.turnId) ?? asString(turnObj?.id)
-    const itemId = asString(paramsObj.itemId) ?? asString(itemObj?.id)
+    const threadId = asString(paramsObj.threadId) ?? asString(paramsObj.thread_id)
+    const turnId =
+      asString(paramsObj.turnId) ??
+      asString(paramsObj.turn_id) ??
+      asString(turnObj?.id) ??
+      asString(itemObj?.turnId) ??
+      asString(itemObj?.turn_id)
+    const itemId =
+      asString(paramsObj.itemId) ?? asString(paramsObj.item_id) ?? asString(itemObj?.id)
 
     return {
+      ...(threadId ? { threadId } : {}),
       ...(turnId ? { turnId } : {}),
       ...(itemId ? { itemId } : {})
     }

--- a/src/main/services/codex-config.ts
+++ b/src/main/services/codex-config.ts
@@ -1,0 +1,118 @@
+import { existsSync, readFileSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+
+interface CodexConfigSection {
+  values: Record<string, string>
+}
+
+export interface CodexConfig {
+  model?: string
+  modelContextWindow?: number
+  activeProfile?: string
+  profiles: Record<string, CodexConfigSection>
+}
+
+function stripInlineComment(line: string): string {
+  let inString = false
+  let quote: '"' | "'" | null = null
+
+  for (let i = 0; i < line.length; i++) {
+    const ch = line[i]
+    if ((ch === '"' || ch === "'") && line[i - 1] !== '\\') {
+      if (!inString) {
+        inString = true
+        quote = ch
+      } else if (quote === ch) {
+        inString = false
+        quote = null
+      }
+    }
+    if (ch === '#' && !inString) {
+      return line.slice(0, i).trim()
+    }
+  }
+
+  return line.trim()
+}
+
+function parseTomlScalar(value: string): string {
+  const trimmed = value.trim()
+  if (
+    (trimmed.startsWith('"') && trimmed.endsWith('"')) ||
+    (trimmed.startsWith("'") && trimmed.endsWith("'"))
+  ) {
+    return trimmed.slice(1, -1)
+  }
+  return trimmed
+}
+
+function toPositiveInteger(value: string | undefined): number | undefined {
+  if (!value) return undefined
+  const parsed = Number(value)
+  return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : undefined
+}
+
+export function getCodexConfigPath(): string {
+  const codexHome = process.env.CODEX_HOME?.trim() || join(homedir(), '.codex')
+  return join(codexHome, 'config.toml')
+}
+
+export function parseCodexConfigToml(raw: string): CodexConfig {
+  const root: Record<string, string> = {}
+  const profiles: Record<string, CodexConfigSection> = {}
+  let current: Record<string, string> = root
+
+  for (const rawLine of raw.split(/\r?\n/)) {
+    const line = stripInlineComment(rawLine)
+    if (!line) continue
+
+    const sectionMatch = line.match(/^\[([^\]]+)\]$/)
+    if (sectionMatch) {
+      const section = sectionMatch[1]?.trim() ?? ''
+      const profileMatch = section.match(/^profiles\.([A-Za-z0-9_.-]+)$/)
+      if (profileMatch) {
+        const profileName = profileMatch[1]!
+        profiles[profileName] = profiles[profileName] ?? { values: {} }
+        current = profiles[profileName].values
+      } else {
+        current = {}
+      }
+      continue
+    }
+
+    const assignment = line.match(/^([A-Za-z0-9_.-]+)\s*=\s*(.+)$/)
+    if (!assignment) continue
+    current[assignment[1]!] = parseTomlScalar(assignment[2]!)
+  }
+
+  const activeProfile = root.profile
+  const profileValues = activeProfile ? profiles[activeProfile]?.values : undefined
+
+  return {
+    model: profileValues?.model ?? root.model,
+    modelContextWindow:
+      toPositiveInteger(profileValues?.model_context_window) ??
+      toPositiveInteger(root.model_context_window),
+    activeProfile,
+    profiles
+  }
+}
+
+export function readCodexConfig(): CodexConfig | null {
+  const configPath = getCodexConfigPath()
+  if (!existsSync(configPath)) return null
+  try {
+    return parseCodexConfigToml(readFileSync(configPath, 'utf-8'))
+  } catch {
+    return null
+  }
+}
+
+export function getCodexConfiguredModel(): string | undefined {
+  return readCodexConfig()?.model
+}
+
+export function getCodexConfiguredContextWindow(): number | undefined {
+  return readCodexConfig()?.modelContextWindow
+}

--- a/src/main/services/codex-event-mapper.ts
+++ b/src/main/services/codex-event-mapper.ts
@@ -10,6 +10,7 @@ import type {
 import { classifyCodexItem, type ClassifiedCodexItem } from '@shared/lib/codex-classify'
 import type { CodexManagerEvent } from './codex-app-server-manager'
 import { asObject, asString, asNumber } from './codex-utils'
+import { getCodexConfiguredContextWindow } from './codex-config'
 
 // Re-export for callers that previously imported from this module.
 export { classifyCodexItem }
@@ -631,18 +632,23 @@ function tokenUsageEvent(
   const payload = asObject(event.payload)
   const tokenUsage = asObject(payload?.tokenUsage)
   if (!tokenUsage) return null
-  const total = asObject(tokenUsage.total)
-  const contextWindow = asNumber(tokenUsage.modelContextWindow)
-  const inputTokens = asNumber(total?.inputTokens) ?? 0
-  const outputTokens = asNumber(total?.outputTokens) ?? 0
-  const cachedInputTokens = asNumber(total?.cachedInputTokens)
-  const reasoningTokens = asNumber(total?.reasoningOutputTokens)
+  // The context meter represents the current prompt's window occupancy, not
+  // cumulative billing/usage across the whole thread. Codex sends that as
+  // `last`; older payloads may only include `total`, so keep it as a fallback.
+  const usage = asObject(tokenUsage.last) ?? asObject(tokenUsage.total)
+  const contextWindow = getCodexConfiguredContextWindow() ?? asNumber(tokenUsage.modelContextWindow)
+  const inputTokens = asNumber(usage?.inputTokens) ?? 0
+  const outputTokens = asNumber(usage?.outputTokens) ?? 0
+  const cachedInputTokens = asNumber(usage?.cachedInputTokens)
+  const reasoningTokens = asNumber(usage?.reasoningOutputTokens)
+  const uncachedInputTokens =
+    cachedInputTokens !== undefined ? Math.max(0, inputTokens - cachedInputTokens) : inputTokens
   return {
     type: 'session.context_usage',
     sessionId: hiveSessionId,
     data: {
       tokens: {
-        input: inputTokens,
+        input: uncachedInputTokens,
         output: outputTokens,
         ...(cachedInputTokens !== undefined ? { cacheRead: cachedInputTokens } : {}),
         ...(reasoningTokens !== undefined ? { reasoning: reasoningTokens } : {})
@@ -881,9 +887,10 @@ export function mapCodexEventToStreamEvents(
 
   // ── Thread status → session.status (active = busy, idle = idle) ─
   if (method === 'thread/status/changed') {
-    const status = asObject(asObject(event.payload)?.status)
+    const payload = asObject(event.payload)
+    const status = asObject(payload?.status) ?? payload
     const t = asString(status?.type)
-    if (t === 'active') {
+    if (t === 'active' || t === 'running' || t === 'busy') {
       return [
         {
           type: 'session.status',

--- a/src/main/services/codex-event-mapper.ts
+++ b/src/main/services/codex-event-mapper.ts
@@ -632,15 +632,14 @@ function tokenUsageEvent(
   const payload = asObject(event.payload)
   const tokenUsage = asObject(payload?.tokenUsage)
   if (!tokenUsage) return null
-  // The context meter represents the current prompt's window occupancy, not
-  // cumulative billing/usage across the whole thread. Codex sends that as
-  // `last`; older payloads may only include `total`, so keep it as a fallback.
-  const usage = asObject(tokenUsage.last) ?? asObject(tokenUsage.total)
+  const currentUsage = asObject(tokenUsage.last) ?? asObject(tokenUsage.total)
+  const cumulativeUsage = asObject(tokenUsage.total) ?? currentUsage
   const contextWindow = getCodexConfiguredContextWindow() ?? asNumber(tokenUsage.modelContextWindow)
-  const inputTokens = asNumber(usage?.inputTokens) ?? 0
-  const outputTokens = asNumber(usage?.outputTokens) ?? 0
-  const cachedInputTokens = asNumber(usage?.cachedInputTokens)
-  const reasoningTokens = asNumber(usage?.reasoningOutputTokens)
+  const inputTokens = asNumber(cumulativeUsage?.inputTokens) ?? 0
+  const outputTokens = asNumber(cumulativeUsage?.outputTokens) ?? 0
+  const cachedInputTokens = asNumber(cumulativeUsage?.cachedInputTokens)
+  const reasoningTokens = asNumber(cumulativeUsage?.reasoningOutputTokens)
+  const currentInputTokens = asNumber(currentUsage?.inputTokens) ?? inputTokens
   const uncachedInputTokens =
     cachedInputTokens !== undefined ? Math.max(0, inputTokens - cachedInputTokens) : inputTokens
   return {
@@ -653,7 +652,16 @@ function tokenUsageEvent(
         ...(cachedInputTokens !== undefined ? { cacheRead: cachedInputTokens } : {}),
         ...(reasoningTokens !== undefined ? { reasoning: reasoningTokens } : {})
       },
-      ...(contextWindow !== undefined ? { contextWindow } : {})
+      ...(contextWindow !== undefined
+        ? {
+            contextWindow,
+            breakdown: {
+              usedTokens: currentInputTokens,
+              maxTokens: contextWindow,
+              percentage: contextWindow > 0 ? (currentInputTokens / contextWindow) * 100 : 0
+            }
+          }
+        : {})
     }
   }
 }

--- a/src/main/services/codex-implementer.ts
+++ b/src/main/services/codex-implementer.ts
@@ -1,5 +1,6 @@
 import type { BrowserWindow } from 'electron'
 import { randomUUID } from 'node:crypto'
+import { readFileSync } from 'node:fs'
 
 import type {
   AgentSdkCapabilities,
@@ -26,10 +27,12 @@ import {
 import { ensureCodexAppServerLaunchSpec } from './codex-binary-resolver'
 import { asNumber, asObject, asString, toDebugSnapshot } from './codex-utils'
 import { generateCodexSessionTitle } from './codex-session-title'
+import { getCodexConfiguredContextWindow, getCodexConfiguredModel } from './codex-config'
 import type { DatabaseService } from '../db/database'
 import { autoRenameWorktreeBranch } from './git-service'
 import { beginSessionRun, emitAgentEvent } from '@shared/lib/normalize-agent-event'
 import { stripFieldContextEnvelope } from '@shared/lib/field-context-envelope'
+import { calculateUsageCost } from '@shared/usage/pricing'
 import { notificationService } from './notification-service'
 import { buildXfpFallbackContext } from '../xfp/fallback-context'
 import { xfpProvider } from '../xfp/provider'
@@ -52,6 +55,7 @@ export interface CodexSessionState {
   revertDiff: string | null
   titleGenerated: boolean
   titleGenerationStarted: boolean
+  tokenUsageCostByTurn?: Map<string, number>
   /**
    * Per-session mapper state. Codex commandExecution streams stdout via
    * outputDelta chunks; the mapper aggregates them into state.output here so
@@ -69,6 +73,7 @@ export interface CodexSessionState {
    * between streaming and the snapshot.
    */
   itemTimestampsByTurn: Map<string, string[]>
+  recordedItemIdsByTurn?: Map<string, Set<string>>
 }
 
 interface CodexActiveRun {
@@ -77,6 +82,7 @@ interface CodexActiveRun {
   state: 'starting' | 'running' | 'aborting' | 'finalizing' | 'settled'
   startedAt: number
   abortController: AbortController
+  interruptRequestedTurnId?: string | null
 }
 
 interface CodexLiveToolPart {
@@ -115,6 +121,24 @@ interface CodexLiveAssistantDraft {
   timestamp: string
   parts: CodexLiveDraftPart[]
   toolIndexById: Map<string, number>
+}
+
+interface CodexJsonlTextTimestamp {
+  text: string
+  timestamp: string
+}
+
+interface CodexJsonlTurnTimeline {
+  /**
+   * Fallback sequence from the JSONL response stream. This is only safe when
+   * its length matches the `thread/read` item count; otherwise the server may
+   * have returned a summarized item list and text must be matched by content.
+   */
+  positional: string[]
+  userMessages: CodexJsonlTextTimestamp[]
+  assistantMessages: CodexJsonlTextTimestamp[]
+  reasoningMessages: CodexJsonlTextTimestamp[]
+  toolCallTimestampsById: Map<string, string>
 }
 
 // ── Pending HITL entry (shared by questions and approvals) ────────
@@ -205,6 +229,49 @@ function stripCodexPromptPart(part: CodexPromptPart): CodexPromptPart {
   return { ...part, text: stripFieldContextEnvelope(part.text) }
 }
 
+function normalizeCodexTimelineText(text: string): string {
+  return text.trim().replace(/\s+/g, ' ')
+}
+
+function extractCodexJsonlContentText(content: unknown): string {
+  if (!Array.isArray(content)) return ''
+
+  return content
+    .map((entry) => asObject(entry))
+    .map((entry) => asString(entry?.text) ?? '')
+    .filter(Boolean)
+    .join('\n')
+    .trim()
+}
+
+function extractCodexJsonlReasoningText(payload: Record<string, unknown>): string {
+  const extract = (value: unknown): string[] => {
+    if (!Array.isArray(value)) return []
+    return value.flatMap((entry) => {
+      if (typeof entry === 'string') return entry
+      const entryObj = asObject(entry)
+      const text = asString(entryObj?.text)
+      return text ? [text] : []
+    })
+  }
+
+  return [...extract(payload.summary), ...extract(payload.content)].join('\n').trim()
+}
+
+function shiftMatchingCodexJsonlTextTimestamp(
+  entries: CodexJsonlTextTimestamp[],
+  text: string
+): string | null {
+  const target = normalizeCodexTimelineText(text)
+  if (!target) return null
+
+  const index = entries.findIndex((entry) => normalizeCodexTimelineText(entry.text) === target)
+  if (index < 0) return null
+
+  const [entry] = entries.splice(index, 1)
+  return entry?.timestamp ?? null
+}
+
 function normalizeCodexDisplayMessage(message: CodexPromptMessage): {
   text: string
   parts: CodexPromptPart[]
@@ -268,6 +335,30 @@ function sanitizeCodexUserMessageForPersistence(message: unknown): unknown {
   return sanitized
 }
 
+function hasRenderableAssistantMessage(messages: unknown[]): boolean {
+  return messages.some((message) => {
+    const record = asObject(message)
+    if (record?.role !== 'assistant') return false
+
+    if (typeof record.content === 'string' && record.content.trim().length > 0) {
+      return true
+    }
+
+    const parts = Array.isArray(record.parts) ? record.parts : []
+    return parts.some((part) => {
+      const partRecord = asObject(part)
+      if (!partRecord) return false
+      if (partRecord.type === 'text' && typeof partRecord.text === 'string') {
+        return partRecord.text.trim().length > 0
+      }
+      if (partRecord.type === 'reasoning' && typeof partRecord.text === 'string') {
+        return partRecord.text.trim().length > 0
+      }
+      return false
+    })
+  })
+}
+
 // ── Immediate title helpers ────────────────────────────────────────────────
 
 const IMMEDIATE_TITLE_LENGTH = 50
@@ -296,18 +387,167 @@ export function normalizeCodexMessageTimestamps<T extends { created_at: string }
   })
 }
 
+function extractCodexTurnIdFromMessageId(messageId: string | undefined): string | null {
+  if (!messageId) return null
+  const match = messageId.match(/^(.*):(user|assistant)(?::.*)?$/)
+  return match?.[1] ?? null
+}
+
+function hasRenderableTextMessage(message: unknown): boolean {
+  const record = asObject(message)
+  if (!record) return false
+  if (typeof record.content === 'string' && record.content.trim().length > 0) return true
+
+  const parts = Array.isArray(record.parts) ? record.parts : []
+  return parts.some((part) => {
+    const partRecord = asObject(part)
+    if (!partRecord) return false
+    if (partRecord.type === 'text' && typeof partRecord.text === 'string') {
+      return partRecord.text.trim().length > 0
+    }
+    if (partRecord.type === 'reasoning' && typeof partRecord.text === 'string') {
+      return partRecord.text.trim().length > 0
+    }
+    return false
+  })
+}
+
+function isCodexToolItemType(itemType: string | undefined): boolean {
+  return (
+    itemType === 'commandExecution' ||
+    itemType === 'fileChange' ||
+    itemType === 'webSearch' ||
+    itemType === 'mcpToolCall'
+  )
+}
+
+function timestampFromMs(value: unknown): string | null {
+  const raw = asNumber(value)
+  if (raw === undefined) return null
+  const ms = raw < 10_000_000_000 ? raw * 1000 : raw
+  const date = new Date(ms)
+  return Number.isFinite(date.getTime()) ? date.toISOString() : null
+}
+
+function eventTimestampFromPayload(payload: Record<string, unknown> | null): string | null {
+  return (
+    timestampFromMs(payload?.startedAtMs) ??
+    timestampFromMs(payload?.completedAtMs) ??
+    timestampFromMs(payload?.createdAtMs) ??
+    timestampFromMs(payload?.updatedAtMs)
+  )
+}
+
+export function hasCollapsedCodexMessageTimeline(
+  messages: unknown[],
+  activities: Array<{ turn_id?: string | null; kind?: string; created_at?: string }>
+): boolean {
+  const toolSpansByTurn = new Map<string, { min: number; max: number; count: number }>()
+
+  for (const activity of activities) {
+    if (!activity.kind?.startsWith('tool.')) continue
+    if (!activity.turn_id) continue
+    const ts = Date.parse(activity.created_at ?? '')
+    if (!Number.isFinite(ts)) continue
+    const current = toolSpansByTurn.get(activity.turn_id) ?? {
+      min: Number.POSITIVE_INFINITY,
+      max: Number.NEGATIVE_INFINITY,
+      count: 0
+    }
+    current.min = Math.min(current.min, ts)
+    current.max = Math.max(current.max, ts)
+    current.count += 1
+    toolSpansByTurn.set(activity.turn_id, current)
+  }
+
+  if (toolSpansByTurn.size === 0) return false
+
+  const assistantTimesByTurn = new Map<string, number[]>()
+  for (const message of messages) {
+    const record = asObject(message)
+    if (!record || record.role !== 'assistant') continue
+    if (!hasRenderableTextMessage(message)) continue
+
+    const turnId = extractCodexTurnIdFromMessageId(asString(record.id))
+    if (!turnId) continue
+    const ts = Date.parse(asString(record.timestamp) ?? '')
+    if (!Number.isFinite(ts)) continue
+    const list = assistantTimesByTurn.get(turnId) ?? []
+    list.push(ts)
+    assistantTimesByTurn.set(turnId, list)
+  }
+
+  for (const [turnId, assistantTimes] of assistantTimesByTurn) {
+    if (assistantTimes.length < 2) continue
+    const toolSpan = toolSpansByTurn.get(turnId)
+    if (!toolSpan || toolSpan.count === 0) continue
+
+    const minAssistant = Math.min(...assistantTimes)
+    const maxAssistant = Math.max(...assistantTimes)
+    const assistantSpread = maxAssistant - minAssistant
+    const toolSpread = toolSpan.max - toolSpan.min
+
+    if (assistantSpread <= 1000 && toolSpread >= 2000 && maxAssistant < toolSpan.min) {
+      return true
+    }
+  }
+
+  return false
+}
+
 export class CodexImplementer implements AgentSdkImplementer, AgentRuntimeAdapter {
   readonly id = 'codex' as const
   readonly capabilities: AgentSdkCapabilities = CODEX_CAPABILITIES
 
   private mainWindow: BrowserWindow | null = null
   private dbService: DatabaseService | null = null
-  private selectedModel: string = CODEX_DEFAULT_MODEL
+  private selectedModel: string = resolveCodexModelSlug(
+    getCodexConfiguredModel() ?? CODEX_DEFAULT_MODEL
+  )
   private selectedVariant: string | undefined
   private manager: CodexAppServerManager = new CodexAppServerManager()
   private sessions = new Map<string, CodexSessionState>()
   private pendingQuestions = new Map<string, PendingHitlEntry>()
   private pendingApprovalSessions = new Map<string, PendingHitlEntry>()
+
+  private resolveContextWindow(runtimeValue: number | undefined, modelID: string): number {
+    return (
+      getCodexConfiguredContextWindow() ??
+      runtimeValue ??
+      getCodexModelInfo(modelID)?.limit.context ??
+      0
+    )
+  }
+
+  private calculateTurnTokenUsageCostDelta(
+    session: CodexSessionState,
+    turnId: string | undefined,
+    modelID: string,
+    tokens: { input: number; cacheRead: number; cacheWrite: number; output: number }
+  ): { cost?: number; requestId?: string } {
+    if (!turnId) return {}
+
+    const costByTurn =
+      session.tokenUsageCostByTurn ?? (session.tokenUsageCostByTurn = new Map<string, number>())
+    const totalCost = calculateUsageCost(modelID, tokens, 'codex')
+    const previousCost = costByTurn.get(turnId) ?? 0
+    costByTurn.set(turnId, Math.max(previousCost, totalCost))
+
+    const delta = Math.max(0, totalCost - previousCost)
+    if (delta <= 0) return {}
+
+    return {
+      cost: delta,
+      requestId: [
+        'codex-context-usage',
+        turnId,
+        tokens.input,
+        tokens.cacheRead,
+        tokens.cacheWrite,
+        tokens.output
+      ].join(':')
+    }
+  }
 
   // ── Window binding ───────────────────────────────────────────────
 
@@ -387,24 +627,7 @@ export class CodexImplementer implements AgentSdkImplementer, AgentRuntimeAdapte
     if (targetSession) {
       this.persistActivity(targetSession, event)
 
-      // Record per-turn item arrival timestamps so parseThreadSnapshot can
-      // assign chronologically-correct timestamps later. Codex's thread/read
-      // response renumbers item ids (`item-1`, `item-2`, …) so id-keyed
-      // matching always misses; positional matching (turn → ordered list of
-      // ts) is the reliable bridge between streaming and snapshot.
-      if (
-        event.kind === 'notification' &&
-        (event.method === 'item/started' || event.method === 'item.started')
-      ) {
-        const turnId = event.turnId ?? asString(asObject(event.payload)?.turnId) ?? null
-        if (turnId) {
-          const list =
-            targetSession.itemTimestampsByTurn.get(turnId) ??
-            (targetSession.itemTimestampsByTurn.set(turnId, []),
-            targetSession.itemTimestampsByTurn.get(turnId)!)
-          list.push(new Date().toISOString())
-        }
-      }
+      this.recordCodexItemTimelineTimestamp(targetSession, event)
 
       // Phase 21.5: emit agent.* field events when a tool item completes.
       // Wrapped in try/catch — instrumentation failure must never affect
@@ -445,7 +668,7 @@ export class CodexImplementer implements AgentSdkImplementer, AgentRuntimeAdapte
       // The context window shows how full the current prompt is,
       // not the sum of all tokens consumed across every turn.
       const last = asObject(tokenUsage?.last)
-      const contextWindow = asNumber(tokenUsage?.modelContextWindow) ?? 0
+      const turnId = event.turnId ?? asString(payload?.turnId)
 
       const inputTokens = asNumber(last?.inputTokens) ?? 0
       const cachedInputTokens = asNumber(last?.cachedInputTokens) ?? 0
@@ -453,22 +676,27 @@ export class CodexImplementer implements AgentSdkImplementer, AgentRuntimeAdapte
       const reasoningTokens = asNumber(last?.reasoningOutputTokens) ?? 0
 
       const modelID = resolveCodexModelSlug(asString(payload?.model) ?? this.selectedModel)
+      const contextWindow = this.resolveContextWindow(
+        asNumber(tokenUsage?.modelContextWindow),
+        modelID
+      )
+      const tokens = {
+        input: Math.max(0, inputTokens - cachedInputTokens),
+        cacheRead: cachedInputTokens,
+        cacheWrite: 0,
+        output: outputTokens,
+        reasoning: reasoningTokens
+      }
+      const costData = this.calculateTurnTokenUsageCostDelta(targetSession, turnId, modelID, tokens)
 
       emitAgentEvent(this.mainWindow, {
         type: 'session.context_usage',
         sessionId: targetSession.hiveSessionId,
         data: {
-          tokens: {
-            // inputTokens includes cached; subtract so
-            // input + cacheRead = total prompt tokens in store
-            input: inputTokens - cachedInputTokens,
-            cacheRead: cachedInputTokens,
-            cacheWrite: 0,
-            output: outputTokens,
-            reasoning: reasoningTokens
-          },
+          tokens,
           model: { providerID: 'codex', modelID },
-          contextWindow
+          contextWindow,
+          ...costData
         }
       })
       return
@@ -721,8 +949,10 @@ export class CodexImplementer implements AgentSdkImplementer, AgentRuntimeAdapte
       revertDiff: null,
       titleGenerated: false,
       titleGenerationStarted: false,
+      tokenUsageCostByTurn: new Map(),
       mapperState: createCodexMapperState(),
-      itemTimestampsByTurn: new Map()
+      itemTimestampsByTurn: new Map(),
+      recordedItemIdsByTurn: new Map()
     }
     this.sessions.set(key, state)
 
@@ -743,6 +973,7 @@ export class CodexImplementer implements AgentSdkImplementer, AgentRuntimeAdapte
     hiveSessionId: string
   ): Promise<{
     success: boolean
+    sessionId?: string
     sessionStatus?: 'idle' | 'busy' | 'retry'
     revertMessageID?: string | null
   }> {
@@ -759,7 +990,7 @@ export class CodexImplementer implements AgentSdkImplementer, AgentRuntimeAdapte
         hiveSessionId,
         sessionStatus
       })
-      return { success: true, sessionStatus, revertMessageID: null }
+      return { success: true, sessionId: existing.threadId, sessionStatus, revertMessageID: null }
     }
 
     // Otherwise, start a new session with thread resume
@@ -795,8 +1026,10 @@ export class CodexImplementer implements AgentSdkImplementer, AgentRuntimeAdapte
         revertDiff: null,
         titleGenerated: true,
         titleGenerationStarted: true,
+        tokenUsageCostByTurn: new Map(),
         mapperState: createCodexMapperState(),
-        itemTimestampsByTurn: new Map()
+        itemTimestampsByTurn: new Map(),
+        recordedItemIdsByTurn: new Map()
       }
       this.sessions.set(newKey, state)
 
@@ -808,6 +1041,7 @@ export class CodexImplementer implements AgentSdkImplementer, AgentRuntimeAdapte
 
       return {
         success: true,
+        sessionId: state.threadId,
         sessionStatus: this.statusToHive(state.status),
         revertMessageID: null
       }
@@ -949,6 +1183,7 @@ export class CodexImplementer implements AgentSdkImplementer, AgentRuntimeAdapte
       // prevents late events from a stopped turn from completing or repainting
       // a newly-started prompt on the same Codex thread.
       if (!this.eventMatchesActiveRun(session, runId, event)) return
+      this.bindActiveRunTurnId(session, runId, event)
 
       const streamEvents = mapCodexEventToStreamEvents(
         event,
@@ -957,7 +1192,7 @@ export class CodexImplementer implements AgentSdkImplementer, AgentRuntimeAdapte
       )
       for (const streamEvent of streamEvents) {
         if (
-          event.method === 'turn/completed' &&
+          (event.method === 'turn/completed' || event.method === 'thread/status/changed') &&
           streamEvent.type === 'session.status' &&
           streamEvent.statusPayload?.type === 'idle'
         ) {
@@ -1163,8 +1398,10 @@ export class CodexImplementer implements AgentSdkImplementer, AgentRuntimeAdapte
         return
       }
 
-      activeRun.expectedTurnId = turnStart.turnId || null
-      activeRun.state = 'running'
+      activeRun.expectedTurnId = turnStart.turnId || activeRun.expectedTurnId || null
+      if (activeRun.state !== 'aborting') {
+        activeRun.state = 'running'
+      }
 
       // Wait for turn completion (the sendTurn starts the turn, but
       // events stream asynchronously via the manager's event emitter)
@@ -1480,19 +1717,8 @@ export class CodexImplementer implements AgentSdkImplementer, AgentRuntimeAdapte
     const managerSession = this.manager.getSession(session.threadId)
     const expectedTurnId = activeRun?.expectedTurnId ?? managerSession?.activeTurnId ?? null
 
-    const materialized = this.materializeLiveAssistantDraft(session, {
-      aborted: true,
-      terminalizeRunningTools: true,
-      emitTerminalTools: true
-    })
-    if (materialized) {
-      this.persistCanonicalMessages(session)
-    }
-    session.liveAssistantDraft = null
-
     if (activeRun) {
-      activeRun.abortController.abort()
-      this.settleRun(session, activeRun.runId)
+      activeRun.interruptRequestedTurnId = expectedTurnId
     }
 
     try {
@@ -1502,19 +1728,36 @@ export class CodexImplementer implements AgentSdkImplementer, AgentRuntimeAdapte
         await this.manager.interruptTurn(session.threadId)
       }
     } catch (error) {
-      log.warn('Abort: interruptTurn failed, continuing cleanup', {
+      log.warn('Abort: interruptTurn failed', {
         worktreePath,
         agentSessionId,
         error: error instanceof Error ? error.message : String(error)
       })
+      return false
     }
 
-    session.status = 'ready'
-    this.emitStatus(session.hiveSessionId, 'idle')
+    if (!activeRun) {
+      const materialized = this.materializeLiveAssistantDraft(session, {
+        aborted: true,
+        terminalizeRunningTools: true,
+        emitTerminalTools: true
+      })
+      if (materialized) {
+        this.persistCanonicalMessages(session)
+      }
+      session.liveAssistantDraft = null
+      session.status = 'ready'
+      this.emitStatus(session.hiveSessionId, 'idle')
+    }
+
     return true
   }
 
-  async getMessages(worktreePath: string, agentSessionId: string): Promise<unknown[]> {
+  async getMessages(
+    worktreePath: string,
+    agentSessionId: string,
+    options?: { forceRefresh?: boolean }
+  ): Promise<unknown[]> {
     const key = this.getSessionKey(worktreePath, agentSessionId)
     let session = this.sessions.get(key)
     if (!session) {
@@ -1527,11 +1770,25 @@ export class CodexImplementer implements AgentSdkImplementer, AgentRuntimeAdapte
       return []
     }
 
-    // Return in-memory messages if available
+    let fallbackMessages: unknown[] | null = null
+
+    // Return in-memory messages if they contain assistant text. A user-only
+    // cache is incomplete after reconnect/abort paths; continue to thread/read
+    // so missing Codex replies can be recovered.
     if (session.messages.length > 0) {
       const liveDraftMessage =
         session.status === 'running' ? this.cloneLiveAssistantDraftMessage(session) : null
-      return liveDraftMessage ? [...session.messages, liveDraftMessage] : [...session.messages]
+      const inMemoryMessages = liveDraftMessage
+        ? [...session.messages, liveDraftMessage]
+        : [...session.messages]
+      if (
+        !options?.forceRefresh &&
+        (hasRenderableAssistantMessage(inMemoryMessages) || session.status === 'running') &&
+        !this.shouldRefreshCollapsedTimeline(session, inMemoryMessages)
+      ) {
+        return inMemoryMessages
+      }
+      fallbackMessages = inMemoryMessages
     }
 
     if (session.status === 'running') {
@@ -1558,7 +1815,14 @@ export class CodexImplementer implements AgentSdkImplementer, AgentRuntimeAdapte
               sanitizeCodexUserMessageForPersistence(message)
             )
             session.messages = sanitized
-            return [...sanitized]
+            if (
+              !options?.forceRefresh &&
+              (hasRenderableAssistantMessage(sanitized) || session.status === 'closed') &&
+              !this.shouldRefreshCollapsedTimeline(session, sanitized)
+            ) {
+              return [...sanitized]
+            }
+            fallbackMessages = [...sanitized]
           }
         }
       } catch (error) {
@@ -1591,13 +1855,28 @@ export class CodexImplementer implements AgentSdkImplementer, AgentRuntimeAdapte
       }
     }
 
-    return []
+    return fallbackMessages ? [...fallbackMessages] : []
   }
 
   // ── Models ───────────────────────────────────────────────────────
 
   async getAvailableModels(): Promise<unknown> {
-    return getAvailableCodexModels()
+    const configuredContextWindow = getCodexConfiguredContextWindow()
+    const providers = getAvailableCodexModels()
+    if (!configuredContextWindow) return providers
+
+    return providers.map((provider) => ({
+      ...provider,
+      models: Object.fromEntries(
+        Object.entries(provider.models).map(([id, model]) => [
+          id,
+          {
+            ...model,
+            limit: { ...model.limit, context: configuredContextWindow }
+          }
+        ])
+      )
+    }))
   }
 
   async getModelInfo(
@@ -1608,7 +1887,13 @@ export class CodexImplementer implements AgentSdkImplementer, AgentRuntimeAdapte
     name: string
     limit: { context: number; input?: number; output: number }
   } | null> {
-    return getCodexModelInfo(modelId)
+    const info = getCodexModelInfo(modelId)
+    const configuredContextWindow = getCodexConfiguredContextWindow()
+    if (!info || !configuredContextWindow) return info
+    return {
+      ...info,
+      limit: { ...info.limit, context: configuredContextWindow }
+    }
   }
 
   setSelectedModel(model: { providerID: string; modelID: string; variant?: string }): void {
@@ -1622,7 +1907,7 @@ export class CodexImplementer implements AgentSdkImplementer, AgentRuntimeAdapte
   }
 
   clearSelectedModel(): void {
-    this.selectedModel = CODEX_DEFAULT_MODEL
+    this.selectedModel = resolveCodexModelSlug(getCodexConfiguredModel() ?? CODEX_DEFAULT_MODEL)
     this.selectedVariant = undefined
     log.info('Selected model cleared, reset to default', { model: this.selectedModel })
   }
@@ -2129,18 +2414,19 @@ export class CodexImplementer implements AgentSdkImplementer, AgentRuntimeAdapte
       const cachedInputTokens = asNumber(lastUsage.cached_input_tokens) ?? 0
       const outputTokens = asNumber(lastUsage.output_tokens) ?? 0
       const reasoningTokens = asNumber(lastUsage.reasoning_output_tokens) ?? 0
-      const contextWindow = asNumber(lastTokenCount.model_context_window) ?? 0
-
       if (inputTokens === 0 && outputTokens === 0) return
 
       const modelID = resolveCodexModelSlug(this.selectedModel)
-
+      const contextWindow = this.resolveContextWindow(
+        asNumber(lastTokenCount.model_context_window),
+        modelID
+      )
       emitAgentEvent(this.mainWindow, {
         type: 'session.context_usage',
         sessionId: session.hiveSessionId,
         data: {
           tokens: {
-            input: inputTokens - cachedInputTokens,
+            input: Math.max(0, inputTokens - cachedInputTokens),
             cacheRead: cachedInputTokens,
             cacheWrite: 0,
             output: outputTokens,
@@ -2352,6 +2638,52 @@ export class CodexImplementer implements AgentSdkImplementer, AgentRuntimeAdapte
     return event.turnId ?? asString(payload?.turnId) ?? asString(asObject(payload?.turn)?.id)
   }
 
+  private recordCodexItemTimelineTimestamp(
+    session: CodexSessionState,
+    event: CodexManagerEvent
+  ): void {
+    if (event.kind !== 'notification') return
+
+    const method = event.method
+    const isStarted = method === 'item/started' || method === 'item.started'
+    const isCompleted = method === 'item/completed' || method === 'item.completed'
+    if (!isStarted && !isCompleted) return
+
+    const payload = asObject(event.payload)
+    const item = asObject(payload?.item)
+    if (!item) return
+
+    const turnId = this.extractEventTurnId(event)
+    if (!turnId) return
+
+    const itemType = asString(item.type)
+    session.itemTimestampsByTurn ??= new Map()
+
+    const itemId =
+      asString(item.id) ??
+      event.itemId ??
+      `${method}:${turnId}:${session.itemTimestampsByTurn.get(turnId)?.length ?? 0}`
+    const isTool = isCodexToolItemType(itemType)
+
+    // Record one timestamp per turn item, matching the order `thread/read`
+    // later exposes. Tool items are anchored at start; text/reasoning items
+    // only become useful once completed and carrying their final content.
+    if ((isTool && !isStarted) || (!isTool && !isCompleted)) return
+
+    const seenByTurn =
+      session.recordedItemIdsByTurn ??
+      (session.recordedItemIdsByTurn = new Map<string, Set<string>>())
+    const seen = seenByTurn.get(turnId) ?? new Set<string>()
+    if (seen.has(itemId)) return
+
+    const list =
+      session.itemTimestampsByTurn.get(turnId) ??
+      (session.itemTimestampsByTurn.set(turnId, []), session.itemTimestampsByTurn.get(turnId)!)
+    list.push(eventTimestampFromPayload(payload) ?? event.createdAt ?? new Date().toISOString())
+    seen.add(itemId)
+    seenByTurn.set(turnId, seen)
+  }
+
   private eventMatchesActiveRun(
     session: CodexSessionState,
     runId: string,
@@ -2364,12 +2696,28 @@ export class CodexImplementer implements AgentSdkImplementer, AgentRuntimeAdapte
     const expectedTurnId = activeRun.expectedTurnId
     const eventTurnId = this.extractEventTurnId(event)
     if (!expectedTurnId && eventTurnId) {
-      return false
+      if (event.method === 'turn/started') return true
+      const managerTurnId = this.manager.getSession(session.threadId)?.activeTurnId
+      return managerTurnId === eventTurnId
     }
     if (expectedTurnId && eventTurnId && eventTurnId !== expectedTurnId) {
       return false
     }
     return true
+  }
+
+  private bindActiveRunTurnId(
+    session: CodexSessionState,
+    runId: string,
+    event: CodexManagerEvent
+  ): void {
+    const activeRun = session.activeRun
+    if (!activeRun || activeRun.runId !== runId || activeRun.expectedTurnId) return
+
+    const eventTurnId = this.extractEventTurnId(event)
+    if (eventTurnId) {
+      activeRun.expectedTurnId = eventTurnId
+    }
   }
 
   private parsedMessagesContainUserText(messages: unknown[], candidates: string[]): boolean {
@@ -2394,6 +2742,20 @@ export class CodexImplementer implements AgentSdkImplementer, AgentRuntimeAdapte
       }
     }
     return false
+  }
+
+  private shouldRefreshCollapsedTimeline(
+    session: CodexSessionState,
+    messages: unknown[]
+  ): boolean {
+    if (!this.dbService || session.status === 'running' || session.status === 'closed') return false
+
+    try {
+      const activities = this.dbService.getSessionActivities(session.hiveSessionId)
+      return hasCollapsedCodexMessageTimeline(messages, activities)
+    } catch {
+      return false
+    }
   }
 
   private resetLiveAssistantDraft(session: CodexSessionState): void {
@@ -2700,6 +3062,16 @@ export class CodexImplementer implements AgentSdkImplementer, AgentRuntimeAdapte
           return
         }
 
+        if (event.method === 'thread/status/changed') {
+          const payload = asObject(event.payload)
+          const status = asObject(payload?.status) ?? payload
+          if (asString(status?.type) === 'idle') {
+            const activeRun = session.activeRun
+            finish(activeRun?.state === 'aborting' ? 'interrupted' : 'completed')
+            return
+          }
+        }
+
         // Only reject on truly fatal errors — not stderr warnings.
         // The Codex app-server may output benign stderr content (warnings,
         // progress info, non-standard log formats) that should not abort
@@ -2862,8 +3234,10 @@ export class CodexImplementer implements AgentSdkImplementer, AgentRuntimeAdapte
         revertDiff: null,
         titleGenerated: true,
         titleGenerationStarted: true,
+        tokenUsageCostByTurn: new Map(),
         mapperState: createCodexMapperState(),
-        itemTimestampsByTurn: new Map()
+        itemTimestampsByTurn: new Map(),
+        recordedItemIdsByTurn: new Map()
       }
 
       this.sessions.set(this.getSessionKey(worktreePath, threadId), recovered)
@@ -3013,6 +3387,170 @@ export class CodexImplementer implements AgentSdkImplementer, AgentRuntimeAdapte
     }
   }
 
+  private readJsonlItemTimelineByTurn(snapshot: unknown): Map<string, CodexJsonlTurnTimeline> {
+    const obj = asObject(snapshot)
+    const threadObj = asObject(obj?.thread) ?? obj
+    const jsonlPath = asString(threadObj?.path)
+    if (!jsonlPath) return new Map()
+
+    const result = new Map<string, CodexJsonlTurnTimeline>()
+    const getTurnTimeline = (turnId: string): CodexJsonlTurnTimeline => {
+      const existing = result.get(turnId)
+      if (existing) return existing
+      const created: CodexJsonlTurnTimeline = {
+        positional: [],
+        userMessages: [],
+        assistantMessages: [],
+        reasoningMessages: [],
+        toolCallTimestampsById: new Map()
+      }
+      result.set(turnId, created)
+      return created
+    }
+
+    try {
+      const lines = readFileSync(jsonlPath, 'utf-8').split('\n')
+      let currentTurnId: string | null = null
+
+      const normalizeTimestamp = (timestamp: string | undefined): string | null => {
+        if (!timestamp) return null
+        const parsed = Date.parse(timestamp)
+        if (!Number.isFinite(parsed)) return null
+        return new Date(parsed).toISOString()
+      }
+
+      const pushPositional = (timestamp: string | undefined): string | null => {
+        if (!currentTurnId || !timestamp) return null
+        const normalized = normalizeTimestamp(timestamp)
+        if (!normalized) return null
+        getTurnTimeline(currentTurnId).positional.push(normalized)
+        return normalized
+      }
+
+      const pushText = (
+        collection: keyof Pick<
+          CodexJsonlTurnTimeline,
+          'userMessages' | 'assistantMessages' | 'reasoningMessages'
+        >,
+        text: string,
+        timestamp: string | undefined
+      ): void => {
+        if (!currentTurnId || !text.trim()) return
+        const normalized = normalizeTimestamp(timestamp)
+        if (!normalized) return
+        getTurnTimeline(currentTurnId)[collection].push({ text, timestamp: normalized })
+      }
+
+      for (const line of lines) {
+        if (!line.trim()) continue
+        let entry: Record<string, unknown>
+        try {
+          entry = JSON.parse(line) as Record<string, unknown>
+        } catch {
+          continue
+        }
+
+        const entryType = asString(entry.type)
+        const payload = asObject(entry.payload)
+        const timestamp = asString(entry.timestamp)
+
+        if (entryType === 'event_msg') {
+          const payloadType = asString(payload?.type)
+          if (payloadType === 'task_started') {
+            currentTurnId = asString(payload?.turn_id) ?? null
+            continue
+          }
+          if (payloadType === 'user_message') {
+            pushPositional(timestamp)
+            pushText('userMessages', asString(payload?.message) ?? '', timestamp)
+          }
+          continue
+        }
+
+        if (entryType !== 'response_item' || !currentTurnId) continue
+
+        const itemType = asString(payload?.type)
+        const role = asString(payload?.role)
+        if (itemType === 'message' && role === 'assistant') {
+          pushPositional(timestamp)
+          pushText('assistantMessages', extractCodexJsonlContentText(payload?.content), timestamp)
+        } else if (itemType === 'message' && role === 'user') {
+          pushText('userMessages', extractCodexJsonlContentText(payload?.content), timestamp)
+        } else if (itemType === 'reasoning') {
+          pushPositional(timestamp)
+          pushText('reasoningMessages', extractCodexJsonlReasoningText(payload), timestamp)
+        } else if (
+          itemType === 'function_call' ||
+          itemType === 'custom_tool_call' ||
+          itemType === 'tool_search_call' ||
+          itemType === 'local_shell_call' ||
+          itemType === 'web_search_call' ||
+          itemType === 'image_generation_call'
+        ) {
+          const normalized = pushPositional(timestamp)
+          const callId = asString(payload?.call_id) ?? asString(payload?.id)
+          if (normalized && callId) {
+            getTurnTimeline(currentTurnId).toolCallTimestampsById.set(callId, normalized)
+          }
+        }
+      }
+    } catch (error) {
+      log.debug('parseThreadSnapshot: failed to read Codex JSONL timestamps', {
+        jsonlPath,
+        error: error instanceof Error ? error.message : String(error)
+      })
+    }
+
+    return result
+  }
+
+  private getJsonlTimestampForThreadItem(
+    turnTimeline: CodexJsonlTurnTimeline | undefined,
+    itemObj: Record<string, unknown>,
+    itemType: string | undefined
+  ): string | null {
+    if (!turnTimeline) return null
+
+    if (itemType === 'userMessage') {
+      const content = itemObj.content as unknown[] | undefined
+      const text = Array.isArray(content)
+        ? content
+            .map((entry) => asObject(entry))
+            .map((entry) => asString(entry?.text) ?? '')
+            .filter(Boolean)
+            .join('\n')
+        : ''
+      return shiftMatchingCodexJsonlTextTimestamp(turnTimeline.userMessages, text)
+    }
+
+    if (itemType === 'agentMessage' || itemType === 'plan') {
+      return shiftMatchingCodexJsonlTextTimestamp(
+        turnTimeline.assistantMessages,
+        asString(itemObj.text) ?? ''
+      )
+    }
+
+    if (itemType === 'reasoning') {
+      const summary = Array.isArray(itemObj.summary)
+        ? itemObj.summary.filter((entry): entry is string => typeof entry === 'string')
+        : []
+      const content = Array.isArray(itemObj.content)
+        ? itemObj.content.filter((entry): entry is string => typeof entry === 'string')
+        : []
+      return shiftMatchingCodexJsonlTextTimestamp(
+        turnTimeline.reasoningMessages,
+        [...summary, ...content].join('\n').trim()
+      )
+    }
+
+    const itemId = asString(itemObj.id)
+    if (itemId && turnTimeline.toolCallTimestampsById.has(itemId)) {
+      return turnTimeline.toolCallTimestampsById.get(itemId) ?? null
+    }
+
+    return null
+  }
+
   /** Parse a thread/read snapshot into a message array for getMessages() */
   private parseThreadSnapshot(
     snapshot: unknown,
@@ -3027,6 +3565,7 @@ export class CodexImplementer implements AgentSdkImplementer, AgentRuntimeAdapte
 
     const messages: Array<{ message: unknown; sortTime: number; order: number }> = []
     let order = 0
+    const jsonlTimelineByTurn = this.readJsonlItemTimelineByTurn(snapshot)
     const pushMessage = (message: unknown, timestamp: string | null | undefined): void => {
       const parsedTimestamp = timestamp ? Date.parse(timestamp) : Number.NaN
       messages.push({
@@ -3075,11 +3614,15 @@ export class CodexImplementer implements AgentSdkImplementer, AgentRuntimeAdapte
           return `${turnId}:assistant:${suffix}`
         }
 
-        // Resolve per-turn streaming timestamps. We match by POSITION within
-        // the turn because codex's thread/read renumbers item ids. Falls back
-        // to turnTimestamp (turn startedAt) when the streaming list is too
-        // short — happens for past turns we never streamed.
-        const turnPositionalTimestamps = turnId ? (itemTimestampsByTurn?.get(turnId) ?? []) : []
+        // Resolve per-turn timestamps. Codex `thread/read` may return a
+        // summarized item list whose item positions do not match the JSONL
+        // `response_item` stream, so JSONL timestamps are matched by content
+        // first. Positional fallback is only used when the sequence lengths
+        // match exactly.
+        const turnJsonlTimeline = turnId ? jsonlTimelineByTurn.get(turnId) : undefined
+        const livePositionalTimestamps = turnId ? (itemTimestampsByTurn?.get(turnId) ?? []) : []
+        const livePositionReliable = livePositionalTimestamps.length === items.length
+        const jsonlPositionReliable = turnJsonlTimeline?.positional.length === items.length
         let itemPositionInTurn = 0
 
         for (const item of items) {
@@ -3088,8 +3631,20 @@ export class CodexImplementer implements AgentSdkImplementer, AgentRuntimeAdapte
 
           const itemType = asString(itemObj.type)
           const itemId = asString(itemObj.id)
-          const positionalTs = turnPositionalTimestamps[itemPositionInTurn]
-          const itemTimestamp = positionalTs ?? turnTimestamp ?? new Date().toISOString()
+          const jsonlItemTimestamp = this.getJsonlTimestampForThreadItem(
+            turnJsonlTimeline,
+            itemObj,
+            itemType
+          )
+          const positionalTs =
+            (livePositionReliable ? livePositionalTimestamps[itemPositionInTurn] : undefined) ??
+            (jsonlPositionReliable ? turnJsonlTimeline?.positional[itemPositionInTurn] : undefined)
+          const itemTimestamp =
+            eventTimestampFromPayload(itemObj) ??
+            jsonlItemTimestamp ??
+            positionalTs ??
+            turnTimestamp ??
+            new Date().toISOString()
           itemPositionInTurn += 1
 
           if (itemType === 'userMessage') {

--- a/src/main/services/codex-implementer.ts
+++ b/src/main/services/codex-implementer.ts
@@ -664,16 +664,18 @@ export class CodexImplementer implements AgentSdkImplementer, AgentRuntimeAdapte
 
       const payload = asObject(event.payload)
       const tokenUsage = asObject(payload?.tokenUsage)
-      // Use "last" (per-turn prompt size) not "total" (cumulative).
-      // The context window shows how full the current prompt is,
-      // not the sum of all tokens consumed across every turn.
       const last = asObject(tokenUsage?.last)
+      const total = asObject(tokenUsage?.total) ?? last
       const turnId = event.turnId ?? asString(payload?.turnId)
 
-      const inputTokens = asNumber(last?.inputTokens) ?? 0
-      const cachedInputTokens = asNumber(last?.cachedInputTokens) ?? 0
-      const outputTokens = asNumber(last?.outputTokens) ?? 0
-      const reasoningTokens = asNumber(last?.reasoningOutputTokens) ?? 0
+      const lastInputTokens = asNumber(last?.inputTokens) ?? 0
+      const lastCachedInputTokens = asNumber(last?.cachedInputTokens) ?? 0
+      const lastOutputTokens = asNumber(last?.outputTokens) ?? 0
+      const lastReasoningTokens = asNumber(last?.reasoningOutputTokens) ?? 0
+      const totalInputTokens = asNumber(total?.inputTokens) ?? lastInputTokens
+      const totalCachedInputTokens = asNumber(total?.cachedInputTokens) ?? lastCachedInputTokens
+      const totalOutputTokens = asNumber(total?.outputTokens) ?? lastOutputTokens
+      const totalReasoningTokens = asNumber(total?.reasoningOutputTokens) ?? lastReasoningTokens
 
       const modelID = resolveCodexModelSlug(asString(payload?.model) ?? this.selectedModel)
       const contextWindow = this.resolveContextWindow(
@@ -681,13 +683,25 @@ export class CodexImplementer implements AgentSdkImplementer, AgentRuntimeAdapte
         modelID
       )
       const tokens = {
-        input: Math.max(0, inputTokens - cachedInputTokens),
-        cacheRead: cachedInputTokens,
+        input: Math.max(0, totalInputTokens - totalCachedInputTokens),
+        cacheRead: totalCachedInputTokens,
         cacheWrite: 0,
-        output: outputTokens,
-        reasoning: reasoningTokens
+        output: totalOutputTokens,
+        reasoning: totalReasoningTokens
       }
-      const costData = this.calculateTurnTokenUsageCostDelta(targetSession, turnId, modelID, tokens)
+      const lastTokens = {
+        input: Math.max(0, lastInputTokens - lastCachedInputTokens),
+        cacheRead: lastCachedInputTokens,
+        cacheWrite: 0,
+        output: lastOutputTokens,
+        reasoning: lastReasoningTokens
+      }
+      const costData = this.calculateTurnTokenUsageCostDelta(
+        targetSession,
+        turnId,
+        modelID,
+        lastTokens
+      )
 
       emitAgentEvent(this.mainWindow, {
         type: 'session.context_usage',
@@ -696,6 +710,11 @@ export class CodexImplementer implements AgentSdkImplementer, AgentRuntimeAdapte
           tokens,
           model: { providerID: 'codex', modelID },
           contextWindow,
+          breakdown: {
+            usedTokens: lastInputTokens,
+            maxTokens: contextWindow,
+            percentage: contextWindow > 0 ? (lastInputTokens / contextWindow) * 100 : 0
+          },
           ...costData
         }
       })
@@ -2403,18 +2422,24 @@ export class CodexImplementer implements AgentSdkImplementer, AgentRuntimeAdapte
         return
       }
 
-      // 3. Extract token data (snake_case fields from JSONL)
-      // Use last_token_usage (per-turn prompt size), not total_token_usage
-      // (cumulative). The context bar shows current prompt fill, not
-      // lifetime consumption.
+      // 3. Extract token data (snake_case fields from JSONL).  The renderer
+      // uses cumulative tokens for session/worktree totals, while the context
+      // bar uses the last prompt's input size as current window occupancy.
       const lastUsage = asObject(lastTokenCount.last_token_usage)
+      const totalUsage = asObject(lastTokenCount.total_token_usage) ?? lastUsage
       if (!lastUsage) return
 
-      const inputTokens = asNumber(lastUsage.input_tokens) ?? 0
-      const cachedInputTokens = asNumber(lastUsage.cached_input_tokens) ?? 0
-      const outputTokens = asNumber(lastUsage.output_tokens) ?? 0
-      const reasoningTokens = asNumber(lastUsage.reasoning_output_tokens) ?? 0
-      if (inputTokens === 0 && outputTokens === 0) return
+      const lastInputTokens = asNumber(lastUsage.input_tokens) ?? 0
+      const totalInputTokens = asNumber(totalUsage?.input_tokens) ?? lastInputTokens
+      const totalCachedInputTokens =
+        asNumber(totalUsage?.cached_input_tokens) ?? asNumber(lastUsage.cached_input_tokens) ?? 0
+      const totalOutputTokens =
+        asNumber(totalUsage?.output_tokens) ?? asNumber(lastUsage.output_tokens) ?? 0
+      const totalReasoningTokens =
+        asNumber(totalUsage?.reasoning_output_tokens) ??
+        asNumber(lastUsage.reasoning_output_tokens) ??
+        0
+      if (totalInputTokens === 0 && totalOutputTokens === 0) return
 
       const modelID = resolveCodexModelSlug(this.selectedModel)
       const contextWindow = this.resolveContextWindow(
@@ -2426,20 +2451,25 @@ export class CodexImplementer implements AgentSdkImplementer, AgentRuntimeAdapte
         sessionId: session.hiveSessionId,
         data: {
           tokens: {
-            input: Math.max(0, inputTokens - cachedInputTokens),
-            cacheRead: cachedInputTokens,
+            input: Math.max(0, totalInputTokens - totalCachedInputTokens),
+            cacheRead: totalCachedInputTokens,
             cacheWrite: 0,
-            output: outputTokens,
-            reasoning: reasoningTokens
+            output: totalOutputTokens,
+            reasoning: totalReasoningTokens
           },
           model: { providerID: 'codex', modelID },
-          contextWindow
+          contextWindow,
+          breakdown: {
+            usedTokens: lastInputTokens,
+            maxTokens: contextWindow,
+            percentage: contextWindow > 0 ? (lastInputTokens / contextWindow) * 100 : 0
+          }
         }
       })
 
       log.info('hydrateTokenUsage: emitted context_usage from JSONL', {
         hiveSessionId: session.hiveSessionId,
-        inputTokens,
+        inputTokens: totalInputTokens,
         contextWindow,
         modelID
       })

--- a/src/main/services/codex-implementer.ts
+++ b/src/main/services/codex-implementer.ts
@@ -3034,12 +3034,33 @@ export class CodexImplementer implements AgentSdkImplementer, AgentRuntimeAdapte
         }, remainingMs)
       }
 
+      const resetInactivityTimer = () => {
+        if (hasPendingHitlForThread()) return
+        remainingMs = timeoutMs
+        startTimer()
+      }
+
       const pauseTimer = () => {
         if (!timer) return
         clearTimeout(timer)
         timer = null
         const elapsed = Date.now() - timerStartedAt
         remainingMs = Math.max(0, remainingMs - elapsed)
+      }
+
+      const isProgressEvent = (event: CodexManagerEvent): boolean => {
+        if (contentStreamKindFromMethod(event.method)) return true
+        if (event.method.startsWith('item/')) return true
+        if (event.method.startsWith('codex/event/')) return true
+        if (event.method === 'turn/started') return true
+        if (event.method === 'thread/tokenUsage/updated') return true
+        if (event.method === 'account/rateLimits/updated') return true
+        if (event.method === 'thread/status/changed') {
+          const payload = asObject(event.payload)
+          const status = asObject(payload?.status) ?? payload
+          return asString(status?.type) === 'active'
+        }
+        return false
       }
 
       const checkEvent = (event: CodexManagerEvent) => {
@@ -3115,6 +3136,11 @@ export class CodexImplementer implements AgentSdkImplementer, AgentRuntimeAdapte
 
         if (hitlStateChanged && !hasPendingHitlForThread() && remainingMs > 0) {
           startTimer()
+          return
+        }
+
+        if (isProgressEvent(event)) {
+          resetInactivityTimer()
         }
       }
 

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -662,6 +662,7 @@ declare global {
         hiveSessionId: string
       ) => Promise<
         import('../shared/types/agent-ipc').AgentIpcResult<{
+          sessionId?: string
           sessionStatus?: 'idle' | 'busy' | 'retry'
           revertMessageID?: string | null
         }>

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -117,6 +117,7 @@ interface SessionMessage {
   opencode_message_json: string | null
   opencode_parts_json: string | null
   opencode_timeline_json: string | null
+  sequence: number | null
   created_at: string
 }
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1257,6 +1257,7 @@ const agentOps = {
     hiveSessionId: string
   ): Promise<{
     success: boolean
+    sessionId?: string
     sessionStatus?: 'idle' | 'busy' | 'retry'
     revertMessageID?: string | null
   }> => ipcRenderer.invoke('agent:reconnect', worktreePath, sessionId, hiveSessionId),

--- a/src/renderer/src/components/context-panel/ContextPanelHost.tsx
+++ b/src/renderer/src/components/context-panel/ContextPanelHost.tsx
@@ -336,11 +336,12 @@ function OverviewPanel({
         : 0
 
       acc.totalCost += Math.max(summary?.total_cost ?? 0, costBySession[sessionId] ?? 0)
-      acc.totalTokens += Math.max(summary?.total_tokens ?? 0, liveTotalTokens)
-      acc.inputTokens += Math.max(summary?.input_tokens ?? 0, tokens?.input ?? 0)
-      acc.outputTokens += Math.max(summary?.output_tokens ?? 0, tokens?.output ?? 0)
-      acc.cacheReadTokens += Math.max(summary?.cache_read_tokens ?? 0, tokens?.cacheRead ?? 0)
-      acc.cacheWriteTokens += Math.max(summary?.cache_write_tokens ?? 0, tokens?.cacheWrite ?? 0)
+      const hasSummary = summary !== undefined
+      acc.totalTokens += hasSummary ? summary.total_tokens : liveTotalTokens
+      acc.inputTokens += hasSummary ? summary.input_tokens : (tokens?.input ?? 0)
+      acc.outputTokens += hasSummary ? summary.output_tokens : (tokens?.output ?? 0)
+      acc.cacheReadTokens += hasSummary ? summary.cache_read_tokens : (tokens?.cacheRead ?? 0)
+      acc.cacheWriteTokens += hasSummary ? summary.cache_write_tokens : (tokens?.cacheWrite ?? 0)
       return acc
     },
     {

--- a/src/renderer/src/components/context-panel/ContextPanelHost.tsx
+++ b/src/renderer/src/components/context-panel/ContextPanelHost.tsx
@@ -519,8 +519,16 @@ function TasksPanel({ activeSessionId }: { activeSessionId: string | null }): Re
   }
 
   return (
-    <div className="min-h-0 flex-1 overflow-auto p-3" data-testid="context-panel-tasks">
-      <TodoCard tasks={tasks} />
+    <div className="min-h-0 flex flex-1 flex-col overflow-hidden px-3 pb-3 pt-2" data-testid="context-panel-tasks">
+      <div className="pb-2">
+        <div className="text-[10px] font-semibold uppercase tracking-[0.16em] text-muted-foreground">
+          {t('contextPanel.tabs.tasks')}
+        </div>
+        <div className="mt-1 text-xs leading-relaxed text-muted-foreground">仅显示当前最新一轮规划。</div>
+      </div>
+      <div className="min-h-0 flex-1 overflow-hidden">
+        <TodoCard tasks={tasks} />
+      </div>
     </div>
   )
 }

--- a/src/renderer/src/components/layout/Header.tsx
+++ b/src/renderer/src/components/layout/Header.tsx
@@ -2,6 +2,8 @@ import { useEffect, useMemo, useState } from 'react'
 import { useShallow } from 'zustand/react/shallow'
 import { isMac } from '@/lib/platform'
 import {
+  PanelLeftClose,
+  PanelLeftOpen,
   PanelRightClose,
   PanelRightOpen,
   Settings,
@@ -237,7 +239,8 @@ function HeaderSessionGlanceFallback({
 }
 
 export function Header(): React.JSX.Element {
-  const { rightSidebarCollapsed, toggleRightSidebar } = useLayoutStore()
+  const { leftSidebarCollapsed, rightSidebarCollapsed, toggleLeftSidebar, toggleRightSidebar } =
+    useLayoutStore()
   const openSettings = useSettingsStore((s) => s.openSettings)
   const selectedProjectId = useProjectStore((s) => s.selectedProjectId)
   const projects = useProjectStore((s) => s.projects)
@@ -506,6 +509,25 @@ export function Header(): React.JSX.Element {
     >
       {/* Spacer for macOS traffic lights */}
       {isMac() && <div className="w-[70px] flex-shrink-0" />}
+      <Button
+        onClick={toggleLeftSidebar}
+        variant="ghost"
+        size="icon"
+        className="h-7 w-7 shrink-0 rounded-md text-muted-foreground hover:bg-muted/55 hover:text-foreground"
+        title={
+          leftSidebarCollapsed
+            ? t('header.controls.showSidebar')
+            : t('header.controls.hideSidebar')
+        }
+        data-testid="left-sidebar-toggle"
+        style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
+      >
+        {leftSidebarCollapsed ? (
+          <PanelLeftOpen className="h-3.5 w-3.5" />
+        ) : (
+          <PanelLeftClose className="h-3.5 w-3.5" />
+        )}
+      </Button>
       <div
         className={cn(
           'crisp-panel-surface flex h-7 min-w-0 items-center gap-2.5 rounded-lg bg-agent-card/85 px-2.5',

--- a/src/renderer/src/components/layout/LeftSidebar.tsx
+++ b/src/renderer/src/components/layout/LeftSidebar.tsx
@@ -3,7 +3,7 @@ import { useLayoutStore } from '@/stores/useLayoutStore'
 import { useProjectStore, useConnectionStore, useFilterStore, useSpaceStore } from '@/stores'
 import { useSettingsStore } from '@/stores/useSettingsStore'
 import { ResizeHandle } from './ResizeHandle'
-import { FolderGit2, Link, Loader2, Plus } from 'lucide-react'
+import { FolderGit2, Link, Loader2, Plus, ChevronsRight } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import {
   ProjectList,
@@ -20,7 +20,8 @@ import { useI18n } from '@/i18n/useI18n'
 import { cn } from '@/lib/utils'
 
 export function LeftSidebar(): React.JSX.Element {
-  const { leftSidebarWidth, leftSidebarCollapsed, setLeftSidebarWidth } = useLayoutStore()
+  const { leftSidebarWidth, leftSidebarCollapsed, setLeftSidebarWidth, setLeftSidebarCollapsed } =
+    useLayoutStore()
   const expandAllProjects = useProjectStore((s) => s.expandAllProjects)
   const projectCount = useProjectStore((s) => s.projects.length)
   const showUsageIndicator = useSettingsStore((s) => s.showUsageIndicator)
@@ -114,7 +115,75 @@ export function LeftSidebar(): React.JSX.Element {
   }
 
   if (leftSidebarCollapsed) {
-    return <div data-testid="left-sidebar-collapsed" />
+    return (
+      <div className="flex flex-shrink-0" data-testid="left-sidebar-container">
+        <aside
+          className="bg-sidebar/92 text-sidebar-foreground border-r border-sidebar-border/45 flex w-14 flex-col items-center overflow-hidden px-2 py-3 backdrop-blur-sm"
+          data-testid="left-sidebar-collapsed"
+          role="navigation"
+          aria-label={t('leftSidebar.ariaLabel')}
+        >
+          <button
+            type="button"
+            onClick={() => setLeftSidebarCollapsed(false)}
+            className="mb-3 inline-flex h-9 w-9 items-center justify-center rounded-xl border border-sidebar-border/55 bg-background/55 text-muted-foreground transition-colors hover:bg-background/75 hover:text-foreground"
+            aria-label={t('header.controls.showSidebar')}
+            title={t('header.controls.showSidebar')}
+            data-testid="left-sidebar-expand"
+          >
+            <ChevronsRight className="h-4 w-4" />
+          </button>
+
+          <div className="flex flex-col items-center gap-2">
+            <button
+              type="button"
+              onClick={() => setSidebarTab('projects')}
+              className={cn(
+                'inline-flex h-9 w-9 items-center justify-center rounded-xl border transition-colors',
+                sidebarTab === 'projects'
+                  ? 'border-primary/45 bg-primary/12 text-primary shadow-[0_10px_30px_-18px_rgba(59,130,246,0.8)]'
+                  : 'border-transparent text-muted-foreground hover:border-sidebar-border/55 hover:bg-background/55 hover:text-foreground'
+              )}
+              aria-label={t('sidebar.projects')}
+              title={t('sidebar.projects')}
+              data-testid="left-sidebar-collapsed-projects"
+            >
+              <FolderGit2 className="h-4 w-4" />
+            </button>
+            <button
+              type="button"
+              onClick={() => setSidebarTab('connections')}
+              className={cn(
+                'inline-flex h-9 w-9 items-center justify-center rounded-xl border transition-colors',
+                sidebarTab === 'connections'
+                  ? 'border-primary/45 bg-primary/12 text-primary shadow-[0_10px_30px_-18px_rgba(59,130,246,0.8)]'
+                  : 'border-transparent text-muted-foreground hover:border-sidebar-border/55 hover:bg-background/55 hover:text-foreground'
+              )}
+              aria-label={t('connectionList.title')}
+              title={t('connectionList.title')}
+              data-testid="left-sidebar-collapsed-connections"
+            >
+              <Link className="h-4 w-4" />
+            </button>
+            <button
+              type="button"
+              onClick={handleAddProject}
+              className="inline-flex h-9 w-9 items-center justify-center rounded-xl border border-transparent text-muted-foreground transition-colors hover:border-sidebar-border/55 hover:bg-background/55 hover:text-foreground"
+              aria-label={t('sidebar.addProjectTitle')}
+              title={t('sidebar.addProjectTitle')}
+              data-testid="left-sidebar-collapsed-add-project"
+            >
+              <Plus className="h-4 w-4" />
+            </button>
+          </div>
+
+          <div className="mt-auto pb-1">
+            <SpacesTabBar />
+          </div>
+        </aside>
+        <ResizeHandle onResize={handleResize} direction="left" />
+      </div>
+    )
   }
 
   return (

--- a/src/renderer/src/components/session-hq/AgentTimeline.tsx
+++ b/src/renderer/src/components/session-hq/AgentTimeline.tsx
@@ -839,6 +839,7 @@ export interface AgentTimelineProps {
    * causing the last few transcript nodes to render BEHIND the composer.
    */
   bottomFloatingHeight?: number
+  clearScreenBottomInset?: number
   activeRoundId?: string | null
   onActiveRoundChange?: (roundId: string | null) => void
   onRoundAnchorNavigate?: (roundId: string) => void
@@ -876,6 +877,7 @@ export function AgentTimeline({
   onPointerUp,
   onPointerCancel,
   bottomFloatingHeight = 0,
+  clearScreenBottomInset = 0,
   activeRoundId = null,
   onActiveRoundChange,
   onRoundAnchorNavigate
@@ -1462,6 +1464,14 @@ export function AgentTimeline({
               <ThreadStatusRow key={status.id} status={status} />
             ))}
 
+            {clearScreenBottomInset > 0 && nodes.length > 0 && (
+              <div
+                aria-hidden="true"
+                data-testid="timeline-clear-screen-spacer"
+                style={{ height: `${clearScreenBottomInset}px` }}
+              />
+            )}
+
             {/* Empty state */}
             {nodes.length === 0 && ephemeralStatusRows.length === 0 && !isStreaming && (
               <div className="flex flex-col items-center justify-center py-20 text-muted-foreground">
@@ -1473,8 +1483,11 @@ export function AgentTimeline({
           </div>
 
           {rounds.length > 0 && (
-            <aside className="sticky top-6 hidden w-10 shrink-0 lg:block">
-              <div className="flex flex-col items-center gap-2 py-2">
+            <aside
+              className="sticky top-1/2 hidden w-10 shrink-0 -translate-y-1/2 lg:block"
+              data-testid="timeline-round-anchor-rail"
+            >
+              <div className="flex max-h-[60vh] flex-col items-center justify-center gap-2 overflow-y-auto py-2">
                 {rounds.map((round, index) => {
                   const isActive =
                     activeRoundId === round.id || (!activeRoundId && index === rounds.length - 1)

--- a/src/renderer/src/components/session-hq/AgentTimeline.tsx
+++ b/src/renderer/src/components/session-hq/AgentTimeline.tsx
@@ -1151,7 +1151,7 @@ export function AgentTimeline({
   return (
     <div
       ref={scrollContainerRef}
-      className="flex-1 overflow-y-auto"
+      className="min-h-0 overflow-y-auto"
       onScroll={onScroll}
       onWheel={onWheel}
       onPointerDown={onPointerDown}

--- a/src/renderer/src/components/session-hq/AgentTimeline.tsx
+++ b/src/renderer/src/components/session-hq/AgentTimeline.tsx
@@ -164,6 +164,56 @@ function groupNodesIntoRounds(nodes: TimelineNode[]): {
   return { preludeNodes, rounds }
 }
 
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max)
+}
+
+function smoothStep(value: number): number {
+  const t = clamp(value, 0, 1)
+  return t * t * (3 - 2 * t)
+}
+
+function getRoundRailDotStyle({
+  roundIndex,
+  roundCount,
+  railHeight,
+  hoverY,
+  active
+}: {
+  roundIndex: number
+  roundCount: number
+  railHeight: number
+  hoverY: number | null
+  active: boolean
+}): React.CSSProperties {
+  const topPercent = roundCount <= 1 ? 50 : (roundIndex / (roundCount - 1)) * 100
+  const dotY = (topPercent / 100) * railHeight
+  const spacing = roundCount <= 1 ? railHeight : railHeight / Math.max(roundCount - 1, 1)
+  const compactHeight = clamp(spacing * 0.46, 1.5, 4)
+  const compactWidth = roundCount > 24 ? compactHeight * 1.9 : compactHeight
+  const influenceRadius = clamp(railHeight * 0.22, 52, 96)
+  const hoverStrength =
+    hoverY === null ? 0 : smoothStep(1 - Math.abs(dotY - hoverY) / influenceRadius)
+  const activeStrength = active ? 0.38 : 0
+  const strength = Math.max(hoverStrength, activeStrength)
+  const height = compactHeight + strength * 10
+  const width = compactWidth + strength * 18
+
+  return {
+    top: `${topPercent}%`,
+    width: `${width}px`,
+    height: `${height}px`,
+    opacity: clamp(0.34 + strength * 0.56 + (active ? 0.16 : 0), 0.34, 1),
+    transform: 'translate(-50%, -50%)',
+    zIndex: Math.round(10 + strength * 30)
+  }
+}
+
+function getRoundRailIndexFromY(y: number, railHeight: number, roundCount: number): number {
+  if (roundCount <= 1) return 0
+  return clamp(Math.round((y / railHeight) * (roundCount - 1)), 0, roundCount - 1)
+}
+
 /**
  * Explode a single TimelineMessage into 1+ timeline nodes.
  *
@@ -1100,6 +1150,55 @@ export function AgentTimeline({
   }, [streamingParts, suppressTodoCards, committedToolUseIds])
 
   const { preludeNodes, rounds } = useMemo(() => groupNodesIntoRounds(nodes), [nodes])
+  const [roundRailHoverY, setRoundRailHoverY] = React.useState<number | null>(null)
+  const [roundRailHeight, setRoundRailHeight] = React.useState(336)
+
+  React.useLayoutEffect(() => {
+    const element = scrollContainerRef?.current
+    if (!element) return
+
+    const updateRailHeight = (): void => {
+      const nextHeight = Math.round(element.clientHeight)
+      if (nextHeight > 0) {
+        setRoundRailHeight(nextHeight)
+      }
+    }
+
+    updateRailHeight()
+
+    if (typeof ResizeObserver === 'undefined') return
+
+    const observer = new ResizeObserver(updateRailHeight)
+    observer.observe(element)
+    return () => observer.disconnect()
+  }, [scrollContainerRef])
+
+  const handleRoundRailPointerMove = React.useCallback(
+    (event: React.PointerEvent<HTMLDivElement> | React.MouseEvent<HTMLDivElement>) => {
+      const rect = event.currentTarget.getBoundingClientRect()
+      if (rect.height <= 0) return
+      if (!Number.isFinite(event.clientY)) return
+      setRoundRailHeight(rect.height)
+      setRoundRailHoverY(clamp(event.clientY - rect.top, 0, rect.height))
+    },
+    []
+  )
+
+  const handleRoundRailPointerLeave = React.useCallback(() => {
+    setRoundRailHoverY(null)
+  }, [])
+
+  const handleRoundRailClick = React.useCallback(
+    (event: React.MouseEvent<HTMLDivElement>) => {
+      if (!onRoundAnchorNavigate || rounds.length === 0) return
+      const rect = event.currentTarget.getBoundingClientRect()
+      if (rect.height <= 0) return
+      const y = clamp(event.clientY - rect.top, 0, rect.height)
+      const roundIndex = getRoundRailIndexFromY(y, rect.height, rounds.length)
+      onRoundAnchorNavigate(rounds[roundIndex].id)
+    },
+    [onRoundAnchorNavigate, rounds]
+  )
 
   useEffect(() => {
     if (isStreaming && rounds.length > 0) {
@@ -1521,36 +1620,56 @@ export function AgentTimeline({
             )}
           </div>
 
-          {rounds.length > 0 && (
+          {rounds.length > 1 && (
             <aside
-              className="sticky top-1/2 hidden w-10 shrink-0 -translate-y-1/2 lg:block"
+              className="sticky top-0 -mt-6 hidden w-8 shrink-0 self-start lg:block"
               data-testid="timeline-round-anchor-rail"
             >
-              <div className="flex max-h-[60vh] flex-col items-center justify-center gap-2 overflow-y-auto py-2">
-                {rounds.map((round, index) => {
+              <div
+                className="relative min-h-40 cursor-pointer overflow-visible rounded-full border border-border/30 bg-background/45 shadow-sm backdrop-blur-sm transition-colors hover:border-primary/35 hover:bg-background/70"
+                data-testid="timeline-round-anchor-rail-items"
+                style={{ height: `${roundRailHeight}px` }}
+                onPointerMove={handleRoundRailPointerMove}
+                onMouseMove={handleRoundRailPointerMove}
+                onPointerLeave={handleRoundRailPointerLeave}
+                onMouseLeave={handleRoundRailPointerLeave}
+                onClick={handleRoundRailClick}
+              >
+                <div
+                  aria-hidden="true"
+                  className="absolute left-1/2 top-0 h-full w-px -translate-x-1/2 bg-border/35"
+                />
+                {rounds.map((round, roundIndex) => {
                   const isActive =
-                    activeRoundId === round.id || (!activeRoundId && index === rounds.length - 1)
+                    activeRoundId === round.id ||
+                    (!activeRoundId && roundIndex === rounds.length - 1)
+                  const dotStyle = getRoundRailDotStyle({
+                    roundIndex,
+                    roundCount: rounds.length,
+                    railHeight: roundRailHeight,
+                    hoverY: roundRailHoverY,
+                    active: isActive
+                  })
                   return (
                     <button
                       key={`rail-${round.id}`}
                       type="button"
-                      onClick={() => onRoundAnchorNavigate?.(round.id)}
+                      onClick={(event) => {
+                        event.stopPropagation()
+                        onRoundAnchorNavigate?.(round.id)
+                      }}
                       className={cn(
-                        'group relative flex h-4 w-4 items-center justify-center rounded-full transition-all',
-                        isActive ? 'scale-110' : 'hover:scale-105'
+                        'absolute left-1/2 rounded-full border transition-[width,height,opacity,background-color,border-color,box-shadow] duration-150 ease-out',
+                        isActive
+                          ? 'border-primary/85 bg-primary/85 shadow-[0_0_12px_rgba(59,130,246,0.42)]'
+                          : 'border-border/45 bg-muted-foreground/25 hover:border-primary/55 hover:bg-primary/45'
                       )}
+                      style={dotStyle}
                       title={round.preview}
-                      aria-label={`跳转到第 ${index + 1} 轮：${round.preview}`}
-                    >
-                      <span
-                        className={cn(
-                          'block h-2.5 w-2.5 rounded-full border transition-all',
-                          isActive
-                            ? 'border-primary bg-primary shadow-[0_0_14px_rgba(59,130,246,0.55)]'
-                            : 'border-border/80 bg-muted-foreground/30 group-hover:border-primary/55 group-hover:bg-primary/45'
-                        )}
-                      />
-                    </button>
+                      aria-current={isActive ? 'step' : undefined}
+                      aria-label={`跳转到第 ${roundIndex + 1} 轮：${round.preview}`}
+                      data-testid="timeline-round-anchor-button"
+                    />
                   )
                 })}
               </div>

--- a/src/renderer/src/components/session-hq/AgentTimeline.tsx
+++ b/src/renderer/src/components/session-hq/AgentTimeline.tsx
@@ -38,6 +38,7 @@ import { SystemNotificationBar } from '../sessions/SystemNotificationBar'
 import { extractTaskNotifications, stripTaskNotifications } from '@/lib/content-sanitizer'
 import { getMessageDisplayContent } from '@/lib/message-actions'
 import type { SessionTask } from '@/lib/session-tasks'
+import { useQuestionStore, type QuestionRequest } from '@/stores/useQuestionStore'
 
 import {
   Terminal,
@@ -53,6 +54,11 @@ import {
   User,
   Loader2
 } from 'lucide-react'
+
+// Stable module-level empty array so the useQuestionStore selector never
+// returns a fresh reference (which would force every TimelineNodeView to
+// re-render on every store mutation).
+const EMPTY_QUESTIONS: readonly QuestionRequest[] = Object.freeze([])
 
 // ---------------------------------------------------------------------------
 // Card type derivation
@@ -477,6 +483,16 @@ function TimelineNodeView({
 }): React.JSX.Element | null {
   const { t } = useI18n()
 
+  // Bug 2 cross-validation: subscribe to the question store so an ask-user
+  // card stays in 'pending' state whenever the runtime still believes the
+  // question is unanswered, even if `toolUse.status` has been advanced to
+  // 'success' (e.g. by Codex emitting a tool-completed event after the user
+  // switched sessions). Without this, switching back to the session shows the
+  // card as "Answered" while the composer is still blocked waiting for input.
+  const pendingQuestions = useQuestionStore((s) =>
+    sessionId ? (s.pendingBySession.get(sessionId) ?? EMPTY_QUESTIONS) : EMPTY_QUESTIONS
+  )
+
   switch (node.cardType) {
     case 'user-message': {
       type FilePart = Extract<MessagePart, { type: 'file' }>
@@ -709,7 +725,21 @@ function TimelineNodeView({
       )
     }
 
-    case 'ask-user':
+    case 'ask-user': {
+      const askToolUseId = node.toolUse?.id
+      // Cross-validate against the runtime question store: even if
+      // toolUse.status says the question was resolved, keep the card in
+      // pending mode while useQuestionStore still has a matching unanswered
+      // question for this session (Bug 2). Match by tool callID first, then
+      // by question id, since either side could be the stable identifier
+      // depending on which agent runtime produced the request.
+      const stillPendingForThisCard =
+        !!askToolUseId &&
+        pendingQuestions.some(
+          (q) => q.tool?.callID === askToolUseId || q.id === askToolUseId
+        )
+      const askStatus = node.toolUse?.status
+      const isPending = askStatus === 'pending' || askStatus === 'running' || stillPendingForThisCard
       return (
         <AskUserCard
           question={(node.toolUse?.input?.question as string) ?? ''}
@@ -723,12 +753,13 @@ function TimelineNodeView({
                 }>)
               : undefined
           }
-          isPending={node.toolUse?.status === 'pending' || node.toolUse?.status === 'running'}
+          isPending={isPending}
           sessionId={sessionId}
           worktreePath={worktreePath}
           answer={node.toolUse?.output}
         />
       )
+    }
 
     case 'todo':
       return node.toolUse ? <TodoCard toolUse={node.toolUse} /> : null

--- a/src/renderer/src/components/session-hq/AgentTimeline.tsx
+++ b/src/renderer/src/components/session-hq/AgentTimeline.tsx
@@ -693,10 +693,18 @@ function TimelineNodeView({
         (inputPlan && inputPlan.length > 0 ? inputPlan : undefined) ??
         output ??
         ''
+      const planStatus = node.toolUse?.status
+      const verdict: 'approved' | 'rejected' | undefined =
+        planStatus === 'success'
+          ? 'approved'
+          : planStatus === 'rejected'
+            ? 'rejected'
+            : undefined
       return (
         <PlanCard
           content={content}
-          isPending={node.toolUse?.status === 'pending' || node.toolUse?.status === 'running'}
+          isPending={planStatus === 'pending' || planStatus === 'running'}
+          verdict={verdict}
         />
       )
     }

--- a/src/renderer/src/components/session-hq/AgentTimeline.tsx
+++ b/src/renderer/src/components/session-hq/AgentTimeline.tsx
@@ -10,7 +10,7 @@
  *   streamingContent (live)    → inline streaming text at bottom
  */
 
-import React, { useMemo } from 'react'
+import React, { useEffect, useMemo } from 'react'
 import { cn } from '@/lib/utils'
 import { formatMessageTime } from '@/lib/format-time'
 import type { TimelineMessage, StreamingPart, ToolUseInfo } from '@shared/lib/timeline-types'
@@ -37,6 +37,7 @@ import { ThreadStatusRow, type ThreadStatusRowData } from './ThreadStatusRow'
 import { SystemNotificationBar } from '../sessions/SystemNotificationBar'
 import { extractTaskNotifications, stripTaskNotifications } from '@/lib/content-sanitizer'
 import { getMessageDisplayContent } from '@/lib/message-actions'
+import type { SessionTask } from '@/lib/session-tasks'
 
 import {
   Terminal,
@@ -109,6 +110,52 @@ interface TimelineNode {
   attachments?: MessagePart[]
   /** True for the last node produced from a single TimelineMessage */
   isLastInMessage?: boolean
+}
+
+interface TimelineRound {
+  id: string
+  anchorId: string
+  preview: string
+  userNode: TimelineNode
+  nodes: TimelineNode[]
+}
+
+function buildRoundPreview(node: TimelineNode): string {
+  const displayText = getMessageDisplayContent(node.textContent ?? '')
+  const compact = displayText.replace(/\s+/g, ' ').trim()
+  return compact.length > 0 ? compact.slice(0, 24) : '未命名提问'
+}
+
+function groupNodesIntoRounds(nodes: TimelineNode[]): {
+  preludeNodes: TimelineNode[]
+  rounds: TimelineRound[]
+} {
+  const preludeNodes: TimelineNode[] = []
+  const rounds: TimelineRound[] = []
+  let currentRound: TimelineRound | null = null
+
+  for (const node of nodes) {
+    if (node.cardType === 'user-message') {
+      const preview = buildRoundPreview(node)
+      currentRound = {
+        id: node.message.id,
+        anchorId: `round-${node.message.id}`,
+        preview,
+        userNode: node,
+        nodes: [node]
+      }
+      rounds.push(currentRound)
+      continue
+    }
+
+    if (currentRound) {
+      currentRound.nodes.push(node)
+    } else {
+      preludeNodes.push(node)
+    }
+  }
+
+  return { preludeNodes, rounds }
 }
 
 /**
@@ -445,131 +492,136 @@ function TimelineNodeView({
       const timestampLabel = node.message.timestamp ? formatMessageTime(node.message.timestamp) : ''
 
       return (
-        <div className="group/user-message">
-          <div className="crisp-subtle-shadow rounded-xl border border-tech-blue/15 bg-tech-blue-soft/70 px-3.5 py-2.5">
-            {node.message.steered === true && (
-              <div className="mb-2">
-                <span className="inline-flex items-center rounded-md bg-neon-violet-soft px-2 py-0.5 text-[10px] font-semibold text-neon-violet">
-                  {t('sessionHq.timeline.steered')}
-                </span>
-              </div>
-            )}
-            {node.message.deliveryStatus === 'queued' && (
-              <div className="mb-2">
-                <span className="inline-flex items-center rounded-md bg-amber-500/15 px-2 py-0.5 text-[10px] font-semibold text-amber-600 dark:text-amber-400">
-                  {t('queuedMessageBubble.badge')}
-                </span>
-              </div>
-            )}
-            {images.length > 0 && (
-              <div className="flex flex-wrap gap-2">
-                {images.map((img, i) => (
-                  <img
-                    key={i}
-                    src={img.url}
-                    alt={img.filename ?? 'attachment'}
-                    className="max-h-48 max-w-[280px] rounded-lg border border-border/50 object-contain"
-                  />
-                ))}
-              </div>
-            )}
-            {files.length > 0 && (
-              <div className={cn('flex flex-wrap gap-2', images.length > 0 && 'mt-2')}>
-                {files.map((f, i) => (
-                  <div
-                    key={i}
-                    className="inline-flex items-center gap-1.5 rounded-md border border-border/60 bg-background/50 px-2.5 py-1.5 text-xs text-muted-foreground"
-                  >
-                    <FileText className="h-3.5 w-3.5 shrink-0" />
-                    {f.filename ?? 'file'}
-                  </div>
-                ))}
-              </div>
-            )}
-            {isEditing ? (
-              <div className={cn((images.length > 0 || files.length > 0) && 'mt-2')}>
-                <textarea
-                  value={editingContent ?? ''}
-                  onChange={(e) => onEditingContentChange?.(e.target.value)}
-                  className="min-h-[96px] w-full resize-y rounded-lg border border-border/70 bg-background/55 px-3 py-2 text-sm text-foreground outline-none focus:ring-2 focus:ring-ring/20"
-                  autoFocus
-                  data-testid="timeline-user-edit-textarea"
-                />
-                <div className="mt-2 flex justify-end gap-2">
-                  <Button
-                    type="button"
-                    variant="outline"
-                    size="sm"
-                    onClick={() => onCancelUserMessageEdit?.()}
-                  >
-                    {t('editMessageButton.cancel')}
-                  </Button>
-                  <Button
-                    type="button"
-                    size="sm"
-                    disabled={!editingContent?.trim()}
-                    onClick={() => {
-                      void onSaveUserMessageEdit?.(node.message.id)
-                    }}
-                  >
-                    {t('editMessageButton.save')}
-                  </Button>
+        <div className="group/user-message flex justify-end">
+          <div className="max-w-[82%]">
+            <div
+              className="rounded-2xl border border-primary/20 bg-primary/10 px-4 py-3 text-foreground shadow-sm transition-colors hover:border-primary/30 hover:bg-primary/14"
+              data-testid={`timeline-user-bubble-${node.message.id}`}
+            >
+              {node.message.steered === true && (
+                <div className="mb-2">
+                  <span className="inline-flex items-center rounded-md bg-neon-violet-soft px-2 py-0.5 text-[10px] font-semibold text-neon-violet">
+                    {t('sessionHq.timeline.steered')}
+                  </span>
                 </div>
-              </div>
-            ) : displayText ? (
-              <div
-                className={cn(
-                  'crisp-readable text-sm text-foreground whitespace-pre-wrap break-words',
-                  (images.length > 0 || files.length > 0) && 'mt-2'
-                )}
-              >
-                {displayText}
-              </div>
-            ) : null}
-          </div>
-          <div
-            className="mt-1.5 flex items-center justify-end gap-1.5 text-xs text-muted-foreground"
-            data-testid={`timeline-user-actions-${node.message.id}`}
-          >
-            {timestampLabel && (
-              <span data-testid={`timeline-user-timestamp-${node.message.id}`}>
-                {timestampLabel}
-              </span>
-            )}
-            {!isEditing && (
-              <>
-                <CopyMessageButton
-                  content={displayText}
-                  className="h-7 w-7 rounded-full bg-transparent opacity-0 group-hover/user-message:opacity-100"
-                  showOnHoverClassName=""
-                  unstyled
-                  onCopy={() => onCopyUserMessage?.(node.message)}
-                />
-                {canEdit && (
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="sm"
-                    className="h-7 w-7 rounded-full p-0 opacity-0 transition-opacity group-hover/user-message:opacity-100"
-                    aria-label={t('editMessageButton.ariaLabel')}
-                    data-testid="edit-message-button"
-                    onClick={() => onEditUserMessage?.(node.message)}
-                  >
-                    <Pencil className="h-3.5 w-3.5 text-muted-foreground" />
-                  </Button>
-                )}
-                {onForkUserMessage && (
-                  <ForkMessageButton
-                    onFork={() => onForkUserMessage(node.message)}
-                    isForking={forkingMessageId === node.message.id}
-                    disabled={forkingMessageId !== null && forkingMessageId !== node.message.id}
+              )}
+              {node.message.deliveryStatus === 'queued' && (
+                <div className="mb-2">
+                  <span className="inline-flex items-center rounded-md bg-amber-500/15 px-2 py-0.5 text-[10px] font-semibold text-amber-600 dark:text-amber-400">
+                    {t('queuedMessageBubble.badge')}
+                  </span>
+                </div>
+              )}
+              {images.length > 0 && (
+                <div className="flex flex-wrap gap-2">
+                  {images.map((img, i) => (
+                    <img
+                      key={i}
+                      src={img.url}
+                      alt={img.filename ?? 'attachment'}
+                      className="max-h-48 max-w-[280px] rounded-lg border border-border/50 object-contain"
+                    />
+                  ))}
+                </div>
+              )}
+              {files.length > 0 && (
+                <div className={cn('flex flex-wrap gap-2', images.length > 0 && 'mt-2')}>
+                  {files.map((f, i) => (
+                    <div
+                      key={i}
+                      className="inline-flex items-center gap-1.5 rounded-md border border-border/60 bg-background/50 px-2.5 py-1.5 text-xs text-muted-foreground"
+                    >
+                      <FileText className="h-3.5 w-3.5 shrink-0" />
+                      {f.filename ?? 'file'}
+                    </div>
+                  ))}
+                </div>
+              )}
+              {isEditing ? (
+                <div className={cn((images.length > 0 || files.length > 0) && 'mt-2')}>
+                  <textarea
+                    value={editingContent ?? ''}
+                    onChange={(e) => onEditingContentChange?.(e.target.value)}
+                    className="min-h-[96px] w-full resize-y rounded-lg border border-border/70 bg-background/55 px-3 py-2 text-sm text-foreground outline-none focus:ring-2 focus:ring-ring/20"
+                    autoFocus
+                    data-testid="timeline-user-edit-textarea"
+                  />
+                  <div className="mt-2 flex justify-end gap-2">
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      onClick={() => onCancelUserMessageEdit?.()}
+                    >
+                      {t('editMessageButton.cancel')}
+                    </Button>
+                    <Button
+                      type="button"
+                      size="sm"
+                      disabled={!editingContent?.trim()}
+                      onClick={() => {
+                        void onSaveUserMessageEdit?.(node.message.id)
+                      }}
+                    >
+                      {t('editMessageButton.save')}
+                    </Button>
+                  </div>
+                </div>
+              ) : displayText ? (
+                <div
+                  className={cn(
+                    'crisp-readable text-sm text-foreground whitespace-pre-wrap break-words',
+                    (images.length > 0 || files.length > 0) && 'mt-2'
+                  )}
+                >
+                  {displayText}
+                </div>
+              ) : null}
+            </div>
+            <div
+              className="mt-1.5 flex items-center justify-end gap-1.5 text-xs text-muted-foreground"
+              data-testid={`timeline-user-actions-${node.message.id}`}
+            >
+              {timestampLabel && (
+                <span data-testid={`timeline-user-timestamp-${node.message.id}`}>
+                  {timestampLabel}
+                </span>
+              )}
+              {!isEditing && (
+                <>
+                  <CopyMessageButton
+                    content={displayText}
                     className="h-7 w-7 rounded-full bg-transparent opacity-0 group-hover/user-message:opacity-100"
                     showOnHoverClassName=""
                     unstyled
+                    onCopy={() => onCopyUserMessage?.(node.message)}
                   />
-                )}
-              </>
-            )}
+                  {canEdit && (
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      className="h-7 w-7 rounded-full p-0 opacity-0 transition-opacity group-hover/user-message:opacity-100"
+                      aria-label={t('editMessageButton.ariaLabel')}
+                      data-testid="edit-message-button"
+                      onClick={() => onEditUserMessage?.(node.message)}
+                    >
+                      <Pencil className="h-3.5 w-3.5 text-muted-foreground" />
+                    </Button>
+                  )}
+                  {onForkUserMessage && (
+                    <ForkMessageButton
+                      onFork={() => onForkUserMessage(node.message)}
+                      isForking={forkingMessageId === node.message.id}
+                      disabled={forkingMessageId !== null && forkingMessageId !== node.message.id}
+                      className="h-7 w-7 rounded-full bg-transparent opacity-0 group-hover/user-message:opacity-100"
+                      showOnHoverClassName=""
+                      unstyled
+                    />
+                  )}
+                </>
+              )}
+            </div>
           </div>
         </div>
       )
@@ -750,7 +802,7 @@ export interface AgentTimelineProps {
   /** Suppress inline TodoCard rendering when the right context panel owns tasks. */
   suppressTodoCards?: boolean
   /** Aggregated final task list — renders one TodoCard when explicitly requested. */
-  finalTodoTasks?: Array<{ id: string; content: string; status: string }>
+  finalTodoTasks?: SessionTask[]
   /** Session ID — needed for interactive AskUserCard reply */
   sessionId?: string
   /** Worktree path — needed for interactive AskUserCard reply */
@@ -787,6 +839,9 @@ export interface AgentTimelineProps {
    * causing the last few transcript nodes to render BEHIND the composer.
    */
   bottomFloatingHeight?: number
+  activeRoundId?: string | null
+  onActiveRoundChange?: (roundId: string | null) => void
+  onRoundAnchorNavigate?: (roundId: string) => void
 }
 
 export function AgentTimeline({
@@ -820,7 +875,10 @@ export function AgentTimeline({
   onPointerDown,
   onPointerUp,
   onPointerCancel,
-  bottomFloatingHeight = 0
+  bottomFloatingHeight = 0,
+  activeRoundId = null,
+  onActiveRoundChange,
+  onRoundAnchorNavigate
 }: AgentTimelineProps): React.JSX.Element {
   const { t } = useI18n()
 
@@ -894,19 +952,6 @@ export function AgentTimeline({
     }
     return ids
   }, [timelineMessages])
-
-  const shouldRenderConnector = (nodeIndex: number): boolean => {
-    const node = nodes[nodeIndex]
-    if (!node || node.cardType === 'user-message') return false
-
-    if (nodeIndex < nodes.length - 1) return true
-
-    // Keep the rail visible for the final committed assistant node.
-    // While streaming, the live streaming nodes continue the rail below it.
-    // After streaming ends, hiding the rail makes the last reply visually
-    // "collapse" until a later message appears.
-    return node.message.role === 'assistant'
-  }
 
   // Convert live streaming parts into timeline nodes
   const streamingNodes = useMemo(() => {
@@ -1013,7 +1058,54 @@ export function AgentTimeline({
     })
   }, [streamingParts, suppressTodoCards, committedToolUseIds])
 
-  const safeBottomPadding = Math.max(bottomFloatingHeight + 88, 140)
+  const { preludeNodes, rounds } = useMemo(() => groupNodesIntoRounds(nodes), [nodes])
+
+  useEffect(() => {
+    if (isStreaming && rounds.length > 0) {
+      onActiveRoundChange?.(rounds[rounds.length - 1].id)
+      return
+    }
+
+    if (!activeRoundId && rounds.length > 0) {
+      onActiveRoundChange?.(rounds[rounds.length - 1].id)
+    }
+  }, [activeRoundId, isStreaming, onActiveRoundChange, rounds])
+
+  useEffect(() => {
+    const container = scrollContainerRef?.current
+    if (!container || rounds.length === 0 || !onActiveRoundChange) return
+
+    const updateActiveRoundFromScroll = (): void => {
+      const sections = Array.from(
+        container.querySelectorAll<HTMLElement>('[data-round-anchor="true"]')
+      )
+      if (sections.length === 0) return
+
+      const containerRect = container.getBoundingClientRect()
+      const targetY = containerRect.top + Math.min(container.clientHeight * 0.28, 180)
+      let bestId: string | null = null
+      let bestDistance = Number.POSITIVE_INFINITY
+
+      for (const section of sections) {
+        const rect = section.getBoundingClientRect()
+        const distance = Math.abs(rect.top - targetY)
+        if (distance < bestDistance) {
+          bestDistance = distance
+          bestId = section.dataset.roundId ?? null
+        }
+      }
+
+      if (bestId) {
+        onActiveRoundChange(bestId)
+      }
+    }
+
+    updateActiveRoundFromScroll()
+    container.addEventListener('scroll', updateActiveRoundFromScroll, { passive: true })
+    return () => container.removeEventListener('scroll', updateActiveRoundFromScroll)
+  }, [onActiveRoundChange, rounds, scrollContainerRef])
+
+  const safeBottomPadding = bottomFloatingHeight > 0 ? 24 : 72
 
   return (
     <div
@@ -1029,76 +1121,76 @@ export function AgentTimeline({
       <div
         className="w-[85%] ml-[5%] py-6"
         style={{
-          // The ComposerBar is `absolute bottom-16` (64px from viewport bottom).
-          // Its TOP edge sits `composerHeight + 64` above the bottom. Reserve
-          // that much plus breathing room so the last transcript node is never
-          // hidden behind it. Keep a hard 140px minimum for the floating console.
+          // SessionShell reserves real layout space for the floating composer.
+          // Keep only breathing room here so the final transcript node does not
+          // feel glued to that boundary.
           paddingBottom: `${safeBottomPadding}px`
         }}
       >
-        {/* Inline compaction marker inserted by timestamp. */}
-        {inflightCompaction && inflightCompactionInsertAfter === -1 && (
-          <ThreadStatusRow key={inflightCompaction.id} status={inflightCompaction} />
-        )}
-        {/* Timeline nodes */}
-        {nodes.map((node, index) => {
-          const iconCfg = ICON_MAP[node.cardType]
-          const Icon = iconCfg.icon
-          const renderConnector = shouldRenderConnector(index)
+        <div className="flex items-start gap-4">
+          <div className="min-w-0 flex-1">
+            {/* Inline compaction marker inserted by timestamp. */}
+            {inflightCompaction && inflightCompactionInsertAfter === -1 && (
+              <ThreadStatusRow key={inflightCompaction.id} status={inflightCompaction} />
+            )}
 
-          // Only show timestamp on: user messages, and the LAST assistant node
-          // before a user message or end of timeline (not on every message).
-          const nextNode = nodes[index + 1]
-          const showTimestamp =
-            node.cardType !== 'user-message' &&
-            node.isLastInMessage &&
-            (!nextNode || nextNode.cardType === 'user-message')
+            {preludeNodes.map((node, index) => {
+              const iconCfg = ICON_MAP[node.cardType]
+              const Icon = iconCfg.icon
+              const renderConnector = node.cardType !== 'user-message'
+              const nextNode = preludeNodes[index + 1]
+              const showTimestamp =
+                node.cardType !== 'user-message' &&
+                node.isLastInMessage &&
+                (!nextNode || nextNode.cardType === 'user-message')
 
-          const compactionSuffix =
-            inflightCompaction && inflightCompactionInsertAfter === index ? (
-              <ThreadStatusRow
-                key={`${inflightCompaction.id}-after-${index}`}
-                status={inflightCompaction}
-              />
-            ) : null
+              if (node.cardType === 'text') {
+                return (
+                  <div key={node.key} className="relative pl-10 mb-4">
+                    {renderConnector && (
+                      <div className="absolute left-[15px] top-0 bottom-0 w-[2px] bg-border opacity-60" />
+                    )}
+                    <TimelineNodeView
+                      node={node}
+                      sessionId={sessionId}
+                      worktreePath={worktreePath}
+                      childPartsMap={childPartsMap}
+                      planContentByToolUseId={planContentByToolUseId}
+                      canEditUserMessage={canEditUserMessage}
+                      editingMessageId={editingMessageId}
+                      editingContent={editingContent}
+                      onEditingContentChange={onEditingContentChange}
+                      onSaveUserMessageEdit={onSaveUserMessageEdit}
+                      onCancelUserMessageEdit={onCancelUserMessageEdit}
+                      onCopyUserMessage={onCopyUserMessage}
+                      onEditUserMessage={onEditUserMessage}
+                      onForkUserMessage={onForkUserMessage}
+                      forkingMessageId={forkingMessageId}
+                    />
+                    {showTimestamp && node.message.timestamp && (
+                      <div className="mt-1 text-xs text-muted-foreground">
+                        {formatMessageTime(node.message.timestamp)}
+                      </div>
+                    )}
+                  </div>
+                )
+              }
 
-          // User messages render without the timeline line
-          if (node.cardType === 'user-message') {
-            return (
-              <React.Fragment key={node.key}>
-                <div className="mb-6">
-                  <TimelineNodeView
-                    node={node}
-                    sessionId={sessionId}
-                    worktreePath={worktreePath}
-                    childPartsMap={childPartsMap}
-                    planContentByToolUseId={planContentByToolUseId}
-                    canEditUserMessage={canEditUserMessage}
-                    editingMessageId={editingMessageId}
-                    editingContent={editingContent}
-                    onEditingContentChange={onEditingContentChange}
-                    onSaveUserMessageEdit={onSaveUserMessageEdit}
-                    onCancelUserMessageEdit={onCancelUserMessageEdit}
-                    onCopyUserMessage={onCopyUserMessage}
-                    onEditUserMessage={onEditUserMessage}
-                    onForkUserMessage={onForkUserMessage}
-                    forkingMessageId={forkingMessageId}
-                  />
-                </div>
-                {compactionSuffix}
-              </React.Fragment>
-            )
-          }
-
-          // Text nodes render inline without icon
-          if (node.cardType === 'text') {
-            return (
-              <React.Fragment key={node.key}>
-                <div className="relative pl-10 mb-4">
-                  {/* Vertical line */}
+              return (
+                <div key={node.key} className="relative pl-10 mb-4">
                   {renderConnector && (
-                    <div className="absolute left-[15px] top-0 bottom-0 w-[2px] bg-agent-hover/70" />
+                    <div className="absolute left-[15px] top-0 bottom-0 w-[2px] bg-border opacity-60" />
                   )}
+                  <div
+                    className={cn(
+                      'absolute left-[4px] top-2.5 w-[24px] h-[24px] rounded-full',
+                      'flex items-center justify-center z-10',
+                      iconCfg.bgClass,
+                      iconCfg.colorClass
+                    )}
+                  >
+                    <Icon className="h-3 w-3" />
+                  </div>
                   <TimelineNodeView
                     node={node}
                     sessionId={sessionId}
@@ -1122,174 +1214,297 @@ export function AgentTimeline({
                     </div>
                   )}
                 </div>
-                {compactionSuffix}
-              </React.Fragment>
-            )
-          }
-
-          return (
-            <React.Fragment key={node.key}>
-              <div className="relative pl-10 mb-4">
-                {/* Vertical line */}
-                {renderConnector && (
-                  <div className="absolute left-[15px] top-0 bottom-0 w-[2px] bg-agent-hover/70" />
-                )}
-
-                {/* Icon node */}
-                <div
-                  className={cn(
-                    'absolute left-[4px] top-2.5 w-[24px] h-[24px] rounded-full',
-                    'flex items-center justify-center z-10',
-                    iconCfg.bgClass,
-                    iconCfg.colorClass
-                  )}
-                >
-                  <Icon className="h-3 w-3" />
-                </div>
-
-                {/* Card */}
-                <TimelineNodeView
-                  node={node}
-                  sessionId={sessionId}
-                  worktreePath={worktreePath}
-                  childPartsMap={childPartsMap}
-                  planContentByToolUseId={planContentByToolUseId}
-                  canEditUserMessage={canEditUserMessage}
-                  editingMessageId={editingMessageId}
-                  editingContent={editingContent}
-                  onEditingContentChange={onEditingContentChange}
-                  onSaveUserMessageEdit={onSaveUserMessageEdit}
-                  onCancelUserMessageEdit={onCancelUserMessageEdit}
-                  onCopyUserMessage={onCopyUserMessage}
-                  onEditUserMessage={onEditUserMessage}
-                  onForkUserMessage={onForkUserMessage}
-                  forkingMessageId={forkingMessageId}
-                />
-                {showTimestamp && node.message.timestamp && (
-                  <div className="mt-1 text-xs text-muted-foreground">
-                    {formatMessageTime(node.message.timestamp)}
-                  </div>
-                )}
-              </div>
-              {compactionSuffix}
-            </React.Fragment>
-          )
-        })}
-
-        {/* Final aggregated TodoCard — rendered only when a parent explicitly passes it. */}
-        {finalTodoTasks && finalTodoTasks.length > 0 && (
-          <div className="relative pl-10 mb-4">
-            <div className="absolute left-[15px] top-0 bottom-0 w-[2px] bg-agent-hover/70" />
-            <div
-              className={cn(
-                'absolute left-[4px] top-2.5 w-[24px] h-[24px] rounded-full',
-                'flex items-center justify-center z-10',
-                ICON_MAP.todo.bgClass,
-                ICON_MAP.todo.colorClass
-              )}
-            >
-              <CheckSquare className="h-3 w-3" />
-            </div>
-            <TodoCard tasks={finalTodoTasks} />
-          </div>
-        )}
-
-        {/* Live streaming parts — real-time tool/text/reasoning rendering */}
-        {isStreaming &&
-          streamingNodes.length > 0 &&
-          streamingNodes.map((node, idx) => {
-            const iconCfg = ICON_MAP[node.cardType]
-            const Icon = iconCfg.icon
-            const isLastStreamNode = idx === streamingNodes.length - 1
-
-            if (node.cardType === 'text') {
-              return (
-                <div key={node.key} className="relative pl-10 mb-4">
-                  <div className="absolute left-[15px] top-0 bottom-0 w-[2px] bg-agent-hover/70" />
-                  <div
-                    className={cn(
-                      'absolute left-[4px] top-2.5 w-[24px] h-[24px] rounded-full',
-                      'flex items-center justify-center z-10',
-                      isLastStreamNode
-                        ? 'bg-neon-mint-soft text-neon-mint'
-                        : iconCfg.bgClass + ' ' + iconCfg.colorClass
-                    )}
-                  >
-                    {isLastStreamNode ? (
-                      <Loader2 className="h-3 w-3 animate-spin" />
-                    ) : (
-                      <Icon className="h-3 w-3" />
-                    )}
-                  </div>
-                  <TextCard content={node.textContent ?? ''} isStreaming={isLastStreamNode} />
-                </div>
               )
-            }
+            })}
 
-            return (
-              <div key={node.key} className="relative pl-10 mb-4">
-                <div className="absolute left-[15px] top-0 bottom-0 w-[2px] bg-agent-hover/70" />
+            {rounds.map((round) => {
+              return (
+                <section
+                  key={round.id}
+                  id={round.anchorId}
+                  data-round-anchor="true"
+                  data-round-id={round.id}
+                  className="mb-7 scroll-mt-8"
+                >
+                  {round.nodes.map((node, nodeIndex) => {
+                    const iconCfg = ICON_MAP[node.cardType]
+                    const Icon = iconCfg.icon
+                    const renderConnector = node.cardType !== 'user-message'
+                    const nextNode = round.nodes[nodeIndex + 1]
+                    const showTimestamp =
+                      node.cardType !== 'user-message' &&
+                      node.isLastInMessage &&
+                      (!nextNode || nextNode.cardType === 'user-message')
+
+                    const globalNodeIndex = nodes.findIndex(
+                      (candidate) => candidate.key === node.key
+                    )
+                    const compactionSuffix =
+                      inflightCompaction && inflightCompactionInsertAfter === globalNodeIndex ? (
+                        <ThreadStatusRow
+                          key={`${inflightCompaction.id}-after-${globalNodeIndex}`}
+                          status={inflightCompaction}
+                        />
+                      ) : null
+
+                    if (node.cardType === 'user-message') {
+                      return (
+                        <React.Fragment key={node.key}>
+                          <div className="mb-6">
+                            <TimelineNodeView
+                              node={node}
+                              sessionId={sessionId}
+                              worktreePath={worktreePath}
+                              childPartsMap={childPartsMap}
+                              planContentByToolUseId={planContentByToolUseId}
+                              canEditUserMessage={canEditUserMessage}
+                              editingMessageId={editingMessageId}
+                              editingContent={editingContent}
+                              onEditingContentChange={onEditingContentChange}
+                              onSaveUserMessageEdit={onSaveUserMessageEdit}
+                              onCancelUserMessageEdit={onCancelUserMessageEdit}
+                              onCopyUserMessage={onCopyUserMessage}
+                              onEditUserMessage={onEditUserMessage}
+                              onForkUserMessage={onForkUserMessage}
+                              forkingMessageId={forkingMessageId}
+                            />
+                          </div>
+                          {compactionSuffix}
+                        </React.Fragment>
+                      )
+                    }
+
+                    if (node.cardType === 'text') {
+                      return (
+                        <React.Fragment key={node.key}>
+                          <div className="relative pl-10 mb-4">
+                            {renderConnector && (
+                              <div className="absolute left-[15px] top-0 bottom-0 w-[2px] bg-border opacity-60" />
+                            )}
+                            <TimelineNodeView
+                              node={node}
+                              sessionId={sessionId}
+                              worktreePath={worktreePath}
+                              childPartsMap={childPartsMap}
+                              planContentByToolUseId={planContentByToolUseId}
+                              canEditUserMessage={canEditUserMessage}
+                              editingMessageId={editingMessageId}
+                              editingContent={editingContent}
+                              onEditingContentChange={onEditingContentChange}
+                              onSaveUserMessageEdit={onSaveUserMessageEdit}
+                              onCancelUserMessageEdit={onCancelUserMessageEdit}
+                              onCopyUserMessage={onCopyUserMessage}
+                              onEditUserMessage={onEditUserMessage}
+                              onForkUserMessage={onForkUserMessage}
+                              forkingMessageId={forkingMessageId}
+                            />
+                            {showTimestamp && node.message.timestamp && (
+                              <div className="mt-1 text-xs text-muted-foreground">
+                                {formatMessageTime(node.message.timestamp)}
+                              </div>
+                            )}
+                          </div>
+                          {compactionSuffix}
+                        </React.Fragment>
+                      )
+                    }
+
+                    return (
+                      <React.Fragment key={node.key}>
+                        <div className="relative pl-10 mb-4">
+                          {renderConnector && (
+                            <div className="absolute left-[15px] top-0 bottom-0 w-[2px] bg-border opacity-60" />
+                          )}
+                          <div
+                            className={cn(
+                              'absolute left-[4px] top-2.5 w-[24px] h-[24px] rounded-full',
+                              'flex items-center justify-center z-10',
+                              iconCfg.bgClass,
+                              iconCfg.colorClass
+                            )}
+                          >
+                            <Icon className="h-3 w-3" />
+                          </div>
+                          <TimelineNodeView
+                            node={node}
+                            sessionId={sessionId}
+                            worktreePath={worktreePath}
+                            childPartsMap={childPartsMap}
+                            planContentByToolUseId={planContentByToolUseId}
+                            canEditUserMessage={canEditUserMessage}
+                            editingMessageId={editingMessageId}
+                            editingContent={editingContent}
+                            onEditingContentChange={onEditingContentChange}
+                            onSaveUserMessageEdit={onSaveUserMessageEdit}
+                            onCancelUserMessageEdit={onCancelUserMessageEdit}
+                            onCopyUserMessage={onCopyUserMessage}
+                            onEditUserMessage={onEditUserMessage}
+                            onForkUserMessage={onForkUserMessage}
+                            forkingMessageId={forkingMessageId}
+                          />
+                          {showTimestamp && node.message.timestamp && (
+                            <div className="mt-1 text-xs text-muted-foreground">
+                              {formatMessageTime(node.message.timestamp)}
+                            </div>
+                          )}
+                        </div>
+                        {compactionSuffix}
+                      </React.Fragment>
+                    )
+                  })}
+                </section>
+              )
+            })}
+
+            {/* Final aggregated TodoCard — rendered only when a parent explicitly passes it. */}
+            {finalTodoTasks && finalTodoTasks.length > 0 && (
+              <div className="relative pl-10 mb-4">
+                <div className="absolute left-[15px] top-0 bottom-0 w-[2px] bg-border opacity-60" />
                 <div
                   className={cn(
                     'absolute left-[4px] top-2.5 w-[24px] h-[24px] rounded-full',
                     'flex items-center justify-center z-10',
-                    iconCfg.bgClass,
-                    iconCfg.colorClass
+                    ICON_MAP.todo.bgClass,
+                    ICON_MAP.todo.colorClass
                   )}
                 >
-                  <Icon className="h-3 w-3" />
+                  <CheckSquare className="h-3 w-3" />
                 </div>
-                <TimelineNodeView
-                  node={node}
-                  sessionId={sessionId}
-                  worktreePath={worktreePath}
-                  childPartsMap={childPartsMap}
-                  planContentByToolUseId={planContentByToolUseId}
-                  canEditUserMessage={canEditUserMessage}
-                  editingMessageId={editingMessageId}
-                  editingContent={editingContent}
-                  onEditingContentChange={onEditingContentChange}
-                  onSaveUserMessageEdit={onSaveUserMessageEdit}
-                  onCancelUserMessageEdit={onCancelUserMessageEdit}
-                  onCopyUserMessage={onCopyUserMessage}
-                  onEditUserMessage={onEditUserMessage}
-                  onForkUserMessage={onForkUserMessage}
-                  forkingMessageId={forkingMessageId}
-                />
+                <TodoCard tasks={finalTodoTasks} />
               </div>
-            )
-          })}
+            )}
 
-        {/* Streaming with no content yet — show pulse */}
-        {isStreaming && streamingNodes.length === 0 && !streamingContent && (
-          <div className="relative pl-10 mb-4">
-            <div
-              className={cn(
-                'absolute left-[4px] top-2.5 w-[24px] h-[24px] rounded-full',
-                'flex items-center justify-center z-10',
-                'bg-neon-mint-soft text-neon-mint'
-              )}
-            >
-              <Loader2 className="h-3 w-3 animate-spin" />
-            </div>
-            <div className="text-sm text-muted-foreground italic">
-              {t('sessionHq.timeline.thinking')}
-            </div>
+            {/* Live streaming parts — real-time tool/text/reasoning rendering */}
+            {isStreaming &&
+              streamingNodes.length > 0 &&
+              streamingNodes.map((node, idx) => {
+                const iconCfg = ICON_MAP[node.cardType]
+                const Icon = iconCfg.icon
+                const isLastStreamNode = idx === streamingNodes.length - 1
+
+                if (node.cardType === 'text') {
+                  return (
+                    <div key={node.key} className="relative pl-10 mb-4">
+                      <div className="absolute left-[15px] top-0 bottom-0 w-[2px] bg-border opacity-60" />
+                      <div
+                        className={cn(
+                          'absolute left-[4px] top-2.5 w-[24px] h-[24px] rounded-full',
+                          'flex items-center justify-center z-10',
+                          isLastStreamNode
+                            ? 'bg-neon-mint-soft text-neon-mint'
+                            : iconCfg.bgClass + ' ' + iconCfg.colorClass
+                        )}
+                      >
+                        {isLastStreamNode ? (
+                          <Loader2 className="h-3 w-3 animate-spin" />
+                        ) : (
+                          <Icon className="h-3 w-3" />
+                        )}
+                      </div>
+                      <TextCard content={node.textContent ?? ''} isStreaming={isLastStreamNode} />
+                    </div>
+                  )
+                }
+
+                return (
+                  <div key={node.key} className="relative pl-10 mb-4">
+                    <div className="absolute left-[15px] top-0 bottom-0 w-[2px] bg-border opacity-60" />
+                    <div
+                      className={cn(
+                        'absolute left-[4px] top-2.5 w-[24px] h-[24px] rounded-full',
+                        'flex items-center justify-center z-10',
+                        iconCfg.bgClass,
+                        iconCfg.colorClass
+                      )}
+                    >
+                      <Icon className="h-3 w-3" />
+                    </div>
+                    <TimelineNodeView
+                      node={node}
+                      sessionId={sessionId}
+                      worktreePath={worktreePath}
+                      childPartsMap={childPartsMap}
+                      planContentByToolUseId={planContentByToolUseId}
+                      canEditUserMessage={canEditUserMessage}
+                      editingMessageId={editingMessageId}
+                      editingContent={editingContent}
+                      onEditingContentChange={onEditingContentChange}
+                      onSaveUserMessageEdit={onSaveUserMessageEdit}
+                      onCancelUserMessageEdit={onCancelUserMessageEdit}
+                      onCopyUserMessage={onCopyUserMessage}
+                      onEditUserMessage={onEditUserMessage}
+                      onForkUserMessage={onForkUserMessage}
+                      forkingMessageId={forkingMessageId}
+                    />
+                  </div>
+                )
+              })}
+
+            {/* Streaming with no content yet — show pulse */}
+            {isStreaming && streamingNodes.length === 0 && !streamingContent && (
+              <div className="relative pl-10 mb-4">
+                <div
+                  className={cn(
+                    'absolute left-[4px] top-2.5 w-[24px] h-[24px] rounded-full',
+                    'flex items-center justify-center z-10',
+                    'bg-neon-mint-soft text-neon-mint'
+                  )}
+                >
+                  <Loader2 className="h-3 w-3 animate-spin" />
+                </div>
+                <div className="text-sm text-muted-foreground italic">
+                  {t('sessionHq.timeline.thinking')}
+                </div>
+              </div>
+            )}
+
+            {ephemeralStatusRows.map((status) => (
+              <ThreadStatusRow key={status.id} status={status} />
+            ))}
+
+            {/* Empty state */}
+            {nodes.length === 0 && ephemeralStatusRows.length === 0 && !isStreaming && (
+              <div className="flex flex-col items-center justify-center py-20 text-muted-foreground">
+                <MessageSquare className="h-10 w-10 mb-3 opacity-30" />
+                <div className="text-sm font-medium">{t('sessionHq.timeline.emptyTitle')}</div>
+                <div className="text-xs mt-1">{t('sessionHq.timeline.emptySubtitle')}</div>
+              </div>
+            )}
           </div>
-        )}
 
-        {ephemeralStatusRows.map((status) => (
-          <ThreadStatusRow key={status.id} status={status} />
-        ))}
-
-        {/* Empty state */}
-        {nodes.length === 0 && ephemeralStatusRows.length === 0 && !isStreaming && (
-          <div className="flex flex-col items-center justify-center py-20 text-muted-foreground">
-            <MessageSquare className="h-10 w-10 mb-3 opacity-30" />
-            <div className="text-sm font-medium">{t('sessionHq.timeline.emptyTitle')}</div>
-            <div className="text-xs mt-1">{t('sessionHq.timeline.emptySubtitle')}</div>
-          </div>
-        )}
+          {rounds.length > 0 && (
+            <aside className="sticky top-6 hidden w-10 shrink-0 lg:block">
+              <div className="flex flex-col items-center gap-2 py-2">
+                {rounds.map((round, index) => {
+                  const isActive =
+                    activeRoundId === round.id || (!activeRoundId && index === rounds.length - 1)
+                  return (
+                    <button
+                      key={`rail-${round.id}`}
+                      type="button"
+                      onClick={() => onRoundAnchorNavigate?.(round.id)}
+                      className={cn(
+                        'group relative flex h-4 w-4 items-center justify-center rounded-full transition-all',
+                        isActive ? 'scale-110' : 'hover:scale-105'
+                      )}
+                      title={round.preview}
+                      aria-label={`跳转到第 ${index + 1} 轮：${round.preview}`}
+                    >
+                      <span
+                        className={cn(
+                          'block h-2.5 w-2.5 rounded-full border transition-all',
+                          isActive
+                            ? 'border-primary bg-primary shadow-[0_0_14px_rgba(59,130,246,0.55)]'
+                            : 'border-border/80 bg-muted-foreground/30 group-hover:border-primary/55 group-hover:bg-primary/45'
+                        )}
+                      />
+                    </button>
+                  )
+                })}
+              </div>
+            </aside>
+          )}
+        </div>
       </div>
     </div>
   )

--- a/src/renderer/src/components/session-hq/AgentTimeline.tsx
+++ b/src/renderer/src/components/session-hq/AgentTimeline.tsx
@@ -1151,7 +1151,7 @@ export function AgentTimeline({
   return (
     <div
       ref={scrollContainerRef}
-      className="min-h-0 overflow-y-auto"
+      className="h-full min-h-0 overflow-y-auto"
       onScroll={onScroll}
       onWheel={onWheel}
       onPointerDown={onPointerDown}

--- a/src/renderer/src/components/session-hq/ComposerBar.tsx
+++ b/src/renderer/src/components/session-hq/ComposerBar.tsx
@@ -165,7 +165,7 @@ const ComposerAttachmentsSection = React.memo(function ComposerAttachmentsSectio
   onRemove
 }: ComposerAttachmentsSectionProps): React.JSX.Element {
   return (
-    <div className="px-4 pt-3 pb-0">
+    <div className="px-3 pt-2 pb-0">
       <AttachmentPreview attachments={attachments} onRemove={onRemove} />
     </div>
   )
@@ -255,7 +255,7 @@ const SuccessCriteriaInput = React.memo(function SuccessCriteriaInput({
 }: SuccessCriteriaInputProps): React.JSX.Element {
   const { t } = useI18n()
   return (
-    <div className="px-4 pb-1">
+    <div className="px-3 pb-1">
       <textarea
         value={value}
         onChange={(e) => onChange?.(e.target.value)}
@@ -319,7 +319,7 @@ const ComposerToolbar = React.memo(function ComposerToolbar({
   const { t } = useI18n()
   const showQueueShortcutHint = iconHint === 'steer' && availableAlternatives.includes('queue')
   return (
-    <div className="flex items-center gap-2 px-3 pb-3 pt-1">
+    <div className="flex items-center gap-2 px-3 pb-2 pt-0.5">
       <AttachmentButton onAttach={onAttach} disabled={disabled} />
       {voiceSlot}
       {controlSlot}
@@ -374,7 +374,7 @@ const ComposerToolbar = React.memo(function ComposerToolbar({
               type="button"
               variant="ghost"
               size="sm"
-              className="h-8 rounded-full border border-border/70 px-2.5"
+              className="h-7 rounded-full border border-border/70 px-2.5"
               disabled={!alternativesEnabled}
               aria-label={t('sessionHq.composer.moreSendActions')}
               data-testid="composer-action-menu-trigger"
@@ -413,7 +413,7 @@ const ComposerToolbar = React.memo(function ComposerToolbar({
         onClick={onSubmit}
         disabled={!buttonEnabled}
         className={cn(
-          'h-8 w-8 rounded-full flex items-center justify-center shrink-0 transition-colors',
+          'h-7 w-7 rounded-full flex items-center justify-center shrink-0 transition-colors',
           iconHint === 'stop'
             ? 'bg-destructive text-destructive-foreground hover:bg-destructive/90'
             : buttonEnabled
@@ -877,8 +877,8 @@ export function ComposerBar({
     <div
       ref={containerRef}
       className={cn(
-        'absolute bottom-12 z-20',
-        'w-[85%] ml-[5%] translate-y-1',
+        'absolute bottom-6 z-20',
+        'w-[85%] ml-[5%]',
         'crisp-floating-surface rounded-xl backdrop-blur-xl',
         voiceCaptureVisible && 'crisp-voice-surface'
       )}
@@ -903,7 +903,7 @@ export function ComposerBar({
 
       {/* Pending message indicator */}
       {pendingCount > 0 && (
-        <div className="px-4 pt-3 pb-0 text-xs text-muted-foreground flex items-center gap-1.5">
+        <div className="px-3 pt-2 pb-0 text-xs text-muted-foreground flex items-center gap-1.5">
           {t('sessionHq.composer.queuedMessages', { count: pendingCount })}
         </div>
       )}
@@ -916,7 +916,7 @@ export function ComposerBar({
       )}
 
       {/* Textarea — seamlessly fills the card top */}
-      <div className={cn('relative px-4 pt-3 pb-1', voiceCaptureVisible && 'min-h-[116px] pb-3')}>
+      <div className={cn('relative px-3 pt-2 pb-0.5', voiceCaptureVisible && 'min-h-[116px] pb-3')}>
         {voiceCaptureVisible && (
           <ComposerVoiceCapturePanel
             state={voice.state}
@@ -937,7 +937,7 @@ export function ComposerBar({
             'text-sm placeholder:text-muted-foreground',
             'focus-visible:outline-none focus-visible:ring-0',
             'disabled:cursor-not-allowed disabled:opacity-50',
-            'min-h-[36px] max-h-[200px]',
+            'min-h-[30px] max-h-[160px]',
             voiceCaptureVisible && 'text-foreground/35 placeholder:text-transparent'
           )}
           rows={1}

--- a/src/renderer/src/components/session-hq/ComposerBar.tsx
+++ b/src/renderer/src/components/session-hq/ComposerBar.tsx
@@ -877,8 +877,8 @@ export function ComposerBar({
     <div
       ref={containerRef}
       className={cn(
-        'absolute bottom-16 z-20',
-        'w-[85%] ml-[5%]',
+        'absolute bottom-12 z-20',
+        'w-[85%] ml-[5%] translate-y-1',
         'crisp-floating-surface rounded-xl backdrop-blur-xl',
         voiceCaptureVisible && 'crisp-voice-surface'
       )}

--- a/src/renderer/src/components/session-hq/ComposerBar.tsx
+++ b/src/renderer/src/components/session-hq/ComposerBar.tsx
@@ -877,7 +877,7 @@ export function ComposerBar({
     <div
       ref={containerRef}
       className={cn(
-        'absolute bottom-6 z-20',
+        'relative z-20',
         'w-[85%] ml-[5%]',
         'crisp-floating-surface rounded-xl backdrop-blur-xl',
         voiceCaptureVisible && 'crisp-voice-surface'

--- a/src/renderer/src/components/session-hq/SessionShell.tsx
+++ b/src/renderer/src/components/session-hq/SessionShell.tsx
@@ -913,7 +913,7 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
   }, [hasDurableCompactionMessage, compactionState, sessionId])
 
   const transitionToolStatus = useCallback(
-    (toolUseID: string, status: 'success' | 'error', error?: string) => {
+    (toolUseID: string, status: 'success' | 'error' | 'rejected', error?: string) => {
       const mapper = (p: SharedStreamingPart): SharedStreamingPart =>
         p.type === 'tool_use' && p.toolUse?.id === toolUseID
           ? { ...p, toolUse: { ...p.toolUse!, status, ...(error ? { error } : {}) } }
@@ -1820,6 +1820,13 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
     useSessionRuntimeStore.getState().removeInterrupt(sessionId, pendingBeforeAction.requestId)
     useWorktreeStatusStore.getState().clearSessionStatus(sessionId)
 
+    // Flip the tool card status to 'rejected' immediately so the durable
+    // PlanCard shows "Rejected" instead of falling through to "Approved"
+    // (mirror of handlePlanImplement's transitionToolStatus('success') call).
+    if (pendingBeforeAction.toolUseID) {
+      transitionToolStatus(pendingBeforeAction.toolUseID, 'rejected')
+    }
+
     if (!worktreePath) return
 
     // Always call the reject IPC — for claude-code it unblocks the SDK; for
@@ -1853,7 +1860,7 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
         console.warn('[SessionShell] codex plan reject persistence failed:', err)
       }
     }
-  }, [pendingPlan, sessionRecord?.agent_sdk, sessionId, worktreePath, refresh])
+  }, [pendingPlan, sessionRecord?.agent_sdk, sessionId, worktreePath, refresh, transitionToolStatus])
 
   const handleRoundAnchorNavigate = useCallback(
     (roundId: string) => {

--- a/src/renderer/src/components/session-hq/SessionShell.tsx
+++ b/src/renderer/src/components/session-hq/SessionShell.tsx
@@ -69,7 +69,11 @@ import { applySessionContextUsage } from '@/lib/context-usage'
 import { mapRawTranscriptToTimeline } from '@shared/lib/timeline-mappers'
 import { lastSendMode, messageSendTimes } from '@/lib/message-send-times'
 import { refreshSessionLastMessageAt } from '@/lib/session-last-message'
-import { extractMissionTasks, type SessionTask } from '@/lib/session-tasks'
+import {
+  applySessionTaskToolEvent,
+  extractMissionTasks,
+  type SessionTask
+} from '@/lib/session-tasks'
 import {
   getMessageDisplayContent,
   getUserMessageForkCutoff,
@@ -78,7 +82,6 @@ import {
 import { useI18n } from '@/i18n/useI18n'
 import { useSessionSmartScroll } from '@/hooks/useSessionSmartScroll'
 import { toast } from 'sonner'
-import { isTodoWriteTool } from '@/components/sessions/tools/todo-utils'
 
 function attachmentToMessagePart(attachment: Attachment): MessagePart | null {
   if (attachment.kind !== 'data') return null
@@ -652,6 +655,18 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
   const [forkingMessageId, setForkingMessageId] = useState<string | null>(null)
   const [pendingForkMessageId, setPendingForkMessageId] = useState<string | null>(null)
   const [forkConfirmDismissChecked, setForkConfirmDismissChecked] = useState(false)
+  const [activeRoundId, setActiveRoundId] = useState<string | null>(null)
+
+  useEffect(() => {
+    const lastUserMessage = [...timelineMessages]
+      .reverse()
+      .find((message) => message.role === 'user')
+    if (lastUserMessage) {
+      setActiveRoundId((current) => current ?? lastUserMessage.id)
+    } else {
+      setActiveRoundId(null)
+    }
+  }, [timelineMessages])
 
   const drainQueuedMessage = useCallback(async (): Promise<boolean> => {
     if (!worktreePath || !droidSessionId) return false
@@ -753,6 +768,7 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
   // --- Mission task state (shared with the right-side context panel) ---
   const missionTasksRef = useRef<SessionTask[]>([])
   const timelineMessagesRef = useRef<TimelineMessage[]>([])
+  const lastTaskRoundIdRef = useRef<string | null>(null)
 
   useEffect(() => {
     timelineMessagesRef.current = timelineMessages
@@ -766,16 +782,23 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
     [sessionId]
   )
 
-  useEffect(() => {
-    missionTasksRef.current = useSessionRuntimeStore.getState().getSessionTasks(sessionId)
-  }, [sessionId])
-
-  const lastUserMessageId = useMemo(() => {
+  const latestUserMessageId = useMemo(() => {
     for (let i = timelineMessages.length - 1; i >= 0; i--) {
       if (timelineMessages[i].role === 'user') return timelineMessages[i].id
     }
     return null
   }, [timelineMessages])
+
+  useEffect(() => {
+    if (lastTaskRoundIdRef.current !== latestUserMessageId) {
+      lastTaskRoundIdRef.current = latestUserMessageId
+      setSharedMissionTasks([])
+    }
+  }, [latestUserMessageId, setSharedMissionTasks])
+
+  useEffect(() => {
+    missionTasksRef.current = useSessionRuntimeStore.getState().getSessionTasks(sessionId)
+  }, [sessionId])
 
   const hasDurableCompactionMessage = useMemo(
     () =>
@@ -883,7 +906,14 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
         if (opcSessionId) {
           const result = await window.agentOps.reconnect(worktreePath, opcSessionId, sessionId)
           if (!cancelled && result.success) {
-            setDroidSessionId(opcSessionId)
+            const runtimeSessionId = result.sessionId ?? opcSessionId
+            setDroidSessionId(runtimeSessionId)
+            if (runtimeSessionId !== opcSessionId) {
+              useSessionStore.getState().setOpenCodeSessionId(sessionId, runtimeSessionId)
+              await window.db.session.update(sessionId, {
+                opencode_session_id: runtimeSessionId
+              })
+            }
           }
         } else {
           const result = await window.agentOps.connect(worktreePath, sessionId)
@@ -1057,38 +1087,13 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
             const state = (part.state as Record<string, unknown>) || {}
 
             // --- Mission Control: detect todo/task tools ---
-            const lowerToolName = toolName?.toLowerCase() ?? ''
-            if (isTodoWriteTool(lowerToolName)) {
-              const todos = (state.input as Record<string, unknown>)?.todos
-              if (Array.isArray(todos)) {
-                const newTasks: SessionTask[] = todos.map(
-                  (t: Record<string, unknown>, idx: number) => ({
-                    id: String(t.id ?? `todo-${idx}`),
-                    content: String(t.content ?? t.subject ?? t.activeForm ?? ''),
-                    status: (t.status as SessionTask['status']) ?? 'pending'
-                  })
-                )
-                setSharedMissionTasks(newTasks)
-              }
-            } else if (lowerToolName === 'taskcreate' || lowerToolName === 'task_create') {
-              const input = (state.input as Record<string, unknown>) ?? {}
-              const newTask: SessionTask = {
-                id: String(input.taskId ?? `task-${Date.now()}`),
-                content: String(input.subject ?? input.description ?? ''),
-                status: 'pending'
-              }
-              setSharedMissionTasks([...missionTasksRef.current, newTask])
-            } else if (lowerToolName === 'taskupdate' || lowerToolName === 'task_update') {
-              const input = (state.input as Record<string, unknown>) ?? {}
-              const taskId = String(input.taskId ?? '')
-              const newStatus = input.status as SessionTask['status'] | undefined
-              if (taskId && newStatus) {
-                setSharedMissionTasks(
-                  missionTasksRef.current.map((t) =>
-                    t.id === taskId ? { ...t, status: newStatus } : t
-                  )
-                )
-              }
+            const nextTasks = applySessionTaskToolEvent(
+              missionTasksRef.current,
+              toolName,
+              state.input
+            )
+            if (nextTasks !== missionTasksRef.current) {
+              setSharedMissionTasks(nextTasks)
             }
           }
         }
@@ -1121,20 +1126,12 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
             // Refresh timeline to pick up newly committed messages
             void refresh()
               .then((msgs) => {
-                // Sync mission tasks from committed timeline (source of truth after idle)
+                // Sync mission tasks from committed timeline using the same reducer semantics
                 if (msgs.length > 0) {
                   const extracted = extractMissionTasks(msgs)
-                  if (extracted.length > 0) {
-                    // Don't overwrite if all tasks already completed in memory —
-                    // streaming TaskUpdate events are more authoritative than DB
-                    // snapshots for task status (DB only has original TodoWrite input)
-                    const currentAllComplete =
-                      missionTasksRef.current.length > 0 &&
-                      missionTasksRef.current.every((t) => t.status === 'completed')
-                    if (!currentAllComplete) {
-                      setSharedMissionTasks(extracted)
-                    }
-                  }
+                  setSharedMissionTasks(extracted)
+                } else {
+                  setSharedMissionTasks([])
                 }
               })
               .finally(() => {
@@ -1244,32 +1241,23 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
       const previousGoalMode = goalMode
       const previousSuccessCriteria = successCriteria
 
-      // Pure stop (no content) — abort, then optimistically clear the live
-      // overlay so the streaming tool / text cards disappear immediately. The
-      // committed transcript (durable timeline messages) remains. Without
-      // this, the in-flight tool card stayed visible until the next prompt,
-      // which made the user think the Stop button "didn't work" and click it
-      // 2-3 more times. Backend aborts were going through; only the optics
-      // were wrong. (See OpenCode plan-mode dump 2026-05-01T09:59 — three
-      // abort.accepted markers within ~6 s for the same idle session.)
+      // Pure stop (no content) requests provider interruption only. Do not
+      // force lifecycle idle or clear the live overlay here: Codex may keep
+      // streaming until it confirms interruption/completion, and hiding that
+      // stream makes a still-running thread look stopped.
       if (action === 'stop_and_send' && !content.trim()) {
         try {
-          const result = await window.agentOps.abort(worktreePath, droidSessionId)
-          if (result.success && result.aborted !== false) {
-            resetLiveOverlay(false)
-            // Phase 1.4.8: optimistically flip lifecycle to 'idle' so the
-            // ComposerBar Stop button (red square) flips back to Send (blue
-            // arrow) immediately. Backend will eventually emit
-            // `session.status idle` via flushAbortDraft, but on slow networks
-            // or when SSE reconnects mid-abort the event can lag by seconds —
-            // long enough that users keep clicking Stop thinking it failed.
-            // Safe because the worst case (abort actually didn't take) is
-            // self-correcting: the next backend `busy` event would put us
-            // back into busy state.
-            useSessionRuntimeStore.getState().setLifecycle(sessionId, 'idle')
+          const result = (await window.agentOps.abort(worktreePath, droidSessionId)) as {
+            success: boolean
+            aborted?: boolean
+            error?: string
+          }
+          if (!result.success || result.aborted === false) {
+            toast.error(result.error ?? 'Failed to stop active turn')
           }
         } catch (err) {
           console.error('[SessionShell] abort failed:', err)
+          toast.error(err instanceof Error ? err.message : 'Failed to stop active turn')
         }
         return false
       }
@@ -1403,11 +1391,11 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
   const canEditUserMessage = useCallback(
     (message: TimelineMessage) =>
       message.role === 'user' &&
-      message.id === lastUserMessageId &&
+      message.id === latestUserMessageId &&
       !isStreaming &&
       lifecycle !== 'busy' &&
       lifecycle !== 'materializing',
-    [lastUserMessageId, isStreaming, lifecycle]
+    [latestUserMessageId, isStreaming, lifecycle]
   )
 
   const handleEditUserMessage = useCallback((message: TimelineMessage) => {
@@ -1810,6 +1798,30 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
     }
   }, [pendingPlan, sessionRecord?.agent_sdk, sessionId, worktreePath, refresh])
 
+  const handleRoundAnchorNavigate = useCallback(
+    (roundId: string) => {
+      setActiveRoundId(roundId)
+      const container = smartScroll.scrollContainerRef.current
+      const section = container?.querySelector<HTMLElement>(`[data-round-id="${roundId}"]`)
+      if (!container || !section) return
+
+      const targetTop = Math.max(section.offsetTop - 24, 0)
+      container.scrollTo({ top: targetTop, behavior: 'smooth' })
+    },
+    [smartScroll.scrollContainerRef]
+  )
+
+  useEffect(() => {
+    if (isStreaming) {
+      const lastUserMessage = [...timelineMessages]
+        .reverse()
+        .find((message) => message.role === 'user')
+      if (lastUserMessage) {
+        setActiveRoundId(lastUserMessage.id)
+      }
+    }
+  }, [isStreaming, timelineMessages])
+
   // --- Loading state ---
   if (loading && timelineMessages.length === 0) {
     return (
@@ -1831,6 +1843,8 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
   // Plan interrupts are handled by PlanReadyImplementFab, not the composer/dock.
   // Filter them out so the composer doesn't enter reply_interrupt mode for plans.
   const composerInterrupt = currentInterrupt?.type === 'plan' ? null : currentInterrupt
+  const composerBoundaryHeight = Math.max(smartScroll.bottomFloatingHeight + 24, 132)
+  const composerVeilHeight = Math.min(Math.max(smartScroll.bottomFloatingHeight + 48, 96), 168)
 
   return (
     <div className="flex flex-col h-full">
@@ -1867,6 +1881,9 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
           onPointerUp={smartScroll.handleScrollPointerUp}
           onPointerCancel={smartScroll.handleScrollPointerCancel}
           bottomFloatingHeight={smartScroll.bottomFloatingHeight}
+          activeRoundId={activeRoundId}
+          onActiveRoundChange={setActiveRoundId}
+          onRoundAnchorNavigate={handleRoundAnchorNavigate}
         />
 
         <ScrollToBottomFab
@@ -1884,6 +1901,13 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
           />
         </div>
 
+        <div
+          className="shrink-0"
+          style={{ height: `${composerBoundaryHeight}px` }}
+          aria-hidden="true"
+          data-testid="session-composer-boundary"
+        />
+
         <PlanReadyImplementFab
           onImplement={handlePlanImplement}
           onHandoff={handlePlanHandoff}
@@ -1892,7 +1916,10 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
           superpowersAvailable={false}
         />
 
-        <div className="crisp-composer-veil pointer-events-none absolute bottom-0 left-0 right-0 z-10 h-44" />
+        <div
+          className="crisp-composer-veil pointer-events-none absolute bottom-0 left-0 right-0 z-10"
+          style={{ height: `${composerVeilHeight}px` }}
+        />
 
         <ComposerBar
           containerRef={composerBarRef}

--- a/src/renderer/src/components/session-hq/SessionShell.tsx
+++ b/src/renderer/src/components/session-hq/SessionShell.tsx
@@ -1911,9 +1911,9 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
   const composerVeilHeight = Math.min(Math.max(smartScroll.bottomFloatingHeight + 24, 72), 128)
 
   return (
-    <div className="flex flex-col h-full">
-      {/* Main content area — relative for floating ComposerBar */}
-      <div className="flex-1 flex flex-col overflow-hidden relative">
+    <div className="flex h-full min-h-0 flex-col overflow-hidden">
+      {/* Main content area — hard-row layout keeps transcript output inside the scroll region. */}
+      <div className="grid min-h-0 flex-1 grid-rows-[minmax(0,1fr)_auto_auto] overflow-hidden relative">
         <AgentTimeline
           timelineMessages={timelineMessages}
           streamingContent={streamingContent}
@@ -1958,7 +1958,7 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
           style={{ bottom: `${scrollFabBottomOffset}px` }}
         />
 
-        <div ref={timelineBottomAreaRef} className="shrink-0">
+        <div ref={timelineBottomAreaRef} className="min-h-0">
           <InterruptDock
             sessionId={sessionId}
             interrupt={currentInterrupt}
@@ -1975,7 +1975,7 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
         />
 
         <div
-          className="relative z-20 shrink-0 pb-4 pt-2"
+          className="relative z-20 min-h-0 pb-4 pt-2"
           data-testid="session-composer-dock"
         >
           <div

--- a/src/renderer/src/components/session-hq/SessionShell.tsx
+++ b/src/renderer/src/components/session-hq/SessionShell.tsx
@@ -16,6 +16,7 @@
 
 import React, {
   useEffect,
+  useLayoutEffect,
   useState,
   useCallback,
   useRef,
@@ -125,6 +126,17 @@ function buildLocalDiffCommentContext(comments: DiffComment[]): string {
       })
       .join('\n\n') + '\n\n'
   )
+}
+
+function findRoundSection(container: HTMLElement, roundId: string): HTMLElement | null {
+  const sections = Array.from(container.querySelectorAll<HTMLElement>('[data-round-id]'))
+  return sections.find((section) => section.dataset.roundId === roundId) ?? null
+}
+
+function getContainerRelativeTop(container: HTMLElement, target: HTMLElement): number {
+  const containerRect = container.getBoundingClientRect()
+  const targetRect = target.getBoundingClientRect()
+  return container.scrollTop + targetRect.top - containerRect.top
 }
 
 function DiffCommentAttachments(): React.JSX.Element | null {
@@ -656,6 +668,19 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
   const [pendingForkMessageId, setPendingForkMessageId] = useState<string | null>(null)
   const [forkConfirmDismissChecked, setForkConfirmDismissChecked] = useState(false)
   const [activeRoundId, setActiveRoundId] = useState<string | null>(null)
+  const [clearScreenActive, setClearScreenActive] = useState(false)
+  const pendingTurnTopScrollRef = useRef<string | null>(null)
+
+  const requestTurnTopScroll = useCallback((roundId: string) => {
+    pendingTurnTopScrollRef.current = roundId
+    setClearScreenActive(true)
+    setActiveRoundId(roundId)
+  }, [])
+
+  useEffect(() => {
+    pendingTurnTopScrollRef.current = null
+    setClearScreenActive(false)
+  }, [sessionId])
 
   useEffect(() => {
     const lastUserMessage = [...timelineMessages]
@@ -842,13 +867,37 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
     mirrorVersion,
     isStreaming,
     bottomAreaRef: timelineBottomAreaRef,
-    composerRef: composerBarRef
+    composerRef: composerBarRef,
+    clearScreenActive
   })
+  const timelineScrollContainerRef = smartScroll.scrollContainerRef
+  const clearScreenBottomInset = smartScroll.clearScreenBottomInset
+  const scrollTimelineToOffset = smartScroll.scrollToOffset
 
   const scrollFabBottomOffset = useMemo(
     () => Math.max(smartScroll.scrollFabBottomOffset, pendingPlan ? 152 : 16),
     [pendingPlan, smartScroll.scrollFabBottomOffset]
   )
+
+  useLayoutEffect(() => {
+    const roundId = pendingTurnTopScrollRef.current
+    const container = timelineScrollContainerRef.current
+    if (!roundId || !container) return
+
+    const section = findRoundSection(container, roundId)
+    if (!section) return
+
+    const targetTop = Math.max(getContainerRelativeTop(container, section) - 24, 0)
+    scrollTimelineToOffset(targetTop, 'instant')
+    pendingTurnTopScrollRef.current = null
+  }, [
+    activeRoundId,
+    clearScreenActive,
+    clearScreenBottomInset,
+    scrollTimelineToOffset,
+    timelineScrollContainerRef,
+    timelineMessages.length
+  ])
 
   useEffect(() => {
     if (hasDurableCompactionMessage && compactionState?.phase === 'completed') {
@@ -963,6 +1012,7 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
           timestamp: new Date().toISOString()
         }
         appendOptimistic(optimisticMsg)
+        requestTurnTopScroll(optimisticMsg.id)
         timelineMessagesRef.current = [...timelineMessagesRef.current, optimisticMsg]
         syncOptimisticMessagesToMirror()
 
@@ -1013,6 +1063,7 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
     mode,
     requestModel,
     appendOptimistic,
+    requestTurnTopScroll,
     syncOptimisticMessagesToMirror,
     optimisticRef,
     resetLiveOverlay,
@@ -1307,6 +1358,7 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
         }
         optimisticMessageId = optimisticMsg.id
         appendOptimistic(optimisticMsg)
+        requestTurnTopScroll(optimisticMsg.id)
         // Sync ref immediately so streaming callbacks can find the user message
         // before the next useEffect tick.
         timelineMessagesRef.current = [...timelineMessagesRef.current, optimisticMsg]
@@ -1375,6 +1427,7 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
       droidSessionId,
       sessionId,
       appendOptimistic,
+      requestTurnTopScroll,
       optimisticRef,
       goalMode,
       successCriteria,
@@ -1438,6 +1491,7 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
         timestamp: new Date().toISOString()
       }
       appendOptimistic(optimisticMsg)
+      requestTurnTopScroll(optimisticMsg.id)
       timelineMessagesRef.current = [...trimmedMessages, optimisticMsg]
       syncOptimisticMessagesToMirror()
 
@@ -1472,6 +1526,7 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
       timelineMessages,
       setMessages,
       appendOptimistic,
+      requestTurnTopScroll,
       requestModel,
       promptOptions,
       agentSdk,
@@ -1635,6 +1690,7 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
         timestamp: new Date().toISOString()
       }
       appendOptimistic(optimisticMsg)
+      requestTurnTopScroll(optimisticMsg.id)
       timelineMessagesRef.current = [...timelineMessagesRef.current, optimisticMsg]
       syncOptimisticMessagesToMirror()
 
@@ -1663,6 +1719,7 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
     agentSdk,
     sessionId,
     appendOptimistic,
+    requestTurnTopScroll,
     resetLiveOverlay,
     syncOptimisticMessagesToMirror,
     transitionToolStatus,
@@ -1801,14 +1858,15 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
   const handleRoundAnchorNavigate = useCallback(
     (roundId: string) => {
       setActiveRoundId(roundId)
-      const container = smartScroll.scrollContainerRef.current
-      const section = container?.querySelector<HTMLElement>(`[data-round-id="${roundId}"]`)
-      if (!container || !section) return
+      const container = timelineScrollContainerRef.current
+      if (!container) return
+      const section = findRoundSection(container, roundId)
+      if (!section) return
 
-      const targetTop = Math.max(section.offsetTop - 24, 0)
-      container.scrollTo({ top: targetTop, behavior: 'smooth' })
+      const targetTop = Math.max(getContainerRelativeTop(container, section) - 24, 0)
+      scrollTimelineToOffset(targetTop, 'smooth')
     },
-    [smartScroll.scrollContainerRef]
+    [scrollTimelineToOffset, timelineScrollContainerRef]
   )
 
   useEffect(() => {
@@ -1843,8 +1901,8 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
   // Plan interrupts are handled by PlanReadyImplementFab, not the composer/dock.
   // Filter them out so the composer doesn't enter reply_interrupt mode for plans.
   const composerInterrupt = currentInterrupt?.type === 'plan' ? null : currentInterrupt
-  const composerBoundaryHeight = Math.max(smartScroll.bottomFloatingHeight + 24, 132)
-  const composerVeilHeight = Math.min(Math.max(smartScroll.bottomFloatingHeight + 48, 96), 168)
+  const composerBoundaryHeight = Math.max(smartScroll.bottomFloatingHeight + 16, 104)
+  const composerVeilHeight = Math.min(Math.max(smartScroll.bottomFloatingHeight + 32, 72), 132)
 
   return (
     <div className="flex flex-col h-full">
@@ -1881,6 +1939,7 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
           onPointerUp={smartScroll.handleScrollPointerUp}
           onPointerCancel={smartScroll.handleScrollPointerCancel}
           bottomFloatingHeight={smartScroll.bottomFloatingHeight}
+          clearScreenBottomInset={clearScreenBottomInset}
           activeRoundId={activeRoundId}
           onActiveRoundChange={setActiveRoundId}
           onRoundAnchorNavigate={handleRoundAnchorNavigate}

--- a/src/renderer/src/components/session-hq/SessionShell.tsx
+++ b/src/renderer/src/components/session-hq/SessionShell.tsx
@@ -1913,43 +1913,48 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
   return (
     <div className="flex h-full min-h-0 flex-col overflow-hidden">
       {/* Main content area — hard-row layout keeps transcript output inside the scroll region. */}
-      <div className="grid min-h-0 flex-1 grid-rows-[minmax(0,1fr)_auto_auto] overflow-hidden relative">
-        <AgentTimeline
-          timelineMessages={timelineMessages}
-          streamingContent={streamingContent}
-          streamingParts={streamingParts}
-          isStreaming={isStreaming}
-          activeRunStartedAt={runStartedAt}
-          lifecycle={lifecycle}
-          ephemeralStatusRows={ephemeralStatusRows}
-          inflightCompaction={inflightCompactionRow}
-          suppressTodoCards
-          sessionId={sessionId}
-          worktreePath={worktreePath}
-          childPartsMap={childPartsMap}
-          planContentByToolUseId={planContentByToolUseId}
-          canEditUserMessage={canEditUserMessage}
-          editingMessageId={editingMessageId}
-          editingContent={editingContent}
-          onEditingContentChange={setEditingContent}
-          onSaveUserMessageEdit={handleSaveUserMessageEdit}
-          onCancelUserMessageEdit={handleCancelUserMessageEdit}
-          onEditUserMessage={handleEditUserMessage}
-          onForkUserMessage={handleForkUserMessage}
-          onCopyUserMessage={() => {}}
-          forkingMessageId={forkingMessageId}
-          scrollContainerRef={smartScroll.scrollContainerRef}
-          onScroll={smartScroll.handleScroll}
-          onWheel={smartScroll.handleScrollWheel}
-          onPointerDown={smartScroll.handleScrollPointerDown}
-          onPointerUp={smartScroll.handleScrollPointerUp}
-          onPointerCancel={smartScroll.handleScrollPointerCancel}
-          bottomFloatingHeight={smartScroll.bottomFloatingHeight}
-          clearScreenBottomInset={clearScreenBottomInset}
-          activeRoundId={activeRoundId}
-          onActiveRoundChange={setActiveRoundId}
-          onRoundAnchorNavigate={handleRoundAnchorNavigate}
-        />
+      <div className="relative grid min-h-0 flex-1 grid-rows-[minmax(0,1fr)_auto] overflow-hidden">
+        <div
+          className="row-start-1 row-end-2 min-h-0 overflow-hidden"
+          data-testid="session-transcript-region"
+        >
+          <AgentTimeline
+            timelineMessages={timelineMessages}
+            streamingContent={streamingContent}
+            streamingParts={streamingParts}
+            isStreaming={isStreaming}
+            activeRunStartedAt={runStartedAt}
+            lifecycle={lifecycle}
+            ephemeralStatusRows={ephemeralStatusRows}
+            inflightCompaction={inflightCompactionRow}
+            suppressTodoCards
+            sessionId={sessionId}
+            worktreePath={worktreePath}
+            childPartsMap={childPartsMap}
+            planContentByToolUseId={planContentByToolUseId}
+            canEditUserMessage={canEditUserMessage}
+            editingMessageId={editingMessageId}
+            editingContent={editingContent}
+            onEditingContentChange={setEditingContent}
+            onSaveUserMessageEdit={handleSaveUserMessageEdit}
+            onCancelUserMessageEdit={handleCancelUserMessageEdit}
+            onEditUserMessage={handleEditUserMessage}
+            onForkUserMessage={handleForkUserMessage}
+            onCopyUserMessage={() => {}}
+            forkingMessageId={forkingMessageId}
+            scrollContainerRef={smartScroll.scrollContainerRef}
+            onScroll={smartScroll.handleScroll}
+            onWheel={smartScroll.handleScrollWheel}
+            onPointerDown={smartScroll.handleScrollPointerDown}
+            onPointerUp={smartScroll.handleScrollPointerUp}
+            onPointerCancel={smartScroll.handleScrollPointerCancel}
+            bottomFloatingHeight={smartScroll.bottomFloatingHeight}
+            clearScreenBottomInset={clearScreenBottomInset}
+            activeRoundId={activeRoundId}
+            onActiveRoundChange={setActiveRoundId}
+            onRoundAnchorNavigate={handleRoundAnchorNavigate}
+          />
+        </div>
 
         <ScrollToBottomFab
           onClick={smartScroll.handleScrollToBottomClick}
@@ -1957,14 +1962,6 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
           count={smartScroll.scrollFabCount}
           style={{ bottom: `${scrollFabBottomOffset}px` }}
         />
-
-        <div ref={timelineBottomAreaRef} className="min-h-0">
-          <InterruptDock
-            sessionId={sessionId}
-            interrupt={currentInterrupt}
-            worktreePath={worktreePath}
-          />
-        </div>
 
         <PlanReadyImplementFab
           onImplement={handlePlanImplement}
@@ -1975,41 +1972,54 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
         />
 
         <div
-          className="relative z-20 min-h-0 pb-4 pt-2"
-          data-testid="session-composer-dock"
+          className="row-start-2 row-end-3 min-h-0 overflow-visible"
+          data-testid="session-bottom-stack"
         >
-          <div
-            className="crisp-composer-veil pointer-events-none absolute inset-x-0 bottom-0 z-0"
-            style={{ height: `${composerVeilHeight}px` }}
-          />
+          <div ref={timelineBottomAreaRef} className="min-h-0">
+            <InterruptDock
+              sessionId={sessionId}
+              interrupt={currentInterrupt}
+              worktreePath={worktreePath}
+            />
+          </div>
 
-          <ComposerBar
-            containerRef={composerBarRef}
-            sessionId={sessionId}
-            lifecycle={lifecycle}
-            pendingCount={pendingCount}
-            firstInterrupt={composerInterrupt}
-            onAction={handleComposerAction}
-            isConnected={!!droidSessionId && !!worktreePath}
-            supportsSteer={supportsSteer}
-            preferSteerWhenBusy={preferSteerWhenBusy}
-            mode={mode}
-            onToggleMode={toggleMode}
-            pendingPlan={pendingPlan}
-            supportsGoalMode={supportsSessionGoalMode}
-            goalMode={goalMode}
-            onToggleGoalMode={toggleGoalMode}
-            successCriteria={successCriteria}
-            onSuccessCriteriaChange={setSuccessCriteria}
-            worktreePath={worktreePath}
-            commandsVersion={commandsVersion}
-            contextAttachmentSlot={<DiffCommentAttachments />}
-            controlSlot={<MemoryPanel worktreeId={worktreeId} variant="composer" />}
-          />
+          <div
+            className="relative z-20 min-h-0 pb-4 pt-2"
+            data-testid="session-composer-dock"
+          >
+            <div
+              className="crisp-composer-veil pointer-events-none absolute inset-x-0 bottom-0 z-0"
+              style={{ height: `${composerVeilHeight}px` }}
+            />
+
+            <ComposerBar
+              containerRef={composerBarRef}
+              sessionId={sessionId}
+              lifecycle={lifecycle}
+              pendingCount={pendingCount}
+              firstInterrupt={composerInterrupt}
+              onAction={handleComposerAction}
+              isConnected={!!droidSessionId && !!worktreePath}
+              supportsSteer={supportsSteer}
+              preferSteerWhenBusy={preferSteerWhenBusy}
+              mode={mode}
+              onToggleMode={toggleMode}
+              pendingPlan={pendingPlan}
+              supportsGoalMode={supportsSessionGoalMode}
+              goalMode={goalMode}
+              onToggleGoalMode={toggleGoalMode}
+              successCriteria={successCriteria}
+              onSuccessCriteriaChange={setSuccessCriteria}
+              worktreePath={worktreePath}
+              commandsVersion={commandsVersion}
+              contextAttachmentSlot={<DiffCommentAttachments />}
+              controlSlot={<MemoryPanel worktreeId={worktreeId} variant="composer" />}
+            />
+          </div>
         </div>
 
         {process.env.NODE_ENV === 'development' && (
-          <div className="absolute bottom-0 left-0 right-0 z-30">
+          <div className="absolute right-3 top-3 z-30 w-[min(720px,calc(100%-1.5rem))] rounded-lg border border-border/45 bg-background/92 shadow-lg backdrop-blur">
             {/* Phase 22A debug: collapsible view of the last Field Context injection.
                 Production users inspect memory through the Composer console. */}
             <FieldContextDebug

--- a/src/renderer/src/components/session-hq/SessionShell.tsx
+++ b/src/renderer/src/components/session-hq/SessionShell.tsx
@@ -1901,8 +1901,7 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
   // Plan interrupts are handled by PlanReadyImplementFab, not the composer/dock.
   // Filter them out so the composer doesn't enter reply_interrupt mode for plans.
   const composerInterrupt = currentInterrupt?.type === 'plan' ? null : currentInterrupt
-  const composerBoundaryHeight = Math.max(smartScroll.bottomFloatingHeight + 16, 104)
-  const composerVeilHeight = Math.min(Math.max(smartScroll.bottomFloatingHeight + 32, 72), 132)
+  const composerVeilHeight = Math.min(Math.max(smartScroll.bottomFloatingHeight + 24, 72), 128)
 
   return (
     <div className="flex flex-col h-full">
@@ -1952,20 +1951,13 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
           style={{ bottom: `${scrollFabBottomOffset}px` }}
         />
 
-        <div ref={timelineBottomAreaRef}>
+        <div ref={timelineBottomAreaRef} className="shrink-0">
           <InterruptDock
             sessionId={sessionId}
             interrupt={currentInterrupt}
             worktreePath={worktreePath}
           />
         </div>
-
-        <div
-          className="shrink-0"
-          style={{ height: `${composerBoundaryHeight}px` }}
-          aria-hidden="true"
-          data-testid="session-composer-boundary"
-        />
 
         <PlanReadyImplementFab
           onImplement={handlePlanImplement}
@@ -1976,33 +1968,38 @@ export function SessionShell({ sessionId }: SessionShellProps): React.JSX.Elemen
         />
 
         <div
-          className="crisp-composer-veil pointer-events-none absolute bottom-0 left-0 right-0 z-10"
-          style={{ height: `${composerVeilHeight}px` }}
-        />
+          className="relative z-20 shrink-0 pb-4 pt-2"
+          data-testid="session-composer-dock"
+        >
+          <div
+            className="crisp-composer-veil pointer-events-none absolute inset-x-0 bottom-0 z-0"
+            style={{ height: `${composerVeilHeight}px` }}
+          />
 
-        <ComposerBar
-          containerRef={composerBarRef}
-          sessionId={sessionId}
-          lifecycle={lifecycle}
-          pendingCount={pendingCount}
-          firstInterrupt={composerInterrupt}
-          onAction={handleComposerAction}
-          isConnected={!!droidSessionId && !!worktreePath}
-          supportsSteer={supportsSteer}
-          preferSteerWhenBusy={preferSteerWhenBusy}
-          mode={mode}
-          onToggleMode={toggleMode}
-          pendingPlan={pendingPlan}
-          supportsGoalMode={supportsSessionGoalMode}
-          goalMode={goalMode}
-          onToggleGoalMode={toggleGoalMode}
-          successCriteria={successCriteria}
-          onSuccessCriteriaChange={setSuccessCriteria}
-          worktreePath={worktreePath}
-          commandsVersion={commandsVersion}
-          contextAttachmentSlot={<DiffCommentAttachments />}
-          controlSlot={<MemoryPanel worktreeId={worktreeId} variant="composer" />}
-        />
+          <ComposerBar
+            containerRef={composerBarRef}
+            sessionId={sessionId}
+            lifecycle={lifecycle}
+            pendingCount={pendingCount}
+            firstInterrupt={composerInterrupt}
+            onAction={handleComposerAction}
+            isConnected={!!droidSessionId && !!worktreePath}
+            supportsSteer={supportsSteer}
+            preferSteerWhenBusy={preferSteerWhenBusy}
+            mode={mode}
+            onToggleMode={toggleMode}
+            pendingPlan={pendingPlan}
+            supportsGoalMode={supportsSessionGoalMode}
+            goalMode={goalMode}
+            onToggleGoalMode={toggleGoalMode}
+            successCriteria={successCriteria}
+            onSuccessCriteriaChange={setSuccessCriteria}
+            worktreePath={worktreePath}
+            commandsVersion={commandsVersion}
+            contextAttachmentSlot={<DiffCommentAttachments />}
+            controlSlot={<MemoryPanel worktreeId={worktreeId} variant="composer" />}
+          />
+        </div>
 
         {process.env.NODE_ENV === 'development' && (
           <div className="absolute bottom-0 left-0 right-0 z-30">

--- a/src/renderer/src/components/session-hq/cards/ActionCard.tsx
+++ b/src/renderer/src/components/session-hq/cards/ActionCard.tsx
@@ -78,7 +78,9 @@ export function ActionCard({
 
       {/* Body */}
       {children && expanded && (
-        <div className="px-3.5 py-3 text-sm text-muted-foreground leading-relaxed">{children}</div>
+        <div className="px-3.5 py-3 text-sm leading-[1.68] text-muted-foreground">
+          {children}
+        </div>
       )}
     </div>
   )

--- a/src/renderer/src/components/session-hq/cards/PlanCard.tsx
+++ b/src/renderer/src/components/session-hq/cards/PlanCard.tsx
@@ -94,7 +94,7 @@ export function PlanCard({
       defaultExpanded={isPending}
       collapsible
     >
-      <div className="prose prose-sm dark:prose-invert max-w-none text-sm leading-relaxed">
+      <div className="prose prose-sm dark:prose-invert max-w-none text-sm leading-[1.72]">
         <MarkdownRenderer content={content} />
       </div>
 

--- a/src/renderer/src/components/session-hq/cards/PlanCard.tsx
+++ b/src/renderer/src/components/session-hq/cards/PlanCard.tsx
@@ -17,17 +17,21 @@ interface PlanCardProps {
   onReject?: () => void
   /** Whether the plan is pending approval */
   isPending?: boolean
+  /** Resolved verdict — only meaningful when isPending is false */
+  verdict?: 'approved' | 'rejected'
 }
 
 export function PlanCard({
   content,
   onApprove,
   onReject,
-  isPending = false
+  isPending = false,
+  verdict
 }: PlanCardProps): React.JSX.Element {
   const { t } = useI18n()
   const [copied, setCopied] = useState(false)
   const hasCopyableContent = content.trim().length > 0
+  const isRejected = !isPending && verdict === 'rejected'
 
   useEffect(() => {
     if (!copied) return
@@ -48,19 +52,25 @@ export function PlanCard({
     }
   }
 
+  const accentClass = isRejected ? 'border-muted-foreground/40' : 'border-purple-500'
+  const headerClass = isRejected
+    ? 'bg-muted text-muted-foreground border-b-muted-foreground/20'
+    : 'bg-purple-500/10 text-purple-600 dark:text-purple-400 border-b-purple-500/20'
+  const statusText = isPending
+    ? t('sessionHq.cards.plan.requiresApproval')
+    : isRejected
+      ? t('sessionHq.cards.plan.rejected')
+      : t('sessionHq.cards.plan.approved')
+
   return (
     <ActionCard
-      key={isPending ? 'pending' : 'resolved'}
-      accentClass="border-purple-500"
-      headerClass="bg-purple-500/10 text-purple-600 dark:text-purple-400 border-b-purple-500/20"
+      key={isPending ? 'pending' : isRejected ? 'rejected' : 'approved'}
+      accentClass={accentClass}
+      headerClass={headerClass}
       headerLeft={<span className="font-semibold">{t('sessionHq.cards.plan.title')}</span>}
       headerRight={
         <div className="flex items-center gap-2">
-          <span>
-            {isPending
-              ? t('sessionHq.cards.plan.requiresApproval')
-              : t('sessionHq.cards.plan.approved')}
-          </span>
+          <span>{statusText}</span>
           {hasCopyableContent && (
             <Button
               type="button"

--- a/src/renderer/src/components/session-hq/cards/TextCard.tsx
+++ b/src/renderer/src/components/session-hq/cards/TextCard.tsx
@@ -15,7 +15,7 @@ interface TextCardProps {
 
 export function TextCard({ content, isStreaming = false }: TextCardProps): React.JSX.Element {
   return (
-    <div className="rounded-xl bg-agent-card/80 px-3.5 py-2.5">
+    <div className="rounded-xl bg-agent-card/80 px-4 py-3">
       <div className="prose prose-sm dark:prose-invert crisp-readable max-w-none text-sm text-foreground">
         <MarkdownRenderer content={content} />
         {isStreaming && (

--- a/src/renderer/src/components/session-hq/cards/TodoCard.tsx
+++ b/src/renderer/src/components/session-hq/cards/TodoCard.tsx
@@ -11,6 +11,14 @@ import { ActionCard } from './ActionCard'
 import { CheckCircle2, Circle, Loader2, AlertCircle } from 'lucide-react'
 import type { ToolUseInfo } from '@shared/lib/timeline-types'
 import { useI18n } from '@/i18n/useI18n'
+import {
+  getSessionTaskCounts,
+  getSessionTaskDisplayTitle,
+  getSessionTaskRawDetail,
+  normalizeSessionTaskStatus,
+  sortSessionTasks,
+  type SessionTask
+} from '@/lib/session-tasks'
 
 interface TodoCardPropsToolUse {
   toolUse: ToolUseInfo
@@ -20,7 +28,7 @@ interface TodoCardPropsToolUse {
 interface TodoCardPropsTasks {
   toolUse?: never
   /** Aggregated task list — used by the right context panel and optional timeline summaries */
-  tasks: Array<{ id: string; content: string; status: string }>
+  tasks: SessionTask[]
 }
 
 type TodoCardProps = TodoCardPropsToolUse | TodoCardPropsTasks
@@ -88,7 +96,7 @@ function TaskRow({ item, index }: { item: TodoItem; index: number }): React.JSX.
     <div className="flex items-center gap-2 py-0.5">
       <StatusIcon status={item.status} />
       <div className="flex-1 min-w-0">
-        <div className="text-sm text-foreground">
+        <div className="text-sm text-foreground leading-5 break-words">
           {item.step ??
             item.content ??
             item.subject ??
@@ -97,10 +105,58 @@ function TaskRow({ item, index }: { item: TodoItem; index: number }): React.JSX.
             t('sessionHq.cards.todo.taskFallback', { index: index + 1 })}
         </div>
         {(item.subject || item.content || item.step) && item.description && (
-          <div className="text-xs text-muted-foreground mt-0.5 truncate">{item.description}</div>
+          <div className="mt-0.5 line-clamp-2 break-words text-xs text-muted-foreground">
+            {item.description}
+          </div>
         )}
       </div>
     </div>
+  )
+}
+
+function TaskSection({
+  title,
+  items,
+  startIndex = 0,
+  muted = false
+}: {
+  title: string
+  items: SessionTask[]
+  startIndex?: number
+  muted?: boolean
+}): React.JSX.Element | null {
+  if (items.length === 0) return null
+
+  return (
+    <section className="space-y-2">
+      <div className="flex items-center justify-between gap-2">
+        <div className="text-[11px] font-semibold uppercase tracking-[0.14em] text-muted-foreground/85">
+          {title}
+        </div>
+        <div className="text-[10px] font-mono text-muted-foreground/75">{items.length}</div>
+      </div>
+      <div className="space-y-1.5">
+        {items.map((item, index) => {
+          const displayTitle = getSessionTaskDisplayTitle(item, startIndex + index)
+          const detail = getSessionTaskRawDetail(item, displayTitle)
+          return (
+            <div key={item.id ?? `${title}-${index}`} className={muted ? 'opacity-75' : ''}>
+              <div className="flex items-start gap-2 py-0.5">
+                <StatusIcon status={item.status} />
+                <div className="min-w-0 flex-1">
+                  <div className="text-sm leading-5 text-foreground break-words">{displayTitle}</div>
+                  {detail && (
+                    <div className="mt-0.5 line-clamp-2 break-words text-xs text-muted-foreground">
+                      {detail}
+                    </div>
+                  )}
+                </div>
+              </div>
+            </div>
+          )
+        })}
+      </div>
+    </section>
   )
 }
 
@@ -109,28 +165,61 @@ export function TodoCard(props: TodoCardProps): React.JSX.Element {
 
   // --- Aggregated tasks mode ---
   if (props.tasks) {
-    const allDone = props.tasks.every((t) => t.status === 'completed')
+    const orderedTasks = sortSessionTasks(props.tasks)
+    const counts = getSessionTaskCounts(orderedTasks)
+    const completedCount = counts.completed
+    const allDone = orderedTasks.length > 0 && completedCount === orderedTasks.length
+    const inProgressItems = orderedTasks.filter(
+      (task) => normalizeSessionTaskStatus(task.status) === 'in_progress'
+    )
+    const pendingItems = orderedTasks.filter(
+      (task) => normalizeSessionTaskStatus(task.status) === 'pending'
+    )
+    const completedItems = orderedTasks.filter(
+      (task) => normalizeSessionTaskStatus(task.status) === 'completed'
+    )
+    const trailingItems = orderedTasks.filter((task) => {
+      const status = normalizeSessionTaskStatus(task.status)
+      return status === 'cancelled' || status === 'error'
+    })
+
     return (
-      <ActionCard
-        accentClass="border-celadon/30"
-        headerClass="border-b-celadon/20 text-celadon"
-        headerLeft={<span className="font-semibold">{t('sessionHq.cards.todo.title')}</span>}
-        headerRight={
-          allDone ? t('sessionHq.cards.todo.done') : t('sessionHq.cards.todo.inProgress')
-        }
-        defaultExpanded
-        collapsible={props.tasks.length > 5}
-      >
-        <div className="flex flex-col gap-1">
-          {props.tasks.map((task, i) => (
-            <TaskRow
-              key={task.id}
-              index={i}
-              item={{ id: task.id, content: task.content, status: task.status }}
-            />
-          ))}
+      <div className="overflow-hidden rounded-[12px] border border-border/55 bg-background/78">
+        <div className="border-b border-border/45 px-3.5 py-3">
+          <div className="flex items-start justify-between gap-3">
+            <div className="min-w-0">
+              <div className="text-sm font-semibold text-foreground">{t('sessionHq.cards.todo.title')}</div>
+              <div className="mt-1 text-xs text-muted-foreground">
+                {t('toolCard.summary.completed', {
+                  completed: completedCount,
+                  total: orderedTasks.length
+                })}
+              </div>
+            </div>
+            <div className="shrink-0 rounded-full bg-background/70 px-2 py-0.5 text-[11px] font-medium text-muted-foreground">
+              {allDone ? t('sessionHq.cards.todo.done') : t('sessionHq.cards.todo.inProgress')}
+            </div>
+          </div>
         </div>
-      </ActionCard>
+        <div className="max-h-[min(60vh,36rem)] overflow-y-auto px-3.5 py-3">
+          <div className="space-y-4">
+            <TaskSection title="进行中" items={inProgressItems} />
+            <TaskSection title="待处理" items={pendingItems} startIndex={inProgressItems.length} />
+            <TaskSection
+              title="已完成"
+              items={completedItems}
+              startIndex={inProgressItems.length + pendingItems.length}
+              muted
+            />
+            <TaskSection
+              title="已取消 / 异常"
+              items={trailingItems}
+              startIndex={inProgressItems.length + pendingItems.length + completedItems.length}
+              muted
+            />
+          </div>
+        </div>
+      </div>
     )
   }
 

--- a/src/renderer/src/components/sessions/ContextIndicator.tsx
+++ b/src/renderer/src/components/sessions/ContextIndicator.tsx
@@ -110,6 +110,7 @@ export function ContextIndicator({
       <TooltipContent side="top" sideOffset={8} className="max-w-[260px]">
         <div className="space-y-1.5">
           <div className="font-medium">{t('contextIndicator.title')}</div>
+          <div className="text-[10px] opacity-70">{t('contextIndicator.explainer')}</div>
           {typeof limit === 'number' ? (
             <div>
               {t('contextIndicator.summary.withLimit', {

--- a/src/renderer/src/components/sessions/MarkdownRenderer.tsx
+++ b/src/renderer/src/components/sessions/MarkdownRenderer.tsx
@@ -11,24 +11,26 @@ interface MarkdownRendererProps {
 
 const components: Components = {
   h1: ({ children }) => (
-    <h1 className="crisp-strong-title text-xl mt-6 mb-3 first:mt-0">{children}</h1>
+    <h1 className="crisp-strong-title text-xl font-bold mt-6 mb-3 first:mt-0">{children}</h1>
   ),
   h2: ({ children }) => (
-    <h2 className="crisp-strong-title text-lg mt-5 mb-2 first:mt-0">{children}</h2>
+    <h2 className="crisp-strong-title text-lg font-semibold mt-5 mb-2 first:mt-0">{children}</h2>
   ),
   h3: ({ children }) => (
-    <h3 className="crisp-strong-title text-base mt-4 mb-2 first:mt-0">{children}</h3>
+    <h3 className="crisp-strong-title text-base font-semibold mt-4 mb-2 first:mt-0">
+      {children}
+    </h3>
   ),
-  p: ({ children }) => <p className="mb-3 last:mb-0 leading-[1.6]">{children}</p>,
+  p: ({ children }) => <p className="mb-3.5 last:mb-0 leading-[1.72]">{children}</p>,
   ul: ({ children }) => (
-    <ul className="list-disc pl-6 mb-3 space-y-1.5 marker:text-steel/70">{children}</ul>
+    <ul className="list-disc pl-6 mb-3.5 space-y-2 marker:text-steel/70">{children}</ul>
   ),
   ol: ({ children }) => (
-    <ol className="list-decimal pl-6 mb-3 space-y-1.5 marker:text-steel/70">{children}</ol>
+    <ol className="list-decimal pl-6 mb-3.5 space-y-2 marker:text-steel/70">{children}</ol>
   ),
-  li: ({ children }) => <li className="leading-[1.6]">{children}</li>,
+  li: ({ children }) => <li className="leading-[1.72]">{children}</li>,
   blockquote: ({ children }) => (
-    <blockquote className="my-3 border-l-2 border-steel/25 pl-4 italic text-muted-foreground">
+    <blockquote className="my-3.5 border-l-2 border-steel/25 pl-4 leading-[1.72] italic text-muted-foreground">
       {children}
     </blockquote>
   ),

--- a/src/renderer/src/components/sessions/SessionCostPill.tsx
+++ b/src/renderer/src/components/sessions/SessionCostPill.tsx
@@ -59,23 +59,23 @@ export function SessionCostPill({
   const { t } = useI18n()
   const modelSummary = formatModelLabelSummary(getSessionSummaryModelLabels(summary))
   const totalCost = Math.max(summary?.total_cost ?? 0, fallbackCost ?? 0)
-  const hasSummaryTokens = (summary?.total_tokens ?? 0) > 0
+  const hasSummary = summary !== null
   const fallbackTotalTokens = fallbackTokens
     ? fallbackTokens.input +
       fallbackTokens.output +
       fallbackTokens.cacheRead +
       fallbackTokens.cacheWrite
     : 0
-  const totalTokens = hasSummaryTokens ? (summary?.total_tokens ?? 0) : fallbackTotalTokens
+  const totalTokens = hasSummary ? (summary?.total_tokens ?? 0) : fallbackTotalTokens
   const hasAnyTokens = totalTokens > 0
-  const inputTokens = hasSummaryTokens ? (summary?.input_tokens ?? 0) : (fallbackTokens?.input ?? 0)
-  const outputTokens = hasSummaryTokens
+  const inputTokens = hasSummary ? (summary?.input_tokens ?? 0) : (fallbackTokens?.input ?? 0)
+  const outputTokens = hasSummary
     ? (summary?.output_tokens ?? 0)
     : (fallbackTokens?.output ?? 0)
-  const cacheWriteTokens = hasSummaryTokens
+  const cacheWriteTokens = hasSummary
     ? (summary?.cache_write_tokens ?? 0)
     : (fallbackTokens?.cacheWrite ?? 0)
-  const cacheReadTokens = hasSummaryTokens
+  const cacheReadTokens = hasSummary
     ? (summary?.cache_read_tokens ?? 0)
     : (fallbackTokens?.cacheRead ?? 0)
 

--- a/src/renderer/src/components/sessions/SessionTaskTracker.tsx
+++ b/src/renderer/src/components/sessions/SessionTaskTracker.tsx
@@ -12,6 +12,7 @@ import {
 import { cn } from '@/lib/utils'
 import { useI18n } from '@/i18n/useI18n'
 import { getTodoCounts, type TodoItem, type TodoToolStatus } from './tools/todo-utils'
+import { sortSessionTaskLikeItems } from '@/lib/session-tasks'
 
 interface SessionTaskTrackerProps {
   todos: TodoItem[]
@@ -69,21 +70,7 @@ export function SessionTaskTracker({
 
   const progressPercent = Math.round((completed / todos.length) * 100)
 
-  const orderedTodos = useMemo(() => {
-    const rank: Record<TodoItem['status'], number> = {
-      in_progress: 0,
-      pending: 1,
-      completed: 2,
-      cancelled: 3
-    }
-
-    return [...todos].sort((a, b) => {
-      if (rank[a.status] !== rank[b.status]) return rank[a.status] - rank[b.status]
-      if (a.priority === b.priority) return 0
-      const priorityRank = { high: 0, medium: 1, low: 2 }
-      return priorityRank[a.priority] - priorityRank[b.priority]
-    })
-  }, [todos])
+  const orderedTodos = useMemo(() => sortSessionTaskLikeItems(todos), [todos])
 
   useEffect(() => {
     setExpanded(false)

--- a/src/renderer/src/components/sessions/SessionView.tsx
+++ b/src/renderer/src/components/sessions/SessionView.tsx
@@ -3183,16 +3183,22 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
           )
           if (shouldAbortInit()) return
           if (reconnectResult.success) {
-            setOpencodeSessionId(existingOpcSessionId)
-            useSessionStore.getState().setOpenCodeSessionId(sessionId, existingOpcSessionId)
-            transcriptSourceRef.current.opencodeSessionId = existingOpcSessionId
+            const runtimeSessionId = reconnectResult.sessionId ?? existingOpcSessionId
+            setOpencodeSessionId(runtimeSessionId)
+            useSessionStore.getState().setOpenCodeSessionId(sessionId, runtimeSessionId)
+            transcriptSourceRef.current.opencodeSessionId = runtimeSessionId
+            if (runtimeSessionId !== existingOpcSessionId) {
+              await window.db.session.update(sessionId, {
+                opencode_session_id: runtimeSessionId
+              })
+            }
             // Only update revertMessageID from reconnect if it carries a value;
             // sessionInfo already hydrated the authoritative value earlier.
             if (reconnectResult.revertMessageID != null) {
               setRevertMessageID(reconnectResult.revertMessageID)
             }
             fetchModelLimits()
-            fetchCommands(wtPath, existingOpcSessionId)
+            fetchCommands(wtPath, runtimeSessionId)
             hydratePermissions(wtPath)
             // Create response log file if logging is enabled
             if (isLogModeRef.current) {
@@ -3386,13 +3392,19 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
           sessionId
         )
         if (reconnectResult.success) {
-          setOpencodeSessionId(existingOpcSessionId)
-          useSessionStore.getState().setOpenCodeSessionId(sessionId, existingOpcSessionId)
-          transcriptSourceRef.current.opencodeSessionId = existingOpcSessionId
+          const runtimeSessionId = reconnectResult.sessionId ?? existingOpcSessionId
+          setOpencodeSessionId(runtimeSessionId)
+          useSessionStore.getState().setOpenCodeSessionId(sessionId, runtimeSessionId)
+          transcriptSourceRef.current.opencodeSessionId = runtimeSessionId
+          if (runtimeSessionId !== existingOpcSessionId) {
+            await window.db.session.update(sessionId, {
+              opencode_session_id: runtimeSessionId
+            })
+          }
           if (reconnectResult.revertMessageID != null) {
             setRevertMessageID(reconnectResult.revertMessageID)
           }
-          activeOpcSessionId = existingOpcSessionId
+          activeOpcSessionId = runtimeSessionId
         } else {
           setRevertMessageID(null)
           activeOpcSessionId = null

--- a/src/renderer/src/components/sessions/SessionView.tsx
+++ b/src/renderer/src/components/sessions/SessionView.tsx
@@ -1377,7 +1377,7 @@ export function SessionView({ sessionId }: SessionViewProps): React.JSX.Element 
   // Transition an ExitPlanMode tool card's status in both streaming parts and
   // committed messages. The card may live in either location depending on timing.
   const transitionToolStatus = useCallback(
-    (toolUseID: string, status: 'success' | 'error', error?: string) => {
+    (toolUseID: string, status: 'success' | 'error' | 'rejected', error?: string) => {
       const mapper = (p: StreamingPart): StreamingPart =>
         p.type === 'tool_use' && p.toolUse?.id === toolUseID
           ? { ...p, toolUse: { ...p.toolUse!, status, ...(error ? { error } : {}) } }

--- a/src/renderer/src/components/sessions/ToolCard.tsx
+++ b/src/renderer/src/components/sessions/ToolCard.tsx
@@ -641,7 +641,9 @@ function CollapsedContent({
   // ExitPlanMode — plan review tool
   if (lowerName === 'exitplanmode') {
     const isAccepted = toolUse.status === 'success'
-    const isRejected = toolUse.status === 'error'
+    // 'rejected' is the post-Bug 3 explicit verdict; 'error' is the legacy
+    // mapping kept for backward-compat with older serialized states.
+    const isRejected = toolUse.status === 'rejected' || toolUse.status === 'error'
     const badgeText = isAccepted
       ? t('toolCard.summary.accepted')
       : isRejected
@@ -1042,7 +1044,10 @@ export const ToolCard = memo(function ToolCard({
   // ExitPlanMode: collapsible plan card with fake user message on acceptance/rejection
   if (isExitPlanMode) {
     const planAccepted = toolUse.status === 'success'
-    const planRejected = toolUse.status === 'error'
+    // Treat both 'rejected' (post-Bug 3 explicit verdict) and the legacy
+    // 'error' (older paths that mapped reject → error) as a rejected plan
+    // so the red highlight stays consistent across SessionView and Session HQ.
+    const planRejected = toolUse.status === 'rejected' || toolUse.status === 'error'
     const isPlanPending = toolUse.status === 'pending'
     // Only pending plans stay expanded for review; all other states collapse by default
     const isSettled = !isPlanPending

--- a/src/renderer/src/components/settings/SettingsModal.tsx
+++ b/src/renderer/src/components/settings/SettingsModal.tsx
@@ -80,7 +80,8 @@ export function SettingsModal(): React.JSX.Element {
           'p-0 gap-0 overflow-hidden',
           activeSection === 'usage' ||
             activeSection === 'archivedChats' ||
-            activeSection === 'skills'
+            activeSection === 'skills' ||
+            activeSection === 'updates'
             ? 'max-w-[min(96vw,1280px)] h-[88vh]'
             : 'max-w-3xl h-[70vh]'
         )}

--- a/src/renderer/src/components/settings/SettingsUpdates.tsx
+++ b/src/renderer/src/components/settings/SettingsUpdates.tsx
@@ -29,7 +29,7 @@ export function SettingsUpdates(): React.JSX.Element {
   }
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-6 pb-8">
       <div>
         <h3 className="text-base font-medium mb-1">{t('settings.updates.title')}</h3>
         <p className="text-sm text-muted-foreground">{t('settings.updates.description')}</p>

--- a/src/renderer/src/hooks/useSessionSmartScroll.ts
+++ b/src/renderer/src/hooks/useSessionSmartScroll.ts
@@ -17,6 +17,7 @@ interface UseSessionSmartScrollOptions {
   isStreaming: boolean
   bottomAreaRef?: React.RefObject<HTMLElement | null>
   composerRef?: React.RefObject<HTMLElement | null>
+  clearScreenActive?: boolean
 }
 
 interface UseSessionSmartScrollResult {
@@ -25,16 +26,22 @@ interface UseSessionSmartScrollResult {
   scrollFabCount: number
   scrollFabBottomOffset: number
   bottomFloatingHeight: number
+  clearScreenBottomInset: number
   handleScroll: () => void
   handleScrollWheel: () => void
   handleScrollPointerDown: () => void
   handleScrollPointerUp: () => void
   handleScrollPointerCancel: () => void
   handleScrollToBottomClick: () => void
+  scrollToOffset: (top: number, behavior?: ScrollBehavior) => void
 }
 
-function getDistanceFromBottom(element: HTMLDivElement): number {
-  return element.scrollHeight - element.scrollTop - element.clientHeight
+function getDistanceFromBottom(element: HTMLDivElement, bottomInset = 0): number {
+  return element.scrollHeight - bottomInset - element.scrollTop - element.clientHeight
+}
+
+function getBottomScrollTop(element: HTMLDivElement, bottomInset = 0): number {
+  return Math.max(0, element.scrollHeight - element.clientHeight - bottomInset)
 }
 
 function scrollElementTo(element: HTMLDivElement, top: number, behavior: ScrollBehavior): void {
@@ -57,7 +64,8 @@ export function useSessionSmartScroll({
   mirrorVersion,
   isStreaming,
   bottomAreaRef,
-  composerRef
+  composerRef,
+  clearScreenActive = false
 }: UseSessionSmartScrollOptions): UseSessionSmartScrollResult {
   const scrollContainerRef = useRef<HTMLDivElement>(null)
   const programmaticScrollResetRef = useRef<number | null>(null)
@@ -70,10 +78,14 @@ export function useSessionSmartScroll({
   const latestMirrorVersionRef = useRef(mirrorVersion)
   const [dockHeight, setDockHeight] = useState(0)
   const [composerHeight, setComposerHeight] = useState(0)
+  const [viewportHeight, setViewportHeight] = useState(0)
   const [viewState, setViewState] = useState<SessionViewState>(() =>
     getSessionViewState(sessionId, mirrorVersion)
   )
   const viewStateRef = useRef(viewState)
+  const clearScreenBottomInset = clearScreenActive
+    ? Math.max((viewportHeight > 0 ? viewportHeight : 456) - 96, 240)
+    : 0
 
   const writeViewState = useCallback(
     (
@@ -103,7 +115,8 @@ export function useSessionSmartScroll({
       }
 
       const stickyBottom =
-        options?.forceStickyBottom ?? getDistanceFromBottom(element) < NEAR_BOTTOM_THRESHOLD
+        options?.forceStickyBottom ??
+        getDistanceFromBottom(element, clearScreenBottomInset) < NEAR_BOTTOM_THRESHOLD
       const shouldMarkSeen = options?.markSeen ?? stickyBottom
 
       const next = writeViewState(
@@ -119,7 +132,7 @@ export function useSessionSmartScroll({
       lastScrollTopRef.current = element.scrollTop
       return next
     },
-    [mirrorVersion, writeViewState]
+    [clearScreenBottomInset, mirrorVersion, writeViewState]
   )
 
   const markProgrammaticScroll = useCallback(() => {
@@ -156,7 +169,7 @@ export function useSessionSmartScroll({
       if (!element) return
 
       markProgrammaticScroll()
-      scrollElementTo(element, element.scrollHeight, behavior)
+      scrollElementTo(element, getBottomScrollTop(element, clearScreenBottomInset), behavior)
 
       const current = viewStateRef.current
       const shouldSyncState =
@@ -170,7 +183,32 @@ export function useSessionSmartScroll({
         markSeen: true
       })
     },
-    [isStreaming, markProgrammaticScroll, mirrorVersion, persistCurrentAnchor]
+    [
+      clearScreenBottomInset,
+      isStreaming,
+      markProgrammaticScroll,
+      mirrorVersion,
+      persistCurrentAnchor
+    ]
+  )
+
+  const scrollToOffset = useCallback(
+    (top: number, behavior: ScrollBehavior = 'instant') => {
+      const element = scrollContainerRef.current
+      if (!element) return
+
+      const nextTop = Math.max(0, Math.min(top, getBottomScrollTop(element, 0)))
+      markProgrammaticScroll()
+      scrollElementTo(element, nextTop, behavior)
+      lastScrollTopRef.current = nextTop
+      writeViewState(() => ({
+        scrollTop: nextTop,
+        stickyBottom: false,
+        manualScrollLocked: false,
+        lastSeenVersion: mirrorVersion
+      }))
+    },
+    [markProgrammaticScroll, mirrorVersion, writeViewState]
   )
 
   const restoreScrollAnchor = useCallback(() => {
@@ -211,7 +249,7 @@ export function useSessionSmartScroll({
     }
     viewStateRef.current = current
 
-    const distanceFromBottom = getDistanceFromBottom(element)
+    const distanceFromBottom = getDistanceFromBottom(element, clearScreenBottomInset)
     const isNearBottom = distanceFromBottom < NEAR_BOTTOM_THRESHOLD
     const hasManualIntent = manualScrollIntentRef.current || pointerDownInScrollerRef.current
 
@@ -245,7 +283,7 @@ export function useSessionSmartScroll({
       { syncState: current.stickyBottom || !current.manualScrollLocked }
     )
     manualScrollIntentRef.current = false
-  }, [mirrorVersion, writeViewState])
+  }, [clearScreenBottomInset, mirrorVersion, writeViewState])
 
   const handleScrollToBottomClick = useCallback(() => {
     resetInteractionState()
@@ -306,11 +344,16 @@ export function useSessionSmartScroll({
   }, [contentVersion, ready, restoreScrollAnchor])
 
   useEffect(() => {
-    if (!ready || !hasRestoredInitialAnchorRef.current || !viewStateRef.current.stickyBottom) {
+    if (
+      !ready ||
+      clearScreenActive ||
+      !hasRestoredInitialAnchorRef.current ||
+      !viewStateRef.current.stickyBottom
+    ) {
       return
     }
     scrollToBottom()
-  }, [contentVersion, mirrorVersion, ready, scrollToBottom])
+  }, [clearScreenActive, contentVersion, mirrorVersion, ready, scrollToBottom])
 
   // Use useLayoutEffect for the initial sync measurement so the first paint
   // already has the correct padding-bottom — otherwise the first frame leaves
@@ -318,6 +361,8 @@ export function useSessionSmartScroll({
   useLayoutEffect(() => {
     const dockElement = bottomAreaRef?.current
     const composerElement = composerRef?.current
+    const scrollElement = scrollContainerRef.current
+    setViewportHeight(scrollElement?.clientHeight ?? 0)
     setDockHeight(dockElement?.getBoundingClientRect().height ?? 0)
     setComposerHeight(composerElement?.getBoundingClientRect().height ?? 0)
   }, [bottomAreaRef, composerRef])
@@ -325,6 +370,8 @@ export function useSessionSmartScroll({
   useEffect(() => {
     const dockElement = bottomAreaRef?.current
     const composerElement = composerRef?.current
+    const scrollElement = scrollContainerRef.current
+    setViewportHeight(scrollElement?.clientHeight ?? 0)
     setDockHeight(dockElement?.getBoundingClientRect().height ?? 0)
     setComposerHeight(composerElement?.getBoundingClientRect().height ?? 0)
 
@@ -334,8 +381,9 @@ export function useSessionSmartScroll({
     const handleResize = () => {
       const scrollElement = scrollContainerRef.current
       if (!scrollElement) return
+      if (clearScreenActive) return
 
-      const distanceFromBottom = getDistanceFromBottom(scrollElement)
+      const distanceFromBottom = getDistanceFromBottom(scrollElement, clearScreenBottomInset)
       const shouldCompensate =
         viewStateRef.current.stickyBottom || distanceFromBottom < BOTTOM_AREA_COMPENSATE_THRESHOLD
 
@@ -352,7 +400,10 @@ export function useSessionSmartScroll({
       })
     }
 
-    const observedTargets: Array<readonly [HTMLElement | null | undefined, (height: number) => void]> = [
+    const observedTargets: Array<
+      readonly [HTMLElement | null | undefined, (height: number) => void]
+    > = [
+      [scrollElement, setViewportHeight],
       [dockElement, setDockHeight],
       [composerElement, setComposerHeight]
     ]
@@ -378,7 +429,15 @@ export function useSessionSmartScroll({
         bottomAreaScrollRafRef.current = null
       }
     }
-  }, [bottomAreaRef, composerRef, resetInteractionState, scrollToBottom, sessionId])
+  }, [
+    bottomAreaRef,
+    clearScreenActive,
+    clearScreenBottomInset,
+    composerRef,
+    resetInteractionState,
+    scrollToBottom,
+    sessionId
+  ])
 
   useEffect(() => {
     return () => {
@@ -407,6 +466,7 @@ export function useSessionSmartScroll({
     showScrollFab,
     scrollFabCount,
     scrollFabBottomOffset,
+    clearScreenBottomInset,
     /**
      * Measured pixel height of the floating ComposerBar (and any sibling
      * floating dock). Consumers should use this to size the bottom padding
@@ -419,6 +479,7 @@ export function useSessionSmartScroll({
     handleScrollPointerDown,
     handleScrollPointerUp,
     handleScrollPointerCancel,
-    handleScrollToBottomClick
+    handleScrollToBottomClick,
+    scrollToOffset
   }
 }

--- a/src/renderer/src/hooks/useSessionSmartScroll.ts
+++ b/src/renderer/src/hooks/useSessionSmartScroll.ts
@@ -456,9 +456,8 @@ export function useSessionSmartScroll({
   const showScrollFab = !viewState.stickyBottom && scrollFabCount > 0
 
   const scrollFabBottomOffset = useMemo(() => {
-    const dockOffset = dockHeight > 0 ? dockHeight + 16 : DEFAULT_SCROLL_FAB_OFFSET
-    const composerOffset = composerHeight > 0 ? composerHeight + 32 : DEFAULT_SCROLL_FAB_OFFSET
-    return Math.max(DEFAULT_SCROLL_FAB_OFFSET, dockOffset, composerOffset)
+    const bottomChromeHeight = dockHeight + composerHeight
+    return bottomChromeHeight > 0 ? bottomChromeHeight + 32 : DEFAULT_SCROLL_FAB_OFFSET
   }, [composerHeight, dockHeight])
 
   return {

--- a/src/renderer/src/i18n/messages.ts
+++ b/src/renderer/src/i18n/messages.ts
@@ -1615,6 +1615,7 @@ export const messages: Record<AppLocale, MessageTree> = {
           title: 'Proposed Execution Plan',
           requiresApproval: 'Requires Approval',
           approved: 'Approved',
+          rejected: 'Rejected',
           rejectModify: 'Reject / Modify',
           approveStart: 'Approve & Start'
         },
@@ -4496,6 +4497,7 @@ export const messages: Record<AppLocale, MessageTree> = {
           title: '待执行计划',
           requiresApproval: '需要批准',
           approved: '已批准',
+          rejected: '已拒绝',
           rejectModify: '拒绝 / 修改',
           approveStart: '批准并开始'
         },

--- a/src/renderer/src/i18n/messages.ts
+++ b/src/renderer/src/i18n/messages.ts
@@ -2435,6 +2435,7 @@ export const messages: Record<AppLocale, MessageTree> = {
     },
     contextIndicator: {
       title: 'Context Window',
+      explainer: 'Model limit, not billing. Shows the latest turn prompt occupancy.',
       latestTurn: 'Latest turn API usage',
       summary: {
         withLimit: '{used} / {limit} tokens ({percent}%)',
@@ -5311,6 +5312,7 @@ export const messages: Record<AppLocale, MessageTree> = {
     },
     contextIndicator: {
       title: '上下文窗口',
+      explainer: '这是模型上下文上限/当前轮占用，不是计费金额。',
       latestTurn: '最近一轮 API 用量',
       summary: {
         withLimit: '{used} / {limit} tokens ({percent}%)',

--- a/src/renderer/src/lib/codex-timeline.ts
+++ b/src/renderer/src/lib/codex-timeline.ts
@@ -128,6 +128,40 @@ function getOrderedActivityTurnIds(activityRows: SessionActivity[]): string[] {
   ]
 }
 
+function extractTurnIdFromMessage(message: OpenCodeMessage): string | null {
+  if (message.role === 'assistant') return extractAssistantTurnId(message.id)
+  if (message.role === 'user') return extractUserTurnId(message.id)
+  return null
+}
+
+function inferToolActivityTurnId(
+  activity: SessionActivity,
+  messages: OpenCodeMessage[]
+): string | null {
+  if (!activity.kind.startsWith('tool.')) return null
+
+  const activityTime = Date.parse(activity.created_at)
+  if (!Number.isFinite(activityTime)) return null
+
+  let currentTurnId: string | null = null
+  for (const message of messages) {
+    const messageTime = Date.parse(message.timestamp)
+    if (!Number.isFinite(messageTime)) continue
+
+    if (message.role === 'user') {
+      if (messageTime > activityTime) break
+      currentTurnId = extractUserTurnId(message.id) ?? currentTurnId
+      continue
+    }
+
+    if (!currentTurnId && messageTime <= activityTime) {
+      currentTurnId = extractTurnIdFromMessage(message)
+    }
+  }
+
+  return currentTurnId
+}
+
 function normalizeCodexMessageRows(
   messages: SessionMessage[],
   activityRows: SessionActivity[]
@@ -381,7 +415,7 @@ export function mergeCodexActivityMessages(
       continue
     }
 
-    const turnId = activity.turn_id
+    const turnId = activity.turn_id ?? inferToolActivityTurnId(activity, normalizedBaseMessages)
     const syntheticId = turnId ? `${turnId}:tool:${toolId}` : `tool:${toolId}`
     const targetCollection = turnId
       ? (anchoredSyntheticByTurnId.get(turnId) ?? [])
@@ -407,6 +441,35 @@ export function mergeCodexActivityMessages(
   const injectedTurns = new Set<string>()
   const orderedMessages: OpenCodeMessage[] = []
 
+  function buildTurnBatch(turnId: string): OpenCodeMessage[] {
+    const synthetics = anchoredSyntheticByTurnId.get(turnId) ?? []
+    const reals = mergedMessages.filter(
+      (message) => message.role === 'assistant' && extractAssistantTurnId(message.id) === turnId
+    )
+    if (synthetics.length === 0) return reals
+
+    const tagged: Array<{ message: OpenCodeMessage; ts: number; isSynthetic: boolean }> = [
+      ...reals.map((message) => ({
+        message,
+        ts: Date.parse(message.timestamp) || 0,
+        isSynthetic: false
+      })),
+      ...synthetics.map((message) => ({
+        message,
+        ts: Date.parse(message.timestamp) || 0,
+        isSynthetic: true
+      }))
+    ]
+
+    tagged.sort((left, right) => {
+      if (left.ts !== right.ts) return left.ts - right.ts
+      if (left.isSynthetic !== right.isSynthetic) return left.isSynthetic ? 1 : -1
+      return 0
+    })
+
+    return tagged.map((entry) => entry.message)
+  }
+
   mergedMessages.forEach((message, index) => {
     const turnId =
       message.role === 'assistant'
@@ -419,8 +482,13 @@ export function mergeCodexActivityMessages(
       firstAssistantIndexByTurnId.get(turnId) === index &&
       !injectedTurns.has(turnId)
     ) {
-      orderedMessages.push(...(anchoredSyntheticByTurnId.get(turnId) ?? []))
+      orderedMessages.push(...buildTurnBatch(turnId))
       injectedTurns.add(turnId)
+      return
+    }
+
+    if (turnId && message.role === 'assistant' && injectedTurns.has(turnId)) {
+      return
     }
 
     orderedMessages.push(message)

--- a/src/renderer/src/lib/context-usage.ts
+++ b/src/renderer/src/lib/context-usage.ts
@@ -2,9 +2,7 @@ import type { AgentSessionContextUsageData } from '@shared/types/agent-protocol'
 import type { ContextUsageCategory, TokenInfo } from '@/stores/useContextStore'
 import { useContextStore } from '@/stores/useContextStore'
 
-function normalizeTokens(
-  tokens: AgentSessionContextUsageData['tokens'] | undefined
-): TokenInfo {
+function normalizeTokens(tokens: AgentSessionContextUsageData['tokens'] | undefined): TokenInfo {
   return {
     input: tokens?.input ?? 0,
     output: tokens?.output ?? 0,
@@ -22,6 +20,26 @@ function hasTokenPayload(tokens: TokenInfo): boolean {
     tokens.cacheRead > 0 ||
     tokens.cacheWrite > 0
   )
+}
+
+function applyContextUsageCost(sessionId: string, data: AgentSessionContextUsageData): void {
+  const store = useContextStore.getState()
+  if (typeof data.totalCost === 'number' && Number.isFinite(data.totalCost) && data.totalCost > 0) {
+    if ((store.costBySession[sessionId] ?? 0) < data.totalCost) {
+      store.setSessionCost(sessionId, data.totalCost)
+    }
+    return
+  }
+
+  if (typeof data.cost !== 'number' || !Number.isFinite(data.cost) || data.cost <= 0) return
+
+  const requestId = typeof data.requestId === 'string' ? data.requestId.trim() : ''
+  if (requestId) {
+    store.addSessionCostOnce(sessionId, `context:${requestId}`, data.cost)
+    return
+  }
+
+  store.addSessionCost(sessionId, data.cost)
 }
 
 function normalizeCategories(
@@ -47,6 +65,8 @@ export function applySessionContextUsage(
   data: AgentSessionContextUsageData
 ): void {
   const store = useContextStore.getState()
+  applyContextUsageCost(sessionId, data)
+
   const tokens = normalizeTokens(data.tokens)
   const model = data.model
     ? {
@@ -80,7 +100,12 @@ export function applySessionContextUsage(
     return
   }
 
-  if (model && typeof data.contextWindow === 'number' && data.contextWindow > 0 && hasTokenPayload(tokens)) {
+  if (
+    model &&
+    typeof data.contextWindow === 'number' &&
+    data.contextWindow > 0 &&
+    hasTokenPayload(tokens)
+  ) {
     const usedTokens = tokens.input + tokens.cacheRead + tokens.cacheWrite
     store.setSessionContextSnapshot(sessionId, {
       usedTokens,

--- a/src/renderer/src/lib/opencode-transcript.ts
+++ b/src/renderer/src/lib/opencode-transcript.ts
@@ -4,7 +4,7 @@ export interface ToolUseInfo {
   id: string
   name: string
   input: Record<string, unknown>
-  status: 'pending' | 'running' | 'success' | 'error'
+  status: 'pending' | 'running' | 'success' | 'error' | 'rejected'
   startTime: number
   endTime?: number
   output?: string

--- a/src/renderer/src/lib/session-tasks.ts
+++ b/src/renderer/src/lib/session-tasks.ts
@@ -1,35 +1,461 @@
 import { isTodoWriteTool } from '@/components/sessions/tools/todo-utils'
+import type { TodoItem } from '@/components/sessions/tools/todo-utils'
 import type { TimelineMessage } from '@shared/lib/timeline-types'
 
-export type SessionTaskStatus = 'pending' | 'in_progress' | 'completed' | 'error'
+export type SessionTaskStatus = 'pending' | 'in_progress' | 'completed' | 'cancelled' | 'error'
 
 export interface SessionTask {
   id: string
   content: string
   status: SessionTaskStatus
+  subject?: string
+  description?: string
+  activeForm?: string
+  priority?: TodoItem['priority']
 }
 
-export function extractMissionTasks(messages: TimelineMessage[]): SessionTask[] {
-  // Scan from end to find the latest todo-like tool snapshot.
-  for (let i = messages.length - 1; i >= 0; i--) {
-    const msg = messages[i]
+type SortableTaskLike = {
+  id?: string
+  status?: string
+  priority?: string
+}
+
+type SessionTaskSource = Pick<
+  SessionTask,
+  'content' | 'subject' | 'description' | 'activeForm' | 'status' | 'priority'
+>
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function compactWhitespace(value: string): string {
+  return value.replace(/\s+/g, ' ').trim()
+}
+
+function containsCjk(value: string): boolean {
+  return /[㐀-鿿]/.test(value)
+}
+
+function humanizeEnglishTaskTarget(value: string): string {
+  const lowered = compactWhitespace(value)
+    .toLowerCase()
+    .replace(/^[a-z]+ing\s+/, '')
+    .replace(/^(to\s+)?(read|inspect|check|review|look\s+through|look\s+at)\s+/, '')
+    .replace(/^(to\s+)?(update|change|adjust|refactor|move)\s+/, '')
+    .replace(/^(to\s+)?(test|verify|validate)\s+/, '')
+    .replace(/^(to\s+)?(implement|build|create|add|render|show|display)\s+/, '')
+    .replace(/^(to\s+)?(fix|debug|resolve)\s+/, '')
+    .replace(/^(to\s+)?(analyze|analyse|investigate|understand|explore)\s+/, '')
+    .replace(/^(to\s+)?(optimize|optimise|improve|polish)\s+/, '')
+    .replace(/^(to\s+)?extract\s+/, '')
+    .replace(/^(the|a|an|current|existing|latest)\s+/, '')
+    .replace(/\b(current|existing|latest)\b/g, '')
+    .replace(/[_.-]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+
+  if (lowered.includes('session task implementation')) return '会话任务实现'
+  if (lowered.includes('codebase structure')) return '代码库结构'
+  if (lowered.includes('authentication bug')) return '认证问题'
+  if (lowered.includes('new api') || lowered.includes('api')) return '新 API'
+  if (lowered.includes('task panel') || lowered.includes('todo panel')) return '任务面板'
+  if (lowered.includes('context panel')) return '右侧面板'
+  if (lowered.includes('timeline')) return '时间线'
+  if (lowered.includes('task list')) return '任务列表'
+  if (lowered.includes('task snapshot')) return '任务快照'
+  if (lowered.includes('task')) return '任务'
+  if (lowered.includes('implementation')) return '实现'
+  if (lowered.includes('helper')) return '辅助逻辑'
+  if (lowered.includes('round')) return '轮次逻辑'
+  if (lowered.includes('session')) return '会话逻辑'
+  if (lowered.includes('ui') || lowered.includes('ux')) return '界面'
+  if (lowered.includes('test')) return '测试'
+  if (lowered.includes('style')) return '样式'
+  if (lowered.includes('prompt')) return '提示词'
+  return '相关内容'
+}
+
+function chooseChineseTaskVerb(value: string): string {
+  const lowered = compactWhitespace(value).toLowerCase()
+
+  if (
+    /(inspect|read|review|check|look\s+through|look\s+at|audit|scan|browse)/.test(lowered)
+  ) {
+    return '查看'
+  }
+  if (/(update|change|adjust|refactor|move|rename|rewrite)/.test(lowered)) {
+    return '更新'
+  }
+  if (/(test|verify|validate|confirm)/.test(lowered)) {
+    return '验证'
+  }
+  if (/(implement|build|create|add|render|show|display)/.test(lowered)) {
+    return '实现'
+  }
+  if (/(fix|debug|resolve|repair)/.test(lowered)) {
+    return '修复'
+  }
+  if (/(analyze|analyse|investigate|understand|explore|research)/.test(lowered)) {
+    return '分析'
+  }
+  if (/(optimize|optimise|improve|polish|tune)/.test(lowered)) {
+    return '优化'
+  }
+  if (/extract/.test(lowered)) {
+    return '提取'
+  }
+  return '处理'
+}
+
+function getTaskSourceText(task: SessionTaskSource): string {
+  return compactWhitespace(task.subject || task.content || task.activeForm || task.description || '')
+}
+
+export function getSessionTaskDisplayTitle(
+  task: SessionTaskSource,
+  index?: number
+): string {
+  const source = getTaskSourceText(task)
+  if (!source) {
+    return typeof index === 'number' ? `任务 ${index + 1}` : '任务'
+  }
+
+  if (containsCjk(source)) {
+    return source.length > 32 ? `${source.slice(0, 32)}…` : source
+  }
+
+  const verb = chooseChineseTaskVerb(source)
+  const target = humanizeEnglishTaskTarget(source)
+  return `${verb}${target}`
+}
+
+export function getSessionTaskRawDetail(task: SessionTaskSource, displayTitle?: string): string | undefined {
+  const detailCandidates = [task.description, task.content, task.subject, task.activeForm]
+    .filter((value): value is string => typeof value === 'string' && compactWhitespace(value).length > 0)
+    .map((value) => compactWhitespace(value))
+
+  const normalizedDisplayTitle = displayTitle ? compactWhitespace(displayTitle) : ''
+  return detailCandidates.find((candidate) => candidate !== normalizedDisplayTitle)
+}
+
+export function normalizeSessionTaskStatus(value: unknown): SessionTaskStatus {
+  switch (value) {
+    case 'in_progress':
+    case 'pending':
+    case 'completed':
+    case 'cancelled':
+    case 'error':
+      return value
+    case 'in-progress':
+      return 'in_progress'
+    case 'complete':
+    case 'done':
+      return 'completed'
+    case 'canceled':
+      return 'cancelled'
+    case 'blocked':
+      return 'error'
+    default:
+      return 'pending'
+  }
+}
+
+export function normalizeSessionTaskPriority(value: unknown): TodoItem['priority'] | undefined {
+  switch (value) {
+    case 'high':
+    case 'medium':
+    case 'low':
+      return value
+    default:
+      return undefined
+  }
+}
+
+export function getSessionTaskContent(input: Record<string, unknown>): string {
+  if (typeof input.content === 'string' && input.content.trim().length > 0) {
+    return input.content.trim()
+  }
+  if (typeof input.subject === 'string' && input.subject.trim().length > 0) {
+    return input.subject.trim()
+  }
+  if (typeof input.activeForm === 'string' && input.activeForm.trim().length > 0) {
+    return input.activeForm.trim()
+  }
+  if (typeof input.description === 'string' && input.description.trim().length > 0) {
+    return input.description.trim()
+  }
+  return ''
+}
+
+function getSessionTaskId(input: Record<string, unknown>, fallback: string): string {
+  const rawId = input.taskId ?? input.id
+  if (typeof rawId === 'string' && rawId.trim().length > 0) {
+    return rawId.trim()
+  }
+  return fallback
+}
+
+function taskFromRecord(input: Record<string, unknown>, fallbackId: string): SessionTask | null {
+  const content = getSessionTaskContent(input)
+  const status = normalizeSessionTaskStatus(input.status)
+  const subject = typeof input.subject === 'string' && input.subject.trim() ? input.subject.trim() : undefined
+  const description =
+    typeof input.description === 'string' && input.description.trim()
+      ? input.description.trim()
+      : undefined
+  const activeForm =
+    typeof input.activeForm === 'string' && input.activeForm.trim() ? input.activeForm.trim() : undefined
+
+  if (!content && !subject && !description && !activeForm) {
+    return null
+  }
+
+  return {
+    id: getSessionTaskId(input, fallbackId),
+    content,
+    status,
+    ...(subject ? { subject } : {}),
+    ...(description ? { description } : {}),
+    ...(activeForm ? { activeForm } : {}),
+    ...(normalizeSessionTaskPriority(input.priority)
+      ? { priority: normalizeSessionTaskPriority(input.priority) }
+      : {})
+  }
+}
+
+function mergeSessionTask(existing: SessionTask | undefined, incoming: SessionTask): SessionTask {
+  return {
+    id: incoming.id || existing?.id || 'task',
+    content: incoming.content || existing?.content || incoming.subject || existing?.subject || '',
+    status: incoming.status ?? existing?.status ?? 'pending',
+    subject: incoming.subject ?? existing?.subject,
+    description: incoming.description ?? existing?.description,
+    activeForm: incoming.activeForm ?? existing?.activeForm,
+    priority: incoming.priority ?? existing?.priority
+  }
+}
+
+function applyTodoSnapshot(current: SessionTask[], input: unknown): SessionTask[] {
+  if (!isRecord(input) || !Array.isArray(input.todos)) {
+    return current
+  }
+
+  return input.todos.flatMap((todo, index) => {
+    if (!isRecord(todo)) return []
+    const task = taskFromRecord(todo, `todo-${index}`)
+    return task ? [task] : []
+  })
+}
+
+function upsertSessionTask(current: SessionTask[], task: SessionTask): SessionTask[] {
+  const index = current.findIndex((existing) => existing.id === task.id)
+  if (index === -1) {
+    return [...current, task]
+  }
+
+  const next = [...current]
+  next[index] = mergeSessionTask(next[index], task)
+  return next
+}
+
+function patchSessionTask(current: SessionTask[], task: SessionTask): SessionTask[] {
+  return upsertSessionTask(current, task)
+}
+
+export function applySessionTaskToolEvent(
+  current: SessionTask[],
+  toolName: string | undefined,
+  input: unknown
+): SessionTask[] {
+  const lowerToolName = toolName?.toLowerCase() ?? ''
+
+  if (isTodoWriteTool(lowerToolName)) {
+    return applyTodoSnapshot(current, input)
+  }
+
+  if (lowerToolName === 'taskcreate' || lowerToolName === 'task_create') {
+    if (!isRecord(input)) return current
+    const task = taskFromRecord(input, `task-${current.length + 1}`)
+    if (!task) return current
+
+    const existing = current.find((candidate) => candidate.id === task.id)
+    if (
+      existing &&
+      typeof input.content !== 'string' &&
+      typeof input.subject !== 'string' &&
+      typeof input.activeForm !== 'string'
+    ) {
+      return upsertSessionTask(current, {
+        ...task,
+        content: existing.content,
+        subject: task.subject ?? existing.subject,
+        activeForm: task.activeForm ?? existing.activeForm
+      })
+    }
+
+    return upsertSessionTask(current, task)
+  }
+
+  if (lowerToolName === 'taskupdate' || lowerToolName === 'task_update') {
+    if (!isRecord(input)) return current
+    const taskId = getSessionTaskId(input, '')
+    if (!taskId) return current
+    const existing = current.find((task) => task.id === taskId)
+    const content = getSessionTaskContent(input) || existing?.content || existing?.subject || ''
+    const task: SessionTask = {
+      id: taskId,
+      content,
+      status: normalizeSessionTaskStatus(input.status ?? existing?.status),
+      ...(typeof input.subject === 'string' && input.subject.trim()
+        ? { subject: input.subject.trim() }
+        : existing?.subject
+          ? { subject: existing.subject }
+          : {}),
+      ...(typeof input.description === 'string' && input.description.trim()
+        ? { description: input.description.trim() }
+        : existing?.description
+          ? { description: existing.description }
+          : {}),
+      ...(typeof input.activeForm === 'string' && input.activeForm.trim()
+        ? { activeForm: input.activeForm.trim() }
+        : existing?.activeForm
+          ? { activeForm: existing.activeForm }
+          : {}),
+      ...(normalizeSessionTaskPriority(input.priority) ?? existing?.priority
+        ? { priority: normalizeSessionTaskPriority(input.priority) ?? existing?.priority }
+        : {})
+    }
+    if (!task.content && !task.subject && !task.description && !task.activeForm) {
+      return current
+    }
+    return patchSessionTask(current, task)
+  }
+
+  return current
+}
+
+function extractRoundTasks(messages: TimelineMessage[]): SessionTask[] {
+  let tasks: SessionTask[] = []
+
+  for (const msg of messages) {
     if (msg.role !== 'assistant') continue
 
     for (const part of msg.parts ?? []) {
       if (part.type !== 'tool_use' || !part.toolUse) continue
-      const toolName = part.toolUse.name?.toLowerCase() ?? ''
-      if (!isTodoWriteTool(toolName)) continue
-
-      const todos = part.toolUse.input?.todos
-      if (!Array.isArray(todos)) continue
-
-      return todos.map((t: Record<string, unknown>, idx: number) => ({
-        id: String(t.id ?? `todo-${idx}`),
-        content: String(t.content ?? t.subject ?? t.activeForm ?? ''),
-        status: (t.status as SessionTaskStatus) ?? 'pending'
-      }))
+      tasks = applySessionTaskToolEvent(tasks, part.toolUse.name, part.toolUse.input)
     }
   }
 
-  return []
+  return tasks
+}
+
+export function extractMissionTasks(messages: TimelineMessage[]): SessionTask[] {
+  let currentRound: TimelineMessage[] = []
+  const rounds: TimelineMessage[][] = []
+
+  for (const message of messages) {
+    if (message.role === 'user') {
+      if (currentRound.length > 0) {
+        rounds.push(currentRound)
+      }
+      currentRound = [message]
+      continue
+    }
+
+    if (currentRound.length > 0) {
+      currentRound.push(message)
+    }
+  }
+
+  if (currentRound.length > 0) {
+    rounds.push(currentRound)
+  }
+
+  for (let index = rounds.length - 1; index >= 0; index--) {
+    const tasks = extractRoundTasks(rounds[index])
+    if (tasks.length > 0) {
+      return tasks
+    }
+  }
+
+  return extractRoundTasks(messages)
+}
+
+function getStatusRank(status: string | undefined): number {
+  switch (status) {
+    case 'in_progress':
+    case 'in-progress':
+      return 0
+    case 'pending':
+      return 1
+    case 'completed':
+    case 'done':
+      return 2
+    case 'cancelled':
+    case 'canceled':
+      return 3
+    case 'error':
+    case 'blocked':
+      return 4
+    default:
+      return 1
+  }
+}
+
+function getPriorityRank(priority: string | undefined): number {
+  switch (priority) {
+    case 'high':
+      return 0
+    case 'medium':
+      return 1
+    case 'low':
+      return 2
+    default:
+      return 1
+  }
+}
+
+export function sortSessionTaskLikeItems<T extends SortableTaskLike>(items: T[]): T[] {
+  return items
+    .map((item, index) => ({ item, index }))
+    .sort((a, b) => {
+      const statusDelta = getStatusRank(a.item.status) - getStatusRank(b.item.status)
+      if (statusDelta !== 0) return statusDelta
+
+      const priorityDelta = getPriorityRank(a.item.priority) - getPriorityRank(b.item.priority)
+      if (priorityDelta !== 0) return priorityDelta
+
+      return a.index - b.index
+    })
+    .map(({ item }) => item)
+}
+
+export function sortSessionTasks(tasks: SessionTask[]): SessionTask[] {
+  return sortSessionTaskLikeItems(tasks)
+}
+
+export function getSessionTaskCounts(tasks: Array<{ status: string }>): {
+  completed: number
+  inProgress: number
+  pending: number
+  cancelled: number
+  error: number
+} {
+  let completed = 0
+  let inProgress = 0
+  let pending = 0
+  let cancelled = 0
+  let error = 0
+
+  for (const task of tasks) {
+    const status = normalizeSessionTaskStatus(task.status)
+    if (status === 'completed') completed++
+    else if (status === 'in_progress') inProgress++
+    else if (status === 'cancelled') cancelled++
+    else if (status === 'error') error++
+    else pending++
+  }
+
+  return { completed, inProgress, pending, cancelled, error }
 }

--- a/src/renderer/src/lib/transcript-refresh.ts
+++ b/src/renderer/src/lib/transcript-refresh.ts
@@ -2,7 +2,7 @@ export interface TranscriptToolUseInfo {
   id: string
   name: string
   input: Record<string, unknown>
-  status: 'pending' | 'running' | 'success' | 'error'
+  status: 'pending' | 'running' | 'success' | 'error' | 'rejected'
   startTime: number
   endTime?: number
   output?: string

--- a/src/renderer/src/stores/useContextStore.ts
+++ b/src/renderer/src/stores/useContextStore.ts
@@ -218,7 +218,7 @@ export const useContextStore = create<ContextState>()((set, get) => ({
     set((state) => {
       const existingKeys = state.costEventKeysBySession[sessionId] ?? {}
       if (existingKeys[eventKey]) {
-        return state
+        return {}
       }
 
       return {

--- a/src/renderer/src/styles/globals.css
+++ b/src/renderer/src/styles/globals.css
@@ -233,7 +233,7 @@
     font-feature-settings:
       'rlig' 1,
       'calt' 1;
-    line-height: 1.55;
+    line-height: 1.6;
   }
 
   .dark body {
@@ -319,13 +319,14 @@
   }
 
   .crisp-readable {
-    line-height: 1.6;
+    line-height: 1.72;
+    letter-spacing: 0;
   }
 
   .crisp-strong-title {
     color: var(--ink);
     font-weight: 650;
-    letter-spacing: -0.012em;
+    letter-spacing: 0;
   }
 
   .crisp-active-row {

--- a/src/renderer/src/styles/globals.css
+++ b/src/renderer/src/styles/globals.css
@@ -398,12 +398,9 @@
     background: linear-gradient(
       180deg,
       transparent 0%,
-      color-mix(in srgb, var(--agent-canvas) 42%, transparent) 34%,
-      color-mix(in srgb, var(--agent-canvas) 90%, transparent) 100%
+      color-mix(in srgb, var(--agent-canvas) 18%, transparent) 42%,
+      color-mix(in srgb, var(--agent-canvas) 82%, transparent) 100%
     );
-    -webkit-backdrop-filter: blur(16px);
-    backdrop-filter: blur(16px);
-    mask-image: linear-gradient(180deg, transparent 0%, black 34%, black 100%);
   }
 
   .crisp-voice-surface {

--- a/src/shared/lib/field-context-envelope.ts
+++ b/src/shared/lib/field-context-envelope.ts
@@ -1,5 +1,5 @@
 const FIELD_CONTEXT_HEADER_RE =
-  /^\s*\[Field Context(?:\s+[^\]\r\n]*|[\u2013\u2014-][^\]\r\n]*)?\][ \t]*(?:\r?\n|$)/
+  /^\s*\[(?:Field Context|Xuanpu Field Fallback)(?:\s+[^\]\r\n]*|[\u2013\u2014-][^\]\r\n]*)?\][ \t]*(?:\r?\n|$)/
 
 const USER_MESSAGE_MARKER_RE = /(?:^|\r?\n)[ \t]*\[User Message\][ \t]*(?:\r?\n|$)/
 

--- a/src/shared/lib/timeline-mappers.ts
+++ b/src/shared/lib/timeline-mappers.ts
@@ -755,7 +755,7 @@ export function parseToolPartFromActivity(activity: DbSessionActivity): Streamin
 
 function parsePlanPartFromActivity(
   activity: DbSessionActivity,
-  resolvedRequestIds?: Set<string>
+  resolvedVerdictByRequestId?: Map<string, 'approved' | 'rejected'>
 ): StreamingPart | null {
   const payload = parseJson<Record<string, unknown>>(activity.payload_json)
   if (activity.kind === 'plan.ready') {
@@ -772,10 +772,13 @@ function parsePlanPartFromActivity(
       activity.id
 
     // If a matching plan.resolved activity exists, the plan has been
-    // approved/rejected — surface the card with success status so the
-    // "Requires Approval" badge disappears and the card collapses.
+    // approved/rejected — surface the card in the corresponding terminal
+    // state so the "Requires Approval" badge disappears. Rejected plans
+    // get status='rejected' so PlanCard renders the greyed-out rejected
+    // verdict on reload (instead of mis-rendering as approved).
     const reqId = activity.request_id ?? activity.id
-    const isResolved = resolvedRequestIds?.has(reqId) ?? false
+    const verdict = resolvedVerdictByRequestId?.get(reqId)
+    const isResolved = verdict != null
 
     return {
       type: 'tool_use',
@@ -783,7 +786,7 @@ function parsePlanPartFromActivity(
         id: toolUseId,
         name: 'ExitPlanMode',
         input: { plan },
-        status: isResolved ? 'success' : 'pending',
+        status: isResolved ? (verdict === 'rejected' ? 'rejected' : 'success') : 'pending',
         startTime: Date.parse(activity.created_at) || Date.now(),
         ...(isResolved ? { endTime: Date.parse(activity.created_at) || Date.now() } : {})
       }
@@ -948,11 +951,20 @@ function mergeCodexActivityMessages(
   })
 
   // Pre-scan for plan.resolved activities so plan.ready cards rendered later
-  // can be marked as resolved (no more "Requires Approval" badge).
-  const resolvedRequestIds = new Set<string>()
+  // can be marked as resolved (no more "Requires Approval" badge) and so
+  // rejected plans surface a 'rejected' verdict instead of mis-rendering as
+  // approved. agent-handlers persists plan.resolved with payload
+  // `{ resolution: 'rejected', ... }` on reject; absence of that field is
+  // treated as approved (e.g. claude-code's approve path doesn't write a
+  // payload but only the reject path persists today — defaulting to
+  // 'approved' for any future approve-side persistence is the safer choice).
+  const resolvedVerdictByRequestId = new Map<string, 'approved' | 'rejected'>()
   for (const activity of sortedActivities) {
     if (activity.kind === 'plan.resolved' && activity.request_id) {
-      resolvedRequestIds.add(activity.request_id)
+      const payload = parseJson<Record<string, unknown>>(activity.payload_json)
+      const verdict: 'approved' | 'rejected' =
+        payload?.resolution === 'rejected' ? 'rejected' : 'approved'
+      resolvedVerdictByRequestId.set(activity.request_id, verdict)
     }
   }
 
@@ -961,7 +973,7 @@ function mergeCodexActivityMessages(
     if (activity.kind === 'plan.resolved') continue
     const activityPart = activity.kind.startsWith('tool.')
       ? parseToolPartFromActivity(activity)
-      : parsePlanPartFromActivity(activity, resolvedRequestIds)
+      : parsePlanPartFromActivity(activity, resolvedVerdictByRequestId)
     if (!activityPart?.toolUse) continue
 
     const toolId = activityPart.toolUse.id
@@ -1101,7 +1113,8 @@ export function deriveCodexTimeline(
  *     synthetic assistant message anchored at the activity's timestamp so
  *     the card still appears.
  *   - Plans with a paired `plan.resolved` row render as `status: 'success'`
- *     (greyed out, no "Requires Approval" badge), same logic Codex uses.
+ *     when approved (greyed out, no badge) or `status: 'rejected'` when the
+ *     payload carries `resolution: 'rejected'`, same logic Codex uses.
  */
 export function mergeOpenCodePlanActivities(
   messages: TimelineMessage[],
@@ -1112,10 +1125,13 @@ export function mergeOpenCodePlanActivities(
   const planReadyRows = activityRows.filter((row) => row.kind === 'plan.ready')
   if (planReadyRows.length === 0) return messages
 
-  const resolvedRequestIds = new Set<string>()
+  const resolvedVerdictByRequestId = new Map<string, 'approved' | 'rejected'>()
   for (const row of activityRows) {
     if (row.kind === 'plan.resolved' && row.request_id) {
-      resolvedRequestIds.add(row.request_id)
+      const payload = parseJson<Record<string, unknown>>(row.payload_json)
+      const verdict: 'approved' | 'rejected' =
+        payload?.resolution === 'rejected' ? 'rejected' : 'approved'
+      resolvedVerdictByRequestId.set(row.request_id, verdict)
     }
   }
 
@@ -1144,7 +1160,7 @@ export function mergeOpenCodePlanActivities(
   const trailing: TimelineMessage[] = []
 
   for (const row of planReadyRows) {
-    const part = parsePlanPartFromActivity(row, resolvedRequestIds)
+    const part = parsePlanPartFromActivity(row, resolvedVerdictByRequestId)
     if (!part?.toolUse) continue
     if (knownToolIds.has(part.toolUse.id)) continue
     knownToolIds.add(part.toolUse.id)

--- a/src/shared/lib/timeline-mappers.ts
+++ b/src/shared/lib/timeline-mappers.ts
@@ -133,10 +133,7 @@ function isSyntheticUserMessage(content: string): boolean {
  */
 export function stripInjectedContextEnvelope(content: string): string {
   if (!content) return content
-  if (
-    !content.startsWith('[Field Context') &&
-    !content.startsWith('[Worktree Context]')
-  ) {
+  if (!content.startsWith('[Field Context') && !content.startsWith('[Worktree Context]')) {
     return content
   }
   // Anchor on the literal closing marker the prefix templates always emit.
@@ -329,9 +326,7 @@ function mapRawMessage(rawMessage: unknown, index: number): MappedMessage {
       timestamp,
       ...(messageRecord?.steered === true || info?.steered === true ? { steered: true } : {}),
       parts: mappedParts.length > 0 ? mappedParts : undefined,
-      ...(role === 'user' && fileAttachments.length > 0
-        ? { attachments: fileAttachments }
-        : {})
+      ...(role === 'user' && fileAttachments.length > 0 ? { attachments: fileAttachments } : {})
     },
     sortTime,
     originalIndex: index
@@ -405,96 +400,93 @@ export function mapDbRowsToTimelineMessages(messages: DbSessionMessage[]): Timel
   return messages
     .filter((m) => !(m.role === 'user' && isSyntheticUserMessage(m.content)))
     .map((message) => {
-    const parsedMessage = parseJson<Record<string, unknown>>(message.opencode_message_json)
-    const parsedParts = parseJson<unknown[]>(message.opencode_parts_json)
-    const parts = Array.isArray(parsedParts)
-      ? parsedParts
-          .map((part, index) => mapPartToStreamingPart(part, index))
-          .filter((part): part is StreamingPart => part !== null)
-      : undefined
+      const parsedMessage = parseJson<Record<string, unknown>>(message.opencode_message_json)
+      const parsedParts = parseJson<unknown[]>(message.opencode_parts_json)
+      const parts = Array.isArray(parsedParts)
+        ? parsedParts
+            .map((part, index) => mapPartToStreamingPart(part, index))
+            .filter((part): part is StreamingPart => part !== null)
+        : undefined
 
-    // Extract usage + model identity from the raw SDK message so the renderer
-    // can rehydrate context-window state when reopening old sessions.
-    let usage: TimelineMessage['usage']
-    let modelRef: TimelineMessage['modelRef']
-    if (message.role === 'assistant' && parsedMessage) {
-      const info = isPlainRecord(parsedMessage.info) ? parsedMessage.info : undefined
-      const innerMessage = isPlainRecord(parsedMessage.message) ? parsedMessage.message : undefined
-      const rawUsage =
-        (isPlainRecord(parsedMessage.usage) ? parsedMessage.usage : undefined) ??
-        (info && isPlainRecord(info.usage) ? info.usage : undefined) ??
-        (innerMessage && isPlainRecord(innerMessage.usage) ? innerMessage.usage : undefined)
+      // Extract usage + model identity from the raw SDK message so the renderer
+      // can rehydrate context-window state when reopening old sessions.
+      let usage: TimelineMessage['usage']
+      let modelRef: TimelineMessage['modelRef']
+      if (message.role === 'assistant' && parsedMessage) {
+        const info = isPlainRecord(parsedMessage.info) ? parsedMessage.info : undefined
+        const innerMessage = isPlainRecord(parsedMessage.message)
+          ? parsedMessage.message
+          : undefined
+        const rawUsage =
+          (isPlainRecord(parsedMessage.usage) ? parsedMessage.usage : undefined) ??
+          (info && isPlainRecord(info.usage) ? info.usage : undefined) ??
+          (innerMessage && isPlainRecord(innerMessage.usage) ? innerMessage.usage : undefined)
 
-      if (rawUsage) {
-        const input = pickNumber(rawUsage, 'input_tokens', 'inputTokens', 'input')
-        const output = pickNumber(rawUsage, 'output_tokens', 'outputTokens', 'output')
-        const cacheRead = pickNumber(
-          rawUsage,
-          'cache_read_input_tokens',
-          'cacheReadInputTokens',
-          'cache_read',
-          'cacheRead'
+        if (rawUsage) {
+          const input = pickNumber(rawUsage, 'input_tokens', 'inputTokens', 'input')
+          const output = pickNumber(rawUsage, 'output_tokens', 'outputTokens', 'output')
+          const cacheRead = pickNumber(
+            rawUsage,
+            'cache_read_input_tokens',
+            'cacheReadInputTokens',
+            'cache_read',
+            'cacheRead'
+          )
+          const cacheWrite = pickNumber(
+            rawUsage,
+            'cache_creation_input_tokens',
+            'cacheCreationInputTokens',
+            'cache_creation',
+            'cacheCreation',
+            'cache_write',
+            'cacheWrite'
+          )
+          const reasoning = pickNumber(rawUsage, 'reasoning_tokens', 'reasoningTokens', 'reasoning')
+          if (input || output || cacheRead || cacheWrite || reasoning) {
+            usage = { input, output, cacheRead, cacheWrite, reasoning }
+          }
+        }
+
+        const providerID = firstString(
+          parsedMessage.providerID,
+          info?.providerID,
+          info?.provider_id,
+          innerMessage?.provider
         )
-        const cacheWrite = pickNumber(
-          rawUsage,
-          'cache_creation_input_tokens',
-          'cacheCreationInputTokens',
-          'cache_creation',
-          'cacheCreation',
-          'cache_write',
-          'cacheWrite'
+        const modelID = firstString(
+          parsedMessage.modelID,
+          parsedMessage.model,
+          info?.modelID,
+          info?.model_id,
+          info?.model,
+          innerMessage?.model
         )
-        const reasoning = pickNumber(rawUsage, 'reasoning_tokens', 'reasoningTokens', 'reasoning')
-        if (input || output || cacheRead || cacheWrite || reasoning) {
-          usage = { input, output, cacheRead, cacheWrite, reasoning }
+        if (providerID && modelID) {
+          modelRef = { providerID, modelID }
+        } else if (modelID) {
+          modelRef = { providerID: 'anthropic', modelID }
         }
       }
 
-      const providerID = firstString(
-        parsedMessage.providerID,
-        info?.providerID,
-        info?.provider_id,
-        innerMessage?.provider
-      )
-      const modelID = firstString(
-        parsedMessage.modelID,
-        parsedMessage.model,
-        info?.modelID,
-        info?.model_id,
-        info?.model,
-        innerMessage?.model
-      )
-      if (providerID && modelID) {
-        modelRef = { providerID, modelID }
-      } else if (modelID) {
-        modelRef = { providerID: 'anthropic', modelID }
+      return {
+        id: message.opencode_message_id ?? message.id,
+        role: message.role,
+        content:
+          message.role === 'user' ? stripInjectedContextEnvelope(message.content) : message.content,
+        timestamp: message.created_at,
+        ...(parsedMessage?.steered === true ? { steered: true } : {}),
+        parts: parts && parts.length > 0 ? parts : undefined,
+        ...(usage ? { usage } : {}),
+        ...(modelRef ? { modelRef } : {})
       }
-    }
-
-    return {
-      id: message.opencode_message_id ?? message.id,
-      role: message.role,
-      content:
-        message.role === 'user'
-          ? stripInjectedContextEnvelope(message.content)
-          : message.content,
-      timestamp: message.created_at,
-      ...(parsedMessage?.steered === true ? { steered: true } : {}),
-      parts: parts && parts.length > 0 ? parts : undefined,
-      ...(usage ? { usage } : {}),
-      ...(modelRef ? { modelRef } : {})
-    }
-  })
+    })
 }
 
 function isPlainRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value)
 }
 
-function pickNumber(
-  source: Record<string, unknown>,
-  ...keys: string[]
-): number {
+function pickNumber(source: Record<string, unknown>, ...keys: string[]): number {
   for (const key of keys) {
     const raw = source[key]
     if (typeof raw === 'number' && Number.isFinite(raw)) return raw
@@ -526,6 +518,40 @@ function extractAssistantTurnId(messageId: string): string | null {
 function extractUserTurnId(messageId: string): string | null {
   const match = messageId.match(/^(.*):user(?::.*)?$/)
   return match?.[1] ?? null
+}
+
+function extractTurnIdFromTimelineMessage(message: TimelineMessage): string | null {
+  if (message.role === 'assistant') return extractAssistantTurnId(message.id)
+  if (message.role === 'user') return extractUserTurnId(message.id)
+  return null
+}
+
+function inferToolActivityTurnId(
+  activity: DbSessionActivity,
+  messages: TimelineMessage[]
+): string | null {
+  if (!activity.kind.startsWith('tool.')) return null
+
+  const activityTime = Date.parse(activity.created_at)
+  if (!Number.isFinite(activityTime)) return null
+
+  let currentTurnId: string | null = null
+  for (const message of messages) {
+    const messageTime = Date.parse(message.timestamp)
+    if (!Number.isFinite(messageTime)) continue
+
+    if (message.role === 'user') {
+      if (messageTime > activityTime) break
+      currentTurnId = extractUserTurnId(message.id) ?? currentTurnId
+      continue
+    }
+
+    if (!currentTurnId && messageTime <= activityTime) {
+      currentTurnId = extractTurnIdFromTimelineMessage(message)
+    }
+  }
+
+  return currentTurnId
 }
 
 function extractRoleOrdinal(messageId: string, role: 'user' | 'assistant'): number {
@@ -632,9 +658,7 @@ function normalizeCodexMessageRows(
 export function parseToolPartFromActivity(activity: DbSessionActivity): StreamingPart | null {
   const payload = parseJson<Record<string, unknown>>(activity.payload_json)
   const item =
-    payload && typeof payload.item === 'object'
-      ? (payload.item as Record<string, unknown>)
-      : null
+    payload && typeof payload.item === 'object' ? (payload.item as Record<string, unknown>) : null
 
   // Codex shape detection: codex items have type ∈ {commandExecution,
   // fileChange, mcpToolCall, webSearch, agentMessage, reasoning,
@@ -669,9 +693,7 @@ export function parseToolPartFromActivity(activity: DbSessionActivity): Streamin
               ? Date.parse(activity.created_at) || Date.now()
               : undefined,
           output:
-            activity.kind === 'tool.completed' && classified.output
-              ? classified.output
-              : undefined,
+            activity.kind === 'tool.completed' && classified.output ? classified.output : undefined,
           error:
             activity.kind === 'tool.failed'
               ? (stringifyValue(classified.output) ?? activity.summary)
@@ -751,9 +773,7 @@ function parsePlanPartFromActivity(
         input: { plan },
         status: isResolved ? 'success' : 'pending',
         startTime: Date.parse(activity.created_at) || Date.now(),
-        ...(isResolved
-          ? { endTime: Date.parse(activity.created_at) || Date.now() }
-          : {})
+        ...(isResolved ? { endTime: Date.parse(activity.created_at) || Date.now() } : {})
       }
     }
   }
@@ -932,7 +952,7 @@ function mergeCodexActivityMessages(
     const toolId = activityPart.toolUse.id
     if (knownToolIds.has(toolId)) continue
 
-    const turnId = activity.turn_id
+    const turnId = activity.turn_id ?? inferToolActivityTurnId(activity, normalizedBaseMessages)
     const syntheticId = turnId ? `${turnId}:tool:${toolId}` : `tool:${toolId}`
     const targetCollection = turnId
       ? (anchoredSyntheticByTurnId.get(turnId) ?? [])
@@ -1044,10 +1064,7 @@ export function deriveCodexTimeline(
   activityRows: DbSessionActivity[]
 ): TimelineMessage[] {
   const normalizedMessages = normalizeCodexMessageRows(messageRows, activityRows)
-  return mergeCodexActivityMessages(
-    mapDbRowsToTimelineMessages(normalizedMessages),
-    activityRows
-  )
+  return mergeCodexActivityMessages(mapDbRowsToTimelineMessages(normalizedMessages), activityRows)
 }
 
 /**
@@ -1124,9 +1141,7 @@ export function mergeOpenCodePlanActivities(
     // approval card. Strip text parts whose content is fully contained in the
     // plan we're about to render so the card becomes the single source.
     const planText =
-      typeof part.toolUse.input?.plan === 'string'
-        ? (part.toolUse.input.plan as string).trim()
-        : ''
+      typeof part.toolUse.input?.plan === 'string' ? (part.toolUse.input.plan as string).trim() : ''
 
     const itemId = row.item_id ?? null
     if (itemId && messageIndex.has(itemId)) {
@@ -1150,8 +1165,7 @@ export function mergeOpenCodePlanActivities(
         ...target,
         // Also clear `content` if it's the same plan text — `messageToNodes`
         // falls back to `content` when `parts` is empty (line 153).
-        content:
-          planText && (target.content ?? '').trim() === planText ? '' : target.content,
+        content: planText && (target.content ?? '').trim() === planText ? '' : target.content,
         parts: [...filteredParts, part]
       }
     } else {

--- a/src/shared/lib/timeline-mappers.ts
+++ b/src/shared/lib/timeline-mappers.ts
@@ -377,6 +377,7 @@ export interface DbSessionMessage {
   opencode_message_json: string | null
   opencode_parts_json: string | null
   opencode_timeline_json: string | null
+  sequence: number | null
   created_at: string
 }
 
@@ -570,6 +571,9 @@ function getOrderedActivityTurnIds(activityRows: DbSessionActivity[]): string[] 
           const leftTime = Date.parse(left.created_at)
           const rightTime = Date.parse(right.created_at)
           if (leftTime !== rightTime) return leftTime - rightTime
+          // TODO(seq-activities): once session_activities.sequence is backfilled
+          // by a follow-up migration, prefer it over UUID lex order here
+          // (mirrors normalizeCodexMessageRows for session_messages.sequence).
           return left.id.localeCompare(right.id)
         })
         .map((activity) => activity.turn_id)
@@ -586,7 +590,15 @@ function normalizeCodexMessageRows(
     const leftTime = Date.parse(left.created_at)
     const rightTime = Date.parse(right.created_at)
     if (leftTime !== rightTime) return leftTime - rightTime
-    return left.id.localeCompare(right.id)
+    // session_messages now carries a per-session monotonic sequence (v24).
+    // Prefer it over UUID lexical order for same-millisecond rows so the
+    // first INSERT is rendered first.
+    const ls = left.sequence
+    const rs = right.sequence
+    if (ls != null && rs != null && ls !== rs) return ls - rs
+    if (ls != null && rs == null) return -1
+    if (ls == null && rs != null) return 1
+    return left.id.localeCompare(right.id) // last-resort for pre-v24 rows
   })
 
   const orderedTurnIds = getOrderedActivityTurnIds(activityRows)
@@ -929,6 +941,9 @@ function mergeCodexActivityMessages(
     const leftTime = Date.parse(left.created_at)
     const rightTime = Date.parse(right.created_at)
     if (leftTime !== rightTime) return leftTime - rightTime
+    // TODO(seq-activities): session_activities.sequence exists but is 0% filled
+    // today. Once a follow-up migration backfills it, prefer it over UUID lex
+    // order here (same shape as normalizeCodexMessageRows).
     return left.id.localeCompare(right.id)
   })
 

--- a/src/shared/lib/timeline-types.ts
+++ b/src/shared/lib/timeline-types.ts
@@ -19,7 +19,7 @@ export interface ToolUseInfo {
   id: string
   name: string
   input: Record<string, unknown>
-  status: 'pending' | 'running' | 'success' | 'error'
+  status: 'pending' | 'running' | 'success' | 'error' | 'rejected'
   startTime: number
   endTime?: number
   output?: string

--- a/src/shared/types/agent-protocol.ts
+++ b/src/shared/types/agent-protocol.ts
@@ -29,6 +29,12 @@ export interface AgentSessionContextUsageData {
     output: number
     reasoning?: number
   }
+  /** Incremental session cost in USD for this usage event. */
+  cost?: number
+  /** Authoritative cumulative session cost in USD when the provider reports total usage. */
+  totalCost?: number
+  /** Stable id used by the renderer to avoid applying the same cost twice. */
+  requestId?: string
   model?: {
     providerID: string
     modelID: string

--- a/test/context-panel/context-panel-host-tabs.test.tsx
+++ b/test/context-panel/context-panel-host-tabs.test.tsx
@@ -594,4 +594,69 @@ describe('ContextPanelHost', () => {
       expect(screen.getByText('2 sessions in this Worktree')).toBeInTheDocument()
     })
   })
+
+  it('does not use live context tokens as worktree session totals once a summary exists', async () => {
+    const sessions = [
+      {
+        id: 'sess-claude-syncing',
+        worktree_id: 'wt-1',
+        project_id: 'proj-1',
+        connection_id: null,
+        name: 'Claude syncing',
+        status: 'active' as const,
+        opencode_session_id: 'claude-runtime-1',
+        agent_sdk: 'claude-code' as const,
+        mode: 'build' as const,
+        model_provider_id: null,
+        model_id: null,
+        model_variant: null,
+        first_message_at: null,
+        created_at: '2026-05-21T00:00:00.000Z',
+        updated_at: '2026-05-21T00:00:00.000Z',
+        completed_at: null
+      }
+    ]
+    useSessionStore.setState({
+      activeSessionId: 'sess-claude-syncing',
+      activeWorktreeId: 'wt-1',
+      sessionsByWorktree: new Map([['wt-1', sessions]]),
+      tabOrderByWorktree: new Map([['wt-1', ['sess-claude-syncing']]])
+    })
+    useContextStore.getState().setSessionTokens('sess-claude-syncing', {
+      input: 3,
+      output: 66,
+      reasoning: 0,
+      cacheRead: 0,
+      cacheWrite: 37_719
+    })
+    window.db.session.getByWorktree = vi.fn().mockResolvedValue(sessions)
+    window.usageAnalyticsOps.fetchSessionSummary = vi.fn().mockResolvedValue({
+      success: true,
+      data: {
+        session_id: 'sess-claude-syncing',
+        engine: 'claude-code',
+        total_cost: 0,
+        total_tokens: 0,
+        input_tokens: 0,
+        output_tokens: 0,
+        cache_write_tokens: 0,
+        cache_read_tokens: 0,
+        duration_seconds: 0,
+        last_used_at: null,
+        model_labels: [],
+        latest_model_label: null,
+        partial: true
+      }
+    })
+
+    renderHost()
+
+    await waitFor(() => {
+      expect(window.usageAnalyticsOps.fetchSessionSummary).toHaveBeenCalledWith(
+        'sess-claude-syncing'
+      )
+      expect(screen.queryByText('37.8K')).not.toBeInTheDocument()
+      expect(screen.queryByText('37.7K')).not.toBeInTheDocument()
+    })
+  })
 })

--- a/test/context-panel/context-panel-host-tabs.test.tsx
+++ b/test/context-panel/context-panel-host-tabs.test.tsx
@@ -252,15 +252,119 @@ describe('ContextPanelHost', () => {
     expect(screen.getByTestId('context-panel-terminal')).toBeInTheDocument()
   })
 
-  it('selects the terminal bottom tab when the right terminal rail item is clicked', async () => {
+  it('renders grouped latest-round tasks in the tasks panel from durable timeline data', async () => {
     const user = userEvent.setup()
-    useLayoutStore.setState({ bottomPanelTab: 'run' })
-    renderHost({ terminalPanel: <div data-testid="context-panel-terminal">Terminal panel</div> })
+    useSessionStore.setState({ activeSessionId: 'sess-tasks' })
+    Object.defineProperty(window, 'agentOps', {
+      configurable: true,
+      writable: true,
+      value: {
+        getTimeline: vi.fn().mockResolvedValue({
+          messages: [
+            {
+              id: 'user-1',
+              role: 'user',
+              content: '旧任务轮次',
+              timestamp: '2026-05-21T00:00:00.000Z'
+            },
+            {
+              id: 'assistant-1',
+              role: 'assistant',
+              content: '',
+              timestamp: '2026-05-21T00:00:01.000Z',
+              parts: [
+                {
+                  type: 'tool_use',
+                  toolUse: {
+                    id: 'todo-old',
+                    name: 'TodoWrite',
+                    status: 'success',
+                    startTime: 1,
+                    input: {
+                      todos: [
+                        { id: 'task-old-1', content: 'Completed old task', status: 'completed' },
+                        { id: 'task-old-2', content: 'Pending old task', status: 'pending' }
+                      ]
+                    }
+                  }
+                }
+              ]
+            },
+            {
+              id: 'user-2',
+              role: 'user',
+              content: '最新任务轮次',
+              timestamp: '2026-05-21T00:00:02.000Z'
+            },
+            {
+              id: 'assistant-2',
+              role: 'assistant',
+              content: '',
+              timestamp: '2026-05-21T00:00:03.000Z',
+              parts: [
+                {
+                  type: 'tool_use',
+                  toolUse: {
+                    id: 'todo-new',
+                    name: 'TodoWrite',
+                    status: 'success',
+                    startTime: 2,
+                    input: {
+                      todos: [
+                        { id: 'task-1', content: 'Inspect session tasks', status: 'in_progress' },
+                        { id: 'task-2', content: 'Update task panel', status: 'pending' },
+                        { id: 'task-3', content: 'Verify UI changes', status: 'completed' }
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        })
+      }
+    })
 
-    await user.click(screen.getByTestId('context-panel-tab-terminal'))
+    renderHost()
 
-    expect(useLayoutStore.getState().rightContextTab).toBe('terminal')
-    expect(useLayoutStore.getState().bottomPanelTab).toBe('terminal')
+    await user.click(screen.getByTestId('context-panel-tab-tasks'))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('context-panel-tasks')).toBeInTheDocument()
+    })
+
+    expect(screen.getByText('进行中')).toBeInTheDocument()
+    expect(screen.getByText('待处理')).toBeInTheDocument()
+    expect(screen.getByText('已完成')).toBeInTheDocument()
+    expect(screen.getByText('查看任务')).toBeInTheDocument()
+    expect(screen.getByText('更新任务面板')).toBeInTheDocument()
+    expect(screen.getByText('Verify UI changes')).toBeInTheDocument()
+    expect(screen.queryByText('Completed old task')).not.toBeInTheDocument()
+    expect(screen.queryByText('Pending old task')).not.toBeInTheDocument()
+  })
+
+  it('prefers runtime tasks over durable fallback in the tasks panel', async () => {
+    const user = userEvent.setup()
+    useSessionStore.setState({ activeSessionId: 'sess-live-tasks' })
+    useSessionRuntimeStore.getState().setSessionTasks('sess-live-tasks', [
+      { id: 'task-live', content: 'Inspect live runtime task', status: 'in_progress' }
+    ])
+    Object.defineProperty(window, 'agentOps', {
+      configurable: true,
+      writable: true,
+      value: {
+        getTimeline: vi.fn().mockResolvedValue({ messages: todoTimeline() })
+      }
+    })
+
+    renderHost()
+
+    await user.click(screen.getByTestId('context-panel-tab-tasks'))
+
+    await waitFor(() => {
+      expect(screen.getByText('查看任务')).toBeInTheDocument()
+    })
+    expect(screen.queryByText('Move tasks into the context panel')).not.toBeInTheDocument()
   })
 
   it('keeps the terminal panel mounted while switching away and back', async () => {
@@ -389,37 +493,6 @@ describe('ContextPanelHost', () => {
     expect(screen.getByTestId('pr-target-branch-trigger')).toHaveTextContent('origin/main')
   })
 
-  it('renders latest session tasks from the shared timeline extraction helper', async () => {
-    const user = userEvent.setup()
-    useSessionStore.setState({ activeSessionId: 'sess-1' })
-    window.agentOps.getTimeline = vi.fn().mockResolvedValue({ messages: todoTimeline() })
-
-    renderHost()
-    await user.click(screen.getByTestId('context-panel-tab-tasks'))
-
-    await waitFor(() => {
-      expect(screen.getByText('Move tasks into the context panel')).toBeInTheDocument()
-    })
-  })
-
-  it('prefers live task snapshots over the persisted timeline in the tasks panel', async () => {
-    const user = userEvent.setup()
-    useSessionStore.setState({ activeSessionId: 'sess-live' })
-    useSessionRuntimeStore.getState().setSessionTasks('sess-live', [
-      {
-        id: 'live-task',
-        content: 'Live task from streaming update',
-        status: 'in_progress'
-      }
-    ])
-    window.agentOps.getTimeline = vi.fn().mockResolvedValue({ messages: todoTimeline() })
-
-    renderHost()
-    await user.click(screen.getByTestId('context-panel-tab-tasks'))
-
-    expect(screen.getByText('Live task from streaming update')).toBeInTheDocument()
-    expect(screen.queryByText('Move tasks into the context panel')).not.toBeInTheDocument()
-  })
 
   it('renders and dismisses completed goals from the right goal panel', async () => {
     const user = userEvent.setup()

--- a/test/context-panel/session-task-extraction.test.ts
+++ b/test/context-panel/session-task-extraction.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from 'vitest'
-import { extractMissionTasks } from '@/lib/session-tasks'
+import {
+  extractMissionTasks,
+  getSessionTaskDisplayTitle,
+  sortSessionTasks,
+  type SessionTask
+} from '@/lib/session-tasks'
 import type { TimelineMessage, ToolUseInfo } from '@shared/lib/timeline-types'
 
 function toolUse(name: string, input: Record<string, unknown>): ToolUseInfo {
@@ -32,27 +37,107 @@ function message(
   }
 }
 
+function userMessage(id: string, content: string): TimelineMessage {
+  return {
+    id,
+    role: 'user',
+    content,
+    timestamp: '2026-05-21T00:00:00.000Z'
+  }
+}
+
 describe('extractMissionTasks', () => {
-  test('extracts tasks from the latest assistant TodoWrite snapshot', () => {
+  test('replays mixed task tool events into the latest canonical state', () => {
     const messages: TimelineMessage[] = [
-      message('old', 'assistant', 'TodoWrite', {
-        todos: [{ id: 'old-1', content: 'Old task', status: 'completed' }]
-      }),
-      message('latest', 'assistant', 'mcp_todowrite', {
+      message('snapshot', 'assistant', 'TodoWrite', {
         todos: [
-          { id: 'task-1', content: 'Read current implementation', status: 'completed' },
-          { id: 'task-2', content: 'Extract helper', status: 'in_progress' }
+          { id: 'task-1', content: 'Read current implementation', status: 'pending' },
+          { id: 'task-2', content: 'Extract helper', status: 'pending' }
         ]
+      }),
+      message('create', 'assistant', 'TaskCreate', {
+        taskId: 'task-3',
+        subject: 'Add grouped task panel',
+        description: 'Render grouped sections in the right panel'
+      }),
+      message('update-existing', 'assistant', 'TaskUpdate', {
+        taskId: 'task-2',
+        status: 'in-progress',
+        description: 'Helper extraction is underway'
+      }),
+      message('update-created', 'assistant', 'task_update', {
+        taskId: 'task-3',
+        status: 'done'
       })
     ]
 
     expect(extractMissionTasks(messages)).toEqual([
-      { id: 'task-1', content: 'Read current implementation', status: 'completed' },
-      { id: 'task-2', content: 'Extract helper', status: 'in_progress' }
+      { id: 'task-1', content: 'Read current implementation', status: 'pending' },
+      {
+        id: 'task-2',
+        content: 'Helper extraction is underway',
+        status: 'in_progress',
+        description: 'Helper extraction is underway'
+      },
+      {
+        id: 'task-3',
+        content: 'Add grouped task panel',
+        status: 'completed',
+        subject: 'Add grouped task panel',
+        description: 'Render grouped sections in the right panel'
+      }
     ])
   })
 
-  test('supports update_plan and existing fallback fields', () => {
+  test('supports TaskCreate and TaskUpdate without a TodoWrite snapshot', () => {
+    const messages: TimelineMessage[] = [
+      message('create', 'assistant', 'task_create', {
+        taskId: 'task-1',
+        subject: 'Create reducer helpers',
+        status: 'pending'
+      }),
+      message('update', 'assistant', 'TaskUpdate', {
+        taskId: 'task-1',
+        status: 'done',
+        activeForm: 'Reducer helpers implemented'
+      })
+    ]
+
+    expect(extractMissionTasks(messages)).toEqual([
+      {
+        id: 'task-1',
+        content: 'Reducer helpers implemented',
+        status: 'completed',
+        subject: 'Create reducer helpers',
+        activeForm: 'Reducer helpers implemented'
+      }
+    ])
+  })
+
+  test('upserts duplicate TaskCreate entries by id instead of duplicating tasks', () => {
+    const messages: TimelineMessage[] = [
+      message('create-1', 'assistant', 'TaskCreate', {
+        taskId: 'task-1',
+        subject: 'Investigate task duplication'
+      }),
+      message('create-2', 'assistant', 'task_create', {
+        taskId: 'task-1',
+        description: 'Keep the same task id while adding details'
+      })
+    ]
+
+    expect(extractMissionTasks(messages)).toEqual([
+      {
+        id: 'task-1',
+        content: 'Investigate task duplication',
+        status: 'pending',
+        subject: 'Investigate task duplication',
+        description: 'Keep the same task id while adding details'
+      }
+    ])
+  })
+
+  test('continues to support update_plan fallback fields', () => {
     const messages: TimelineMessage[] = [
       message('plan', 'assistant', 'update_plan', {
         todos: [
@@ -63,12 +148,17 @@ describe('extractMissionTasks', () => {
     ]
 
     expect(extractMissionTasks(messages)).toEqual([
-      { id: 'todo-0', content: 'Subject fallback', status: 'pending' },
-      { id: 'todo-1', content: 'Active form fallback', status: 'pending' }
+      { id: 'todo-0', content: 'Subject fallback', status: 'pending', subject: 'Subject fallback' },
+      {
+        id: 'todo-1',
+        content: 'Active form fallback',
+        status: 'pending',
+        activeForm: 'Active form fallback'
+      }
     ])
   })
 
-  test('ignores non-assistant and non-TodoWrite tool parts', () => {
+  test('ignores non-assistant and non-task tool parts', () => {
     const messages: TimelineMessage[] = [
       message('user-tool', 'user', 'TodoWrite', {
         todos: [{ id: 'user-task', content: 'Ignore user role', status: 'pending' }]
@@ -81,18 +171,133 @@ describe('extractMissionTasks', () => {
     expect(extractMissionTasks(messages)).toEqual([])
   })
 
-  test('continues scanning when the latest TodoWrite has no todos array', () => {
+  test('returns only the latest round tasks when multiple rounds exist', () => {
     const messages: TimelineMessage[] = [
-      message('valid', 'assistant', 'todo_write', {
-        todos: [{ id: 'valid-task', content: 'Use older valid snapshot', status: 'completed' }]
+      userMessage('user-1', 'First prompt'),
+      message('round-1', 'assistant', 'TodoWrite', {
+        todos: [
+          { id: 'task-old-1', content: 'Old task 1', status: 'completed' },
+          { id: 'task-old-2', content: 'Old task 2', status: 'pending' }
+        ]
       }),
-      message('invalid', 'assistant', 'TodoWrite', {
-        todos: null
+      userMessage('user-2', 'Second prompt'),
+      message('round-2', 'assistant', 'TodoWrite', {
+        todos: [
+          { id: 'task-new-1', content: 'Inspect session tasks', status: 'in_progress' },
+          { id: 'task-new-2', content: 'Update UI', status: 'pending' }
+        ]
       })
     ]
 
-    expect(extractMissionTasks(messages)).toEqual([
-      { id: 'valid-task', content: 'Use older valid snapshot', status: 'completed' }
+    const result = extractMissionTasks(messages)
+    expect(result.map((t) => t.id)).toEqual(['task-new-1', 'task-new-2'])
+    expect(result.map((t) => t.content)).not.toContain('Old task')
+  })
+
+  test('falls back to earlier round if latest round has no tasks', () => {
+    const messages: TimelineMessage[] = [
+      userMessage('user-1', 'First prompt'),
+      message('round-1', 'assistant', 'TodoWrite', {
+        todos: [{ id: 'task-1', content: 'Read the README', status: 'pending' }]
+      }),
+      userMessage('user-2', 'Second prompt'),
+      message('round-2', 'assistant', 'Write', {
+        file: 'src/main/index.ts'
+      })
+    ]
+
+    const result = extractMissionTasks(messages)
+    expect(result.map((t) => t.id)).toEqual(['task-1'])
+  })
+
+  test('falls back to full session scan if no round has tasks', () => {
+    const messages: TimelineMessage[] = [
+      userMessage('user-1', 'First prompt'),
+      message('round-1', 'assistant', 'Bash', { command: 'ls' }),
+      userMessage('user-2', 'Second prompt'),
+      message('round-2', 'assistant', 'Read', { file: 'package.json' }),
+      message('fallback', 'assistant', 'TodoWrite', {
+        todos: [{ id: 'fallback-task', content: 'Fallback task', status: 'pending' }]
+      })
+    ]
+
+    const result = extractMissionTasks(messages)
+    expect(result.map((t) => t.id)).toEqual(['fallback-task'])
+  })
+})
+
+describe('sortSessionTasks', () => {
+  test('orders in progress before pending before completed while keeping stable ties', () => {
+    const tasks: SessionTask[] = [
+      { id: 'task-1', content: 'Completed task', status: 'completed' },
+      { id: 'task-2', content: 'Pending task', status: 'pending' },
+      { id: 'task-3', content: 'Working task', status: 'in_progress' },
+      { id: 'task-4', content: 'High priority pending', status: 'pending', priority: 'high' }
+    ]
+
+    expect(sortSessionTasks(tasks).map((task) => task.id)).toEqual([
+      'task-3',
+      'task-4',
+      'task-2',
+      'task-1'
     ])
+  })
+})
+
+describe('getSessionTaskDisplayTitle', () => {
+  test('returns Chinese display title for English task content', () => {
+    const task: SessionTask = {
+      id: 'task-1',
+      content: 'Inspect session task implementation',
+      status: 'pending'
+    }
+    expect(getSessionTaskDisplayTitle(task)).toBe('查看会话任务实现')
+  })
+
+  test('returns Chinese display title for task with subject', () => {
+    const task: SessionTask = {
+      id: 'task-2',
+      content: 'Implement task panel',
+      subject: 'Implement task panel',
+      status: 'pending'
+    }
+    expect(getSessionTaskDisplayTitle(task)).toBe('实现任务面板')
+  })
+
+  test('returns Chinese for task with Chinese content directly', () => {
+    const task: SessionTask = {
+      id: 'task-3',
+      content: '查看右侧任务列表',
+      status: 'pending'
+    }
+    expect(getSessionTaskDisplayTitle(task)).toBe('查看右侧任务列表')
+  })
+
+  test('returns fallback label for task with empty content', () => {
+    const task: SessionTask = {
+      id: 'task-4',
+      content: '',
+      status: 'pending'
+    }
+    expect(getSessionTaskDisplayTitle(task)).toBe('任务')
+    expect(getSessionTaskDisplayTitle(task, 2)).toBe('任务 3')
+  })
+
+  test('keeps short Chinese content without truncation', () => {
+    const task: SessionTask = {
+      id: 'task-5',
+      content: '查看会话任务实现并更新相关UI组件以及测试用例',
+      status: 'pending'
+    }
+    const result = getSessionTaskDisplayTitle(task)
+    expect(result).toBe('查看会话任务实现并更新相关UI组件以及测试用例')
+    expect(result.endsWith('…')).toBe(false)
+  })
+
+  test('derives Chinese verbs from common English patterns', () => {
+    expect(getSessionTaskDisplayTitle({ id: '1', content: 'Fix authentication bug', status: 'pending' })).toBe('修复认证问题')
+    expect(getSessionTaskDisplayTitle({ id: '2', content: 'Test the new API', status: 'pending' })).toBe('验证新 API')
+    expect(getSessionTaskDisplayTitle({ id: '3', content: 'Add task panel', status: 'pending' })).toBe('实现任务面板')
+    expect(getSessionTaskDisplayTitle({ id: '4', content: 'Analyze codebase structure', status: 'pending' })).toBe('分析代码库结构')
   })
 })

--- a/test/phase-12/session-1/context-calculation.test.ts
+++ b/test/phase-12/session-1/context-calculation.test.ts
@@ -314,6 +314,48 @@ describe('Session 1: Context Calculation Fix', () => {
       expect(usage.rawMaxTokens).toBe(1000000)
       expect(usage.isRefreshing).toBe(false)
     })
+
+    test('applies direct context usage cost once per request id', () => {
+      applySessionContextUsage('s1', {
+        tokens: { input: 100, output: 10 },
+        model: { providerID: 'codex', modelID: 'gpt-5.5' },
+        contextWindow: 500000,
+        cost: 0.012,
+        requestId: 'codex-cost-1'
+      })
+      applySessionContextUsage('s1', {
+        tokens: { input: 100, output: 10 },
+        model: { providerID: 'codex', modelID: 'gpt-5.5' },
+        contextWindow: 500000,
+        cost: 0.012,
+        requestId: 'codex-cost-1'
+      })
+
+      expect(useContextStore.getState().costBySession.s1).toBeCloseTo(0.012)
+    })
+
+    test('applies cumulative context usage total cost as a monotonic session total', () => {
+      applySessionContextUsage('s1', {
+        tokens: { input: 100, output: 10 },
+        model: { providerID: 'codex', modelID: 'gpt-5.5' },
+        contextWindow: 500000,
+        totalCost: 0.02
+      })
+      applySessionContextUsage('s1', {
+        tokens: { input: 100, output: 10 },
+        model: { providerID: 'codex', modelID: 'gpt-5.5' },
+        contextWindow: 500000,
+        totalCost: 0.01
+      })
+      applySessionContextUsage('s1', {
+        tokens: { input: 100, output: 10 },
+        model: { providerID: 'codex', modelID: 'gpt-5.5' },
+        contextWindow: 500000,
+        totalCost: 0.03
+      })
+
+      expect(useContextStore.getState().costBySession.s1).toBeCloseTo(0.03)
+    })
   })
 
   describe('extractTokens', () => {

--- a/test/phase-19/session-3/session-task-tracker.test.tsx
+++ b/test/phase-19/session-3/session-task-tracker.test.tsx
@@ -40,6 +40,47 @@ describe('SessionTaskTracker', () => {
     expect(screen.queryByText('分析现有图标样式实现')).not.toBeInTheDocument()
   })
 
+  test('orders visible tasks by shared status and priority semantics when expanded', () => {
+    render(
+      <SessionTaskTracker
+        toolStatus="running"
+        todos={[
+          {
+            id: 'task-1',
+            content: 'Completed task',
+            status: 'completed',
+            priority: 'medium'
+          },
+          {
+            id: 'task-2',
+            content: 'Pending low task',
+            status: 'pending',
+            priority: 'low'
+          },
+          {
+            id: 'task-3',
+            content: 'Working task',
+            status: 'in_progress',
+            priority: 'medium'
+          },
+          {
+            id: 'task-4',
+            content: 'Pending high task',
+            status: 'pending',
+            priority: 'high'
+          }
+        ]}
+      />
+    )
+
+    act(() => {
+      fireEvent.click(screen.getByLabelText(/expand tasks/i))
+    })
+
+    const labels = screen.getAllByTitle(/task$/).map((node) => node.textContent)
+    expect(labels).toEqual(['Working task', 'Pending high task', 'Pending low task', 'Completed task'])
+  })
+
   test('shows newly completed todo with completion styling while expanded', () => {
     const { rerender } = render(
       <SessionTaskTracker

--- a/test/phase-22/session-2/agent-setup-guard-codex.test.tsx
+++ b/test/phase-22/session-2/agent-setup-guard-codex.test.tsx
@@ -4,6 +4,7 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 let mockSettingsState: {
   initialSetupComplete: boolean
   isLoading: boolean
+  defaultAgentSdk: 'codex'
   updateSetting: ReturnType<typeof vi.fn>
 }
 
@@ -12,7 +13,7 @@ let wizardProps: {
   loading: boolean
   error: string | null
   onRefresh: () => void
-  onComplete: (sdk: 'claude-code' | 'codex' | 'opencode' | 'terminal') => void
+  onComplete: () => void
 } | null = null
 
 vi.mock('@/stores/useSettingsStore', () => ({
@@ -32,7 +33,7 @@ vi.mock('@/components/setup/AgentSetupWizard', () => ({
     loading: boolean
     error: string | null
     onRefresh: () => void
-    onComplete: (sdk: 'claude-code' | 'codex' | 'opencode' | 'terminal') => void
+    onComplete: () => void
   }) => {
     wizardProps = props
 
@@ -44,11 +45,23 @@ vi.mock('@/components/setup/AgentSetupWizard', () => ({
         <button data-testid="wizard-refresh" onClick={() => props.onRefresh()}>
           refresh
         </button>
-        <button data-testid="wizard-complete-codex" onClick={() => props.onComplete('codex')}>
+        <button data-testid="wizard-complete-codex" onClick={() => props.onComplete()}>
           complete codex
         </button>
       </div>
     )
+  }
+}))
+
+vi.mock('@/stores/useShortcutStore', () => ({
+  useShortcutStore: {
+    getState: () => ({ activePreset: 'vscode' })
+  }
+}))
+
+vi.mock('@/stores/useThemeStore', () => ({
+  useThemeStore: {
+    getState: () => ({ themeId: 'system', followSystem: true })
   }
 }))
 
@@ -101,6 +114,7 @@ describe('AgentSetupGuard', () => {
     mockSettingsState = {
       initialSetupComplete: false,
       isLoading: false,
+      defaultAgentSdk: 'codex',
       updateSetting: vi.fn()
     }
 
@@ -149,14 +163,22 @@ describe('AgentSetupGuard', () => {
 
     fireEvent.click(screen.getByTestId('wizard-complete-codex'))
 
-    expect(mockSettingsState.updateSetting).toHaveBeenCalledWith('defaultAgentSdk', 'codex')
     expect(mockSettingsState.updateSetting).toHaveBeenCalledWith('initialSetupComplete', true)
-    expect(mockTrack).toHaveBeenCalledWith('onboarding_completed', {
-      sdk: 'codex',
-      auto_selected: false,
-      wizard: true,
-      ready_agents: 2
-    })
+    expect(mockSettingsState.updateSetting).toHaveBeenCalledTimes(1)
+    expect(mockTrack).toHaveBeenCalledWith(
+      'onboarding_completed',
+      expect.objectContaining({
+        sdk: 'codex',
+        auto_selected: false,
+        wizard: true,
+        ready_agents: 2,
+        event_version: 2,
+        default_runtime: 'codex',
+        keymap_preset: 'vscode',
+        theme_id: 'system',
+        theme_follow_system: true
+      })
+    )
   })
 
   it('surfaces onboarding doctor errors and refreshes on demand', async () => {

--- a/test/phase-22/session-3/codex-implementer-skeleton.test.ts
+++ b/test/phase-22/session-3/codex-implementer-skeleton.test.ts
@@ -12,6 +12,11 @@ vi.mock('../../../src/main/services/logger', () => ({
   })
 }))
 
+vi.mock('../../../src/main/services/codex-config', () => ({
+  getCodexConfiguredModel: vi.fn(() => undefined),
+  getCodexConfiguredContextWindow: vi.fn(() => undefined)
+}))
+
 import { CodexImplementer } from '../../../src/main/services/codex-implementer'
 import { CODEX_CAPABILITIES } from '../../../src/main/services/agent-runtime-types'
 import { CODEX_DEFAULT_MODEL } from '../../../src/main/services/codex-models'
@@ -60,10 +65,10 @@ describe('CodexImplementer skeleton', () => {
       expect(result[0].id).toBe('codex')
     })
 
-    it('provider contains all 4 models', async () => {
+    it('provider contains all 5 models', async () => {
       const result = (await impl.getAvailableModels()) as any[]
       const models = result[0].models
-      expect(Object.keys(models)).toHaveLength(4)
+      expect(Object.keys(models)).toHaveLength(5)
     })
   })
 
@@ -304,12 +309,16 @@ describe('CodexImplementer skeleton', () => {
 
     it('times out after the budget when there is no pending HITL request', async () => {
       ;(impl as any).manager = new EventEmitter()
+      const session = {
+        threadId: 'thread-1',
+        activeRun: { runId: 'run-1', expectedTurnId: null }
+      }
 
-      const promise = (impl as any).waitForTurnCompletion(
-        { threadId: 'thread-1' },
-        () => false,
-        1000
-      ) as Promise<void>
+      const promise = (impl as any).waitForTurnCompletion(session, {
+        runId: 'run-1',
+        isComplete: () => false,
+        timeoutMs: 1000
+      }) as Promise<void>
 
       const outcome = promise.then(
         () => 'resolved',
@@ -326,12 +335,16 @@ describe('CodexImplementer skeleton', () => {
     it('pauses timeout consumption while HITL is pending and resumes with the remaining budget', async () => {
       const manager = new EventEmitter()
       ;(impl as any).manager = manager
+      const session = {
+        threadId: 'thread-1',
+        activeRun: { runId: 'run-1', expectedTurnId: null }
+      }
 
-      const promise = (impl as any).waitForTurnCompletion(
-        { threadId: 'thread-1' },
-        () => false,
-        1000
-      ) as Promise<void>
+      const promise = (impl as any).waitForTurnCompletion(session, {
+        runId: 'run-1',
+        isComplete: () => false,
+        timeoutMs: 1000
+      }) as Promise<void>
       const outcome = promise.then(
         () => 'resolved',
         (error) => error

--- a/test/phase-22/session-3/codex-implementer-skeleton.test.ts
+++ b/test/phase-22/session-3/codex-implementer-skeleton.test.ts
@@ -332,6 +332,57 @@ describe('CodexImplementer skeleton', () => {
       expect((error as Error).message).toBe('Turn timed out')
     })
 
+    it('treats streaming events as progress and resets the inactivity timeout', async () => {
+      const manager = new EventEmitter()
+      ;(impl as any).manager = manager
+      const session = {
+        threadId: 'thread-1',
+        activeRun: { runId: 'run-1', expectedTurnId: 'turn-1' }
+      }
+
+      const promise = (impl as any).waitForTurnCompletion(session, {
+        runId: 'run-1',
+        expectedTurnId: 'turn-1',
+        isComplete: () => false,
+        timeoutMs: 1000
+      }) as Promise<'completed' | 'interrupted'>
+
+      let settled = false
+      void promise.finally(() => {
+        settled = true
+      })
+
+      await vi.advanceTimersByTimeAsync(900)
+      manager.emit('event', {
+        threadId: 'thread-1',
+        turnId: 'turn-1',
+        method: 'item/agentMessage/delta',
+        payload: { delta: 'still running' }
+      })
+
+      await vi.advanceTimersByTimeAsync(900)
+      expect(settled).toBe(false)
+
+      manager.emit('event', {
+        threadId: 'thread-1',
+        turnId: 'turn-1',
+        method: 'item/commandExecution/outputDelta',
+        payload: { delta: 'more output' }
+      })
+
+      await vi.advanceTimersByTimeAsync(999)
+      expect(settled).toBe(false)
+
+      manager.emit('event', {
+        threadId: 'thread-1',
+        turnId: 'turn-1',
+        method: 'turn/completed',
+        payload: { turn: { id: 'turn-1', status: 'completed' } }
+      })
+
+      await expect(promise).resolves.toBe('completed')
+    })
+
     it('pauses timeout consumption while HITL is pending and resumes with the remaining budget', async () => {
       const manager = new EventEmitter()
       ;(impl as any).manager = manager

--- a/test/phase-22/session-3/codex-model-catalog.test.ts
+++ b/test/phase-22/session-3/codex-model-catalog.test.ts
@@ -12,8 +12,14 @@ describe('codex-models', () => {
   // ── CODEX_MODELS constant ──────────────────────────────────────
 
   describe('CODEX_MODELS', () => {
-    it('contains exactly 4 models', () => {
-      expect(CODEX_MODELS).toHaveLength(4)
+    it('contains exactly 5 models', () => {
+      expect(CODEX_MODELS).toHaveLength(5)
+    })
+
+    it('includes gpt-5.5', () => {
+      const model = CODEX_MODELS.find((m) => m.id === 'gpt-5.5')
+      expect(model).toBeDefined()
+      expect(model!.name).toBe('GPT-5.5')
     })
 
     it('includes gpt-5.4', () => {
@@ -95,10 +101,11 @@ describe('codex-models', () => {
       expect(result[0].name).toBe('Codex')
     })
 
-    it('provider entry contains all 4 models keyed by id', () => {
+    it('provider entry contains all 5 models keyed by id', () => {
       const result = getAvailableCodexModels()
       const models = result[0].models
-      expect(Object.keys(models)).toHaveLength(4)
+      expect(Object.keys(models)).toHaveLength(5)
+      expect(models['gpt-5.5']).toBeDefined()
       expect(models['gpt-5.4']).toBeDefined()
       expect(models['gpt-5.3-codex']).toBeDefined()
       expect(models['gpt-5.3-codex-spark']).toBeDefined()
@@ -136,7 +143,7 @@ describe('codex-models', () => {
       expect(info).not.toBeNull()
       expect(info!.id).toBe('gpt-5.4')
       expect(info!.name).toBe('GPT-5.4')
-      expect(info!.limit.context).toBe(200000)
+      expect(info!.limit.context).toBe(258400)
     })
 
     it('returns model info for gpt-5.3-codex', () => {

--- a/test/phase-22/session-4/codex-app-server-manager.test.ts
+++ b/test/phase-22/session-4/codex-app-server-manager.test.ts
@@ -1,8 +1,9 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { EventEmitter } from 'node:events'
-import { spawn } from 'node:child_process'
 import { PassThrough } from 'node:stream'
+
+const mockSpawnLaunchSpec = vi.hoisted(() => vi.fn())
 
 // Mock logger
 vi.mock('../../../src/main/services/logger', () => ({
@@ -23,6 +24,10 @@ vi.mock('node:child_process', async (importOriginal) => {
     spawnSync: vi.fn()
   }
 })
+
+vi.mock('../../../src/main/services/command-launch-utils', () => ({
+  spawnLaunchSpec: mockSpawnLaunchSpec
+}))
 
 vi.mock('node:readline', () => {
   const createInterface = vi.fn(() => ({
@@ -547,6 +552,21 @@ describe('CodexAppServerManager', () => {
       expect(context.session.status).toBe('error')
     })
 
+    it('updates session status on thread/status/changed idle notification', () => {
+      const { context } = createTestContext({ status: 'running', activeTurnId: 'turn-1' })
+
+      manager.handleStdoutLine(
+        context,
+        JSON.stringify({
+          method: 'thread/status/changed',
+          params: { status: { type: 'idle' } }
+        })
+      )
+
+      expect(context.session.status).toBe('ready')
+      expect(context.session.activeTurnId).toBeNull()
+    })
+
     it('extracts route fields from notification params', () => {
       const { context } = createTestContext()
       const events: any[] = []
@@ -561,6 +581,23 @@ describe('CodexAppServerManager', () => {
       )
 
       expect(events[0].turnId).toBe('turn-42')
+      expect(events[0].itemId).toBe('item-7')
+    })
+
+    it('falls back to activeTurnId for item notifications without route fields', () => {
+      const { context } = createTestContext({ status: 'running', activeTurnId: 'turn-active-1' })
+      const events: any[] = []
+      manager.on('event', (event) => events.push(event))
+
+      manager.handleStdoutLine(
+        context,
+        JSON.stringify({
+          method: 'item/started',
+          params: { item: { id: 'item-7', type: 'commandExecution' } }
+        })
+      )
+
+      expect(events[0].turnId).toBe('turn-active-1')
       expect(events[0].itemId).toBe('item-7')
     })
 
@@ -602,7 +639,7 @@ describe('CodexAppServerManager', () => {
       child.kill = vi.fn(() => {
         child.killed = true
       })
-      vi.mocked(spawn).mockReturnValue(child)
+      mockSpawnLaunchSpec.mockReturnValue(child)
 
       const sendRequestSpy = vi
         .spyOn(manager, 'sendRequest')
@@ -639,7 +676,7 @@ describe('CodexAppServerManager', () => {
       child.kill = vi.fn(() => {
         child.killed = true
       })
-      vi.mocked(spawn).mockReturnValue(child)
+      mockSpawnLaunchSpec.mockReturnValue(child)
 
       const sendRequestSpy = vi
         .spyOn(manager, 'sendRequest')

--- a/test/phase-22/session-4/codex-lifecycle.test.ts
+++ b/test/phase-22/session-4/codex-lifecycle.test.ts
@@ -628,6 +628,17 @@ describe('CodexImplementer lifecycle', () => {
       const contextUsageEvents = mockWindow.webContents.send.mock.calls
         .map((call) => call[1] as any)
         .filter((event) => event.type === 'session.context_usage')
+      expect(contextUsageEvents[0].data.tokens).toEqual({
+        input: 5000,
+        cacheRead: 5000,
+        cacheWrite: 0,
+        output: 500,
+        reasoning: 0
+      })
+      expect(contextUsageEvents[0].data.breakdown).toMatchObject({
+        usedTokens: 1000,
+        maxTokens: 258400
+      })
       const firstCost = calculateUsageCost(
         'gpt-5.4',
         { input: 500, cacheRead: 500, cacheWrite: 0, output: 50 },

--- a/test/phase-22/session-4/codex-lifecycle.test.ts
+++ b/test/phase-22/session-4/codex-lifecycle.test.ts
@@ -1,5 +1,8 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 
 // Mock logger
 vi.mock('../../../src/main/services/logger', () => ({
@@ -20,6 +23,7 @@ vi.mock('../../../src/main/services/codex-app-server-manager', () => {
     hasSession: vi.fn().mockReturnValue(false),
     getSession: vi.fn(),
     listSessions: vi.fn().mockReturnValue([]),
+    readThread: vi.fn(),
     on: vi.fn(),
     emit: vi.fn(),
     removeAllListeners: vi.fn()
@@ -31,6 +35,7 @@ vi.mock('../../../src/main/services/codex-app-server-manager', () => {
 
 import { CodexImplementer } from '../../../src/main/services/codex-implementer'
 import { CODEX_DEFAULT_MODEL } from '../../../src/main/services/codex-models'
+import { calculateUsageCost } from '../../../src/shared/usage/pricing'
 
 describe('CodexImplementer lifecycle', () => {
   let impl: CodexImplementer
@@ -38,6 +43,7 @@ describe('CodexImplementer lifecycle', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.stubEnv('CODEX_HOME', '/tmp/xuanpu-vitest-empty-codex-home')
     impl = new CodexImplementer()
     mockManager = impl.getManager()
   })
@@ -203,6 +209,7 @@ describe('CodexImplementer lifecycle', () => {
       const result = await impl.reconnect('/test', 'thread-existing', 'new-hive-id')
 
       expect(result.success).toBe(true)
+      expect(result.sessionId).toBe('thread-existing')
       expect(result.sessionStatus).toBe('idle')
 
       // Verify hiveSessionId was updated
@@ -223,6 +230,7 @@ describe('CodexImplementer lifecycle', () => {
       const result = await impl.reconnect('/test', 'thread-running', 'hive-2')
 
       expect(result.success).toBe(true)
+      expect(result.sessionId).toBe('thread-running')
       expect(result.sessionStatus).toBe('busy')
     })
 
@@ -242,6 +250,7 @@ describe('CodexImplementer lifecycle', () => {
       const result = await impl.reconnect('/test', 'thread-old', 'hive-new')
 
       expect(result.success).toBe(true)
+      expect(result.sessionId).toBe('thread-reconnected')
       expect(result.sessionStatus).toBe('idle')
 
       // Verify manager was called with resume
@@ -462,6 +471,197 @@ describe('CodexImplementer lifecycle', () => {
     it('getMessages returns empty array for unknown session', async () => {
       const messages = await impl.getMessages('/test', 'session-1')
       expect(messages).toEqual([])
+    })
+
+    it('getMessages recovers messages from thread/read when local and DB caches are empty', async () => {
+      impl.getSessions().set('/test::thread-read', {
+        threadId: 'thread-read',
+        hiveSessionId: 'hive-read',
+        worktreePath: '/test',
+        status: 'ready',
+        messages: [],
+        revertMessageID: null,
+        revertDiff: null,
+        titleGenerated: true,
+        titleGenerationStarted: true,
+        mapperState: {
+          outputBuffers: new Map(),
+          toolStartTimes: new Map()
+        },
+        itemTimestampsByTurn: new Map()
+      })
+
+      mockManager.readThread.mockResolvedValue({
+        thread: {
+          turns: [
+            {
+              id: 'turn-1',
+              createdAt: '2026-05-23T08:00:00.000Z',
+              items: [
+                {
+                  type: 'userMessage',
+                  content: [{ type: 'text', text: '继续' }]
+                },
+                {
+                  type: 'agentMessage',
+                  text: '可以继续'
+                }
+              ]
+            }
+          ]
+        }
+      })
+
+      const messages = await impl.getMessages('/test', 'thread-read')
+
+      expect(mockManager.readThread).toHaveBeenCalledWith('thread-read')
+      expect(messages).toHaveLength(2)
+      expect((messages[0] as any).role).toBe('user')
+      expect((messages[1] as any).role).toBe('assistant')
+    })
+  })
+
+  describe('context usage reporting', () => {
+    it('uses model_context_window from codex config over provider runtime limit', () => {
+      const codexHome = mkdtempSync(join(tmpdir(), 'xuanpu-codex-config-'))
+      mkdirSync(codexHome, { recursive: true })
+      writeFileSync(
+        join(codexHome, 'config.toml'),
+        'model = "gpt-5.5"\nmodel_context_window = 500000\n'
+      )
+      vi.stubEnv('CODEX_HOME', codexHome)
+
+      impl = new CodexImplementer()
+      const mockWindow = {
+        isDestroyed: () => false,
+        webContents: { send: vi.fn() }
+      } as any
+      impl.setMainWindow(mockWindow)
+      impl.getSessions().set('/test::thread-usage', {
+        threadId: 'thread-usage',
+        hiveSessionId: 'hive-usage',
+        worktreePath: '/test',
+        status: 'ready',
+        messages: []
+      })
+      ;(impl as any).handleManagerEvent({
+        id: 'evt-usage',
+        kind: 'notification',
+        provider: 'codex',
+        threadId: 'thread-usage',
+        method: 'thread/tokenUsage/updated',
+        createdAt: new Date().toISOString(),
+        payload: {
+          turnId: 'turn-usage',
+          tokenUsage: {
+            last: {
+              inputTokens: 1000,
+              cachedInputTokens: 400,
+              outputTokens: 50,
+              reasoningOutputTokens: 5
+            },
+            modelContextWindow: 258400
+          }
+        }
+      })
+
+      expect(mockWindow.webContents.send).toHaveBeenCalledWith(
+        'agent:stream',
+        expect.objectContaining({
+          type: 'session.context_usage',
+          data: expect.objectContaining({
+            contextWindow: 500000,
+            model: { providerID: 'codex', modelID: 'gpt-5.5' },
+            cost: expect.any(Number),
+            requestId: expect.stringContaining('turn-usage')
+          })
+        })
+      )
+    })
+
+    it('emits incremental Codex turn usage cost without adding cumulative totals', () => {
+      const mockWindow = {
+        isDestroyed: () => false,
+        webContents: { send: vi.fn() }
+      } as any
+      impl.setMainWindow(mockWindow)
+      impl.getSessions().set('/test::thread-cost', {
+        threadId: 'thread-cost',
+        hiveSessionId: 'hive-cost',
+        worktreePath: '/test',
+        status: 'ready',
+        messages: []
+      })
+
+      const emitUsage = (input: number, cached: number, output: number): void => {
+        ;(impl as any).handleManagerEvent({
+          id: `evt-cost-${input}`,
+          kind: 'notification',
+          provider: 'codex',
+          threadId: 'thread-cost',
+          method: 'thread/tokenUsage/updated',
+          createdAt: new Date().toISOString(),
+          payload: {
+            model: 'gpt-5.4',
+            turnId: 'turn-cost',
+            tokenUsage: {
+              last: {
+                inputTokens: input,
+                cachedInputTokens: cached,
+                outputTokens: output,
+                reasoningOutputTokens: 0
+              },
+              total: {
+                inputTokens: input * 10,
+                cachedInputTokens: cached * 10,
+                outputTokens: output * 10
+              },
+              modelContextWindow: 258400
+            }
+          }
+        })
+      }
+
+      emitUsage(1000, 500, 50)
+      emitUsage(1200, 500, 70)
+
+      const contextUsageEvents = mockWindow.webContents.send.mock.calls
+        .map((call) => call[1] as any)
+        .filter((event) => event.type === 'session.context_usage')
+      const firstCost = calculateUsageCost(
+        'gpt-5.4',
+        { input: 500, cacheRead: 500, cacheWrite: 0, output: 50 },
+        'codex'
+      )
+      const secondSnapshotCost = calculateUsageCost(
+        'gpt-5.4',
+        { input: 700, cacheRead: 500, cacheWrite: 0, output: 70 },
+        'codex'
+      )
+
+      expect(contextUsageEvents[0].data.cost).toBeCloseTo(firstCost)
+      expect(contextUsageEvents[1].data.cost).toBeCloseTo(secondSnapshotCost - firstCost)
+      expect(contextUsageEvents[0].data.totalCost).toBeUndefined()
+    })
+
+    it('applies configured context window to Codex model metadata', async () => {
+      const codexHome = mkdtempSync(join(tmpdir(), 'xuanpu-codex-config-'))
+      mkdirSync(codexHome, { recursive: true })
+      writeFileSync(
+        join(codexHome, 'config.toml'),
+        'model = "gpt-5.5"\nmodel_context_window = 500000\n'
+      )
+      vi.stubEnv('CODEX_HOME', codexHome)
+
+      impl = new CodexImplementer()
+
+      const modelInfo = await impl.getModelInfo('/test', 'gpt-5.4')
+      expect(modelInfo?.limit.context).toBe(500000)
+
+      const providers = (await impl.getAvailableModels()) as Array<{
+        models: Record<string, { limit: { context: number } }>
+      }>
+      expect(providers[0]?.models['gpt-5.4']?.limit.context).toBe(500000)
     })
   })
 })

--- a/test/phase-22/session-4/session-timeline-handler-codex.test.ts
+++ b/test/phase-22/session-4/session-timeline-handler-codex.test.ts
@@ -1,0 +1,359 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const ipcHandlers = new Map<string, (...args: unknown[]) => Promise<unknown>>()
+const getTimelineMock = vi.fn()
+const getMessagesMock = vi.fn()
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: vi.fn((channel: string, handler: (...args: unknown[]) => Promise<unknown>) => {
+      ipcHandlers.set(channel, handler)
+    })
+  }
+}))
+
+vi.mock('../../../src/main/services/logger', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn()
+  })
+}))
+
+vi.mock('../../../src/main/services/session-timeline-service', () => ({
+  getSessionTimeline: (...args: unknown[]) => getTimelineMock(...args)
+}))
+
+vi.mock('../../../src/main/db', () => ({
+  getDatabase: () => ({
+    getSession: vi.fn(() => ({
+      id: 'session-1',
+      agent_sdk: 'codex',
+      opencode_session_id: 'thread-1',
+      worktree_id: 'worktree-1',
+      connection_id: null
+    })),
+    getWorktree: vi.fn(() => ({ path: '/repo' })),
+    getConnection: vi.fn()
+  })
+}))
+
+import { registerTimelineHandlers } from '../../../src/main/ipc/session-timeline-handlers'
+
+describe('session:getTimeline Codex fallback', () => {
+  beforeEach(() => {
+    ipcHandlers.clear()
+    getTimelineMock.mockReset()
+    getMessagesMock.mockReset()
+  })
+
+  it('flushes Codex implementer messages and re-reads DB timeline when DB is empty', async () => {
+    getTimelineMock
+      .mockReturnValueOnce({ messages: [], compactionMarkers: [], revertBoundary: null })
+      .mockReturnValueOnce({
+        messages: [{ id: 'm1', role: 'assistant', content: 'recovered' }],
+        compactionMarkers: [],
+        revertBoundary: null
+      })
+    getMessagesMock.mockResolvedValue([{ role: 'assistant', content: 'recovered' }])
+
+    registerTimelineHandlers({
+      getImplementer: vi.fn(() => ({ getMessages: getMessagesMock }))
+    } as never)
+
+    const handler = ipcHandlers.get('session:getTimeline')
+    expect(handler).toBeDefined()
+
+    const result = await handler?.({}, 'session-1')
+
+    expect(getMessagesMock).toHaveBeenCalledWith('/repo', 'thread-1')
+    expect(result).toEqual({
+      messages: [{ id: 'm1', role: 'assistant', content: 'recovered' }],
+      compactionMarkers: [],
+      revertBoundary: null
+    })
+  })
+
+  it('recovers Codex assistant text when DB has only user/tool timeline rows', async () => {
+    getTimelineMock
+      .mockReturnValueOnce({
+        messages: [
+          {
+            id: 'turn-1:user',
+            role: 'user',
+            content: 'question',
+            timestamp: '2026-05-23T08:00:00.000Z'
+          },
+          {
+            id: 'turn-1:tool:tool-1',
+            role: 'assistant',
+            content: '',
+            timestamp: '2026-05-23T08:00:01.000Z',
+            parts: [{ type: 'tool_use', toolUse: { id: 'tool-1', name: 'Bash' } }]
+          }
+        ],
+        compactionMarkers: [],
+        revertBoundary: null
+      })
+      .mockReturnValueOnce({
+        messages: [
+          {
+            id: 'turn-1:user',
+            role: 'user',
+            content: 'question',
+            timestamp: '2026-05-23T08:00:00.000Z'
+          },
+          {
+            id: 'turn-1:assistant',
+            role: 'assistant',
+            content: 'answer',
+            timestamp: '2026-05-23T08:00:02.000Z',
+            parts: [{ type: 'text', text: 'answer' }]
+          }
+        ],
+        compactionMarkers: [],
+        revertBoundary: null
+      })
+    getMessagesMock.mockResolvedValue([{ role: 'assistant', content: 'answer' }])
+
+    registerTimelineHandlers({
+      getImplementer: vi.fn(() => ({ getMessages: getMessagesMock }))
+    } as never)
+
+    const handler = ipcHandlers.get('session:getTimeline')
+    const result = await handler?.({}, 'session-1')
+
+    expect(getMessagesMock).toHaveBeenCalledWith('/repo', 'thread-1')
+    expect(result).toEqual({
+      messages: [
+        {
+          id: 'turn-1:user',
+          role: 'user',
+          content: 'question',
+          timestamp: '2026-05-23T08:00:00.000Z'
+        },
+        {
+          id: 'turn-1:assistant',
+          role: 'assistant',
+          content: 'answer',
+          timestamp: '2026-05-23T08:00:02.000Z',
+          parts: [{ type: 'text', text: 'answer' }]
+        }
+      ],
+      compactionMarkers: [],
+      revertBoundary: null
+    })
+  })
+
+  it('refreshes Codex timeline when recovered assistant timestamps are collapsed before tools', async () => {
+    getTimelineMock
+      .mockReturnValueOnce({
+        messages: [
+          {
+            id: 'turn-1:user',
+            role: 'user',
+            content: 'question',
+            timestamp: '2026-05-23T08:00:00.000Z'
+          },
+          {
+            id: 'turn-1:assistant',
+            role: 'assistant',
+            content: 'intro',
+            timestamp: '2026-05-23T08:00:00.001Z',
+            parts: [{ type: 'text', text: 'intro' }]
+          },
+          {
+            id: 'turn-1:assistant:item-3',
+            role: 'assistant',
+            content: 'after tools',
+            timestamp: '2026-05-23T08:00:00.002Z',
+            parts: [{ type: 'text', text: 'after tools' }]
+          },
+          {
+            id: 'turn-1:tool:tool-1',
+            role: 'assistant',
+            content: '',
+            timestamp: '2026-05-23T08:00:05.000Z',
+            parts: [{ type: 'tool_use', toolUse: { id: 'tool-1', name: 'Bash' } }]
+          },
+          {
+            id: 'turn-1:tool:tool-2',
+            role: 'assistant',
+            content: '',
+            timestamp: '2026-05-23T08:00:08.000Z',
+            parts: [{ type: 'tool_use', toolUse: { id: 'tool-2', name: 'Bash' } }]
+          }
+        ],
+        compactionMarkers: [],
+        revertBoundary: null
+      })
+      .mockReturnValueOnce({
+        messages: [
+          {
+            id: 'turn-1:user',
+            role: 'user',
+            content: 'question',
+            timestamp: '2026-05-23T08:00:00.000Z'
+          },
+          {
+            id: 'turn-1:assistant',
+            role: 'assistant',
+            content: 'intro',
+            timestamp: '2026-05-23T08:00:01.000Z',
+            parts: [{ type: 'text', text: 'intro' }]
+          },
+          {
+            id: 'turn-1:tool:tool-1',
+            role: 'assistant',
+            content: '',
+            timestamp: '2026-05-23T08:00:05.000Z',
+            parts: [{ type: 'tool_use', toolUse: { id: 'tool-1', name: 'Bash' } }]
+          },
+          {
+            id: 'turn-1:assistant:item-3',
+            role: 'assistant',
+            content: 'after tools',
+            timestamp: '2026-05-23T08:00:09.000Z',
+            parts: [{ type: 'text', text: 'after tools' }]
+          }
+        ],
+        compactionMarkers: [],
+        revertBoundary: null
+      })
+    getMessagesMock.mockResolvedValue([{ role: 'assistant', content: 'recovered' }])
+
+    registerTimelineHandlers({
+      getImplementer: vi.fn(() => ({ getMessages: getMessagesMock }))
+    } as never)
+
+    const handler = ipcHandlers.get('session:getTimeline')
+    const result = await handler?.({}, 'session-1')
+
+    expect(getMessagesMock).toHaveBeenCalledWith('/repo', 'thread-1', { forceRefresh: true })
+    const messages = (result as { messages: Array<{ id: string }> }).messages
+    expect(messages.map((message) => message.id)).toEqual([
+      'turn-1:user',
+      'turn-1:assistant',
+      'turn-1:tool:tool-1',
+      'turn-1:assistant:item-3'
+    ])
+  })
+
+  it('refreshes Codex timeline when assistant rows borrowed nearby tool timestamps', async () => {
+    getTimelineMock
+      .mockReturnValueOnce({
+        messages: [
+          {
+            id: 'turn-1:user',
+            role: 'user',
+            content: 'question',
+            timestamp: '2026-05-23T08:00:00.000Z'
+          },
+          {
+            id: 'turn-1:assistant',
+            role: 'assistant',
+            content: 'intro',
+            timestamp: '2026-05-23T08:00:01.000Z',
+            parts: [{ type: 'text', text: 'intro' }]
+          },
+          {
+            id: 'turn-1:assistant:item-3',
+            role: 'assistant',
+            content: 'after first tool',
+            timestamp: '2026-05-23T08:00:05.020Z',
+            parts: [{ type: 'text', text: 'after first tool' }]
+          },
+          {
+            id: 'turn-1:tool:tool-1',
+            role: 'assistant',
+            content: '',
+            timestamp: '2026-05-23T08:00:05.000Z',
+            parts: [{ type: 'tool_use', toolUse: { id: 'tool-1', name: 'Bash' } }]
+          },
+          {
+            id: 'turn-1:assistant:item-4',
+            role: 'assistant',
+            content: 'after second tool',
+            timestamp: '2026-05-23T08:00:08.030Z',
+            parts: [{ type: 'text', text: 'after second tool' }]
+          },
+          {
+            id: 'turn-1:tool:tool-2',
+            role: 'assistant',
+            content: '',
+            timestamp: '2026-05-23T08:00:08.000Z',
+            parts: [{ type: 'tool_use', toolUse: { id: 'tool-2', name: 'Bash' } }]
+          }
+        ],
+        compactionMarkers: [],
+        revertBoundary: null
+      })
+      .mockReturnValueOnce({
+        messages: [
+          {
+            id: 'turn-1:user',
+            role: 'user',
+            content: 'question',
+            timestamp: '2026-05-23T08:00:00.000Z'
+          },
+          {
+            id: 'turn-1:assistant',
+            role: 'assistant',
+            content: 'intro',
+            timestamp: '2026-05-23T08:00:01.000Z',
+            parts: [{ type: 'text', text: 'intro' }]
+          },
+          {
+            id: 'turn-1:tool:tool-1',
+            role: 'assistant',
+            content: '',
+            timestamp: '2026-05-23T08:00:05.000Z',
+            parts: [{ type: 'tool_use', toolUse: { id: 'tool-1', name: 'Bash' } }]
+          },
+          {
+            id: 'turn-1:assistant:item-3',
+            role: 'assistant',
+            content: 'after first tool',
+            timestamp: '2026-05-23T08:00:07.000Z',
+            parts: [{ type: 'text', text: 'after first tool' }]
+          },
+          {
+            id: 'turn-1:tool:tool-2',
+            role: 'assistant',
+            content: '',
+            timestamp: '2026-05-23T08:00:08.000Z',
+            parts: [{ type: 'tool_use', toolUse: { id: 'tool-2', name: 'Bash' } }]
+          },
+          {
+            id: 'turn-1:assistant:item-4',
+            role: 'assistant',
+            content: 'after second tool',
+            timestamp: '2026-05-23T08:00:09.000Z',
+            parts: [{ type: 'text', text: 'after second tool' }]
+          }
+        ],
+        compactionMarkers: [],
+        revertBoundary: null
+      })
+    getMessagesMock.mockResolvedValue([{ role: 'assistant', content: 'recovered' }])
+
+    registerTimelineHandlers({
+      getImplementer: vi.fn(() => ({ getMessages: getMessagesMock }))
+    } as never)
+
+    const handler = ipcHandlers.get('session:getTimeline')
+    const result = await handler?.({}, 'session-1')
+
+    expect(getMessagesMock).toHaveBeenCalledWith('/repo', 'thread-1', { forceRefresh: true })
+    const messages = (result as { messages: Array<{ id: string }> }).messages
+    expect(messages.map((message) => message.id)).toEqual([
+      'turn-1:user',
+      'turn-1:assistant',
+      'turn-1:tool:tool-1',
+      'turn-1:assistant:item-3',
+      'turn-1:tool:tool-2',
+      'turn-1:assistant:item-4'
+    ])
+  })
+})

--- a/test/phase-22/session-5/codex-config.test.ts
+++ b/test/phase-22/session-5/codex-config.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+import { parseCodexConfigToml } from '../../../src/main/services/codex-config'
+
+describe('codex config parsing', () => {
+  it('reads top-level model and configured context window', () => {
+    const config = parseCodexConfigToml(`
+model = "gpt-5.5"
+model_context_window = 500000
+profile = "auto-max"
+
+[profiles.auto-max]
+model = "gpt-5.5"
+model_reasoning_effort = "xhigh"
+`)
+
+    expect(config.model).toBe('gpt-5.5')
+    expect(config.modelContextWindow).toBe(500000)
+    expect(config.activeProfile).toBe('auto-max')
+  })
+
+  it('lets the active profile override root model and context window', () => {
+    const config = parseCodexConfigToml(`
+model = "gpt-5.4"
+model_context_window = 258400
+profile = "large"
+
+[profiles.large]
+model = "gpt-5.5"
+model_context_window = 500000
+`)
+
+    expect(config.model).toBe('gpt-5.5')
+    expect(config.modelContextWindow).toBe(500000)
+  })
+})

--- a/test/phase-22/session-5/codex-durable-read.test.ts
+++ b/test/phase-22/session-5/codex-durable-read.test.ts
@@ -10,7 +10,9 @@
  */
 import { describe, it, expect } from 'vitest'
 import {
+  deriveCodexTimeline,
   parseToolPartFromActivity,
+  type DbSessionMessage,
   type DbSessionActivity
 } from '../../../src/shared/lib/timeline-mappers'
 
@@ -40,9 +42,7 @@ describe('timeline-mappers › codex durable read path', () => {
           type: 'commandExecution',
           id: 'item-1',
           command: 'cat README.md',
-          commandActions: [
-            { type: 'read', name: 'README.md', path: '/abs/README.md' }
-          ],
+          commandActions: [{ type: 'read', name: 'README.md', path: '/abs/README.md' }],
           status: 'completed',
           aggregatedOutput: '# Title\nbody\n',
           exitCode: 0
@@ -180,5 +180,81 @@ describe('timeline-mappers › codex durable read path', () => {
     const part = parseToolPartFromActivity(a)
     expect(part!.toolUse?.status).toBe('error')
     expect(part!.toolUse?.error).toContain('permission denied')
+  })
+
+  it('anchors unscoped Codex tool activities to the surrounding turn by time', () => {
+    const messages: DbSessionMessage[] = [
+      {
+        id: 'db-user-1',
+        session_id: 's-1',
+        role: 'user',
+        content: 'First prompt',
+        opencode_message_id: 'turn-1:user',
+        opencode_message_json: null,
+        opencode_parts_json: JSON.stringify([{ type: 'text', text: 'First prompt' }]),
+        opencode_timeline_json: null,
+        created_at: '2026-05-23T08:00:00.000Z'
+      },
+      {
+        id: 'db-assistant-1',
+        session_id: 's-1',
+        role: 'assistant',
+        content: 'First answer',
+        opencode_message_id: 'turn-1:assistant',
+        opencode_message_json: null,
+        opencode_parts_json: JSON.stringify([{ type: 'text', text: 'First answer' }]),
+        opencode_timeline_json: null,
+        created_at: '2026-05-23T08:00:05.000Z'
+      },
+      {
+        id: 'db-user-2',
+        session_id: 's-1',
+        role: 'user',
+        content: 'Second prompt',
+        opencode_message_id: 'turn-2:user',
+        opencode_message_json: null,
+        opencode_parts_json: JSON.stringify([{ type: 'text', text: 'Second prompt' }]),
+        opencode_timeline_json: null,
+        created_at: '2026-05-23T08:01:00.000Z'
+      },
+      {
+        id: 'db-assistant-2',
+        session_id: 's-1',
+        role: 'assistant',
+        content: 'Second answer',
+        opencode_message_id: 'turn-2:assistant',
+        opencode_message_json: null,
+        opencode_parts_json: JSON.stringify([{ type: 'text', text: 'Second answer' }]),
+        opencode_timeline_json: null,
+        created_at: '2026-05-23T08:01:08.000Z'
+      }
+    ]
+
+    const timeline = deriveCodexTimeline(messages, [
+      activity({
+        id: 'tool-unscoped',
+        turn_id: null,
+        item_id: 'tool-1',
+        created_at: '2026-05-23T08:01:03.000Z',
+        payload_json: JSON.stringify({
+          item: {
+            type: 'commandExecution',
+            id: 'tool-1',
+            command: 'pnpm test',
+            commandActions: [],
+            status: 'completed',
+            aggregatedOutput: 'ok'
+          }
+        })
+      })
+    ])
+
+    expect(timeline.map((message) => message.id)).toEqual([
+      'turn-1:user',
+      'turn-1:assistant',
+      'turn-2:user',
+      'turn-2:tool:tool-1',
+      'turn-2:assistant'
+    ])
   })
 })

--- a/test/phase-22/session-5/codex-event-mapper-fixtures.test.ts
+++ b/test/phase-22/session-5/codex-event-mapper-fixtures.test.ts
@@ -15,6 +15,8 @@ import {
 } from '../../../src/main/services/codex-event-mapper'
 import { loadFixture } from './fixtures/load'
 
+process.env.CODEX_HOME = '/tmp/xuanpu-vitest-empty-codex-home'
+
 const HIVE = 'hive-test'
 
 function streamFromFixture(name: string): unknown[] {
@@ -31,7 +33,9 @@ interface PartUpdate {
 function partsOf(stream: unknown[]): PartUpdate[] {
   return stream.filter(
     (e): e is PartUpdate =>
-      typeof e === 'object' && e !== null && (e as { type?: string }).type === 'message.part.updated'
+      typeof e === 'object' &&
+      e !== null &&
+      (e as { type?: string }).type === 'message.part.updated'
   )
 }
 
@@ -121,9 +125,7 @@ describe('codex mapper › read-via-cat', () => {
 
   it('captures command output inside the tool part state.output', () => {
     const tools = allToolParts(stream)
-    const completed = tools.find(
-      (t) => (t.state as { status?: string }).status === 'completed'
-    )
+    const completed = tools.find((t) => (t.state as { status?: string }).status === 'completed')
     expect(completed).toBeDefined()
     const state = completed!.state as { output?: string }
     expect(typeof state.output).toBe('string')
@@ -179,9 +181,7 @@ describe('codex mapper › file-change-edit', () => {
   it('emits session.turn_diff with cumulative git diff', () => {
     const turnDiffs = stream.filter(
       (e): e is { type: 'session.turn_diff'; data: { turnId: string; diff: string } } =>
-        typeof e === 'object' &&
-        e !== null &&
-        (e as { type?: string }).type === 'session.turn_diff'
+        typeof e === 'object' && e !== null && (e as { type?: string }).type === 'session.turn_diff'
     )
     expect(turnDiffs.length).toBeGreaterThan(0)
     expect(turnDiffs[0].data.diff).toContain('diff --git')

--- a/test/phase-22/session-5/codex-event-mapper.test.ts
+++ b/test/phase-22/session-5/codex-event-mapper.test.ts
@@ -4,7 +4,7 @@
  * codex-event-mapper-fixtures.test.ts: this file exercises individual code
  * paths in isolation; the fixture file covers end-to-end real-traffic shapes.
  */
-import { describe, it, expect } from 'vitest'
+import { beforeEach, describe, it, expect, vi } from 'vitest'
 import {
   mapCodexEventToStreamEvents,
   contentStreamKindFromMethod,
@@ -27,6 +27,10 @@ function makeEvent(overrides: Partial<CodexManagerEvent>): CodexManagerEvent {
 }
 
 const HIVE = 'hive-test'
+
+beforeEach(() => {
+  vi.stubEnv('CODEX_HOME', '/tmp/xuanpu-vitest-empty-codex-home')
+})
 
 // ────────────────────────────────────────────────────────────────────
 // contentStreamKindFromMethod
@@ -582,12 +586,19 @@ describe('thread/goal notifications', () => {
 // thread/tokenUsage/updated → session.context_usage
 // ────────────────────────────────────────────────────────────────────
 describe('thread/tokenUsage/updated', () => {
-  it('emits session.context_usage with totals + contextWindow', () => {
+  it('emits session.context_usage from the current turn usage + contextWindow', () => {
     const result = mapCodexEventToStreamEvents(
       makeEvent({
         method: 'thread/tokenUsage/updated',
         payload: {
           tokenUsage: {
+            last: {
+              totalTokens: 1000,
+              inputTokens: 800,
+              outputTokens: 200,
+              cachedInputTokens: 100,
+              reasoningOutputTokens: 50
+            },
             total: {
               totalTokens: 1000,
               inputTokens: 800,
@@ -604,7 +615,7 @@ describe('thread/tokenUsage/updated', () => {
     expect(result[0].type).toBe('session.context_usage')
     const data = result[0].data as any
     expect(data.tokens).toEqual({
-      input: 800,
+      input: 700,
       output: 200,
       cacheRead: 100,
       reasoning: 50
@@ -631,6 +642,17 @@ describe('thread/status/changed', () => {
       makeEvent({
         method: 'thread/status/changed',
         payload: { status: { type: 'active' } }
+      }),
+      HIVE
+    )
+    expect(result[0].statusPayload?.type).toBe('busy')
+  })
+
+  it('running → busy', () => {
+    const result = mapCodexEventToStreamEvents(
+      makeEvent({
+        method: 'thread/status/changed',
+        payload: { type: 'running' }
       }),
       HIVE
     )

--- a/test/phase-22/session-5/codex-event-mapper.test.ts
+++ b/test/phase-22/session-5/codex-event-mapper.test.ts
@@ -586,7 +586,7 @@ describe('thread/goal notifications', () => {
 // thread/tokenUsage/updated → session.context_usage
 // ────────────────────────────────────────────────────────────────────
 describe('thread/tokenUsage/updated', () => {
-  it('emits session.context_usage from the current turn usage + contextWindow', () => {
+  it('emits cumulative tokens with current prompt context occupancy', () => {
     const result = mapCodexEventToStreamEvents(
       makeEvent({
         method: 'thread/tokenUsage/updated',
@@ -600,11 +600,11 @@ describe('thread/tokenUsage/updated', () => {
               reasoningOutputTokens: 50
             },
             total: {
-              totalTokens: 1000,
-              inputTokens: 800,
-              outputTokens: 200,
-              cachedInputTokens: 100,
-              reasoningOutputTokens: 50
+              totalTokens: 5000,
+              inputTokens: 4200,
+              outputTokens: 700,
+              cachedInputTokens: 3000,
+              reasoningOutputTokens: 100
             },
             modelContextWindow: 475000
           }
@@ -615,12 +615,17 @@ describe('thread/tokenUsage/updated', () => {
     expect(result[0].type).toBe('session.context_usage')
     const data = result[0].data as any
     expect(data.tokens).toEqual({
-      input: 700,
-      output: 200,
-      cacheRead: 100,
-      reasoning: 50
+      input: 1200,
+      output: 700,
+      cacheRead: 3000,
+      reasoning: 100
     })
     expect(data.contextWindow).toBe(475000)
+    expect(data.breakdown).toEqual({
+      usedTokens: 800,
+      maxTokens: 475000,
+      percentage: (800 / 475000) * 100
+    })
   })
 
   it('drops if tokenUsage missing', () => {

--- a/test/phase-22/session-5/codex-prompt-streaming.test.ts
+++ b/test/phase-22/session-5/codex-prompt-streaming.test.ts
@@ -1,4 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+import { mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
 vi.mock('electron', () => ({
@@ -35,6 +38,11 @@ vi.mock('../../../src/main/services/codex-session-title', () => ({
   generateCodexSessionTitle: (...args: any[]) => mockGenerateCodexSessionTitle(...args)
 }))
 
+vi.mock('../../../src/main/services/codex-config', () => ({
+  getCodexConfiguredModel: vi.fn(() => undefined),
+  getCodexConfiguredContextWindow: vi.fn(() => undefined)
+}))
+
 vi.mock('../../../src/main/xfp/fallback-context', () => ({
   buildXfpFallbackContext: (...args: any[]) => mockBuildXfpFallbackContext(...args)
 }))
@@ -61,6 +69,7 @@ vi.mock('../../../src/main/services/codex-app-server-manager', () => {
     listSessions: vi.fn().mockReturnValue([]),
     setThreadGoal: vi.fn(),
     sendTurn: vi.fn(),
+    interruptTurn: vi.fn(),
     readThread: vi.fn(),
     on: vi.fn().mockImplementation((_event: string, handler: any) => {
       eventListeners.push(handler)
@@ -909,6 +918,69 @@ describe('CodexImplementer.prompt()', () => {
     expect(session.activeRun).toBeNull()
   })
 
+  it('keeps streaming after an abort request until Codex confirms the turn stopped', async () => {
+    const session = seedSession()
+    mockManager.sendTurn.mockResolvedValue({ turnId: 'turn-stop', threadId: 'thread-1' })
+    mockManager.interruptTurn.mockResolvedValue(undefined)
+
+    const promptPromise = impl.prompt('/test/project', 'thread-1', 'Stop me')
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    emitManagerEvent({
+      id: 'delta-before-stop',
+      kind: 'notification',
+      provider: 'codex',
+      threadId: 'thread-1',
+      turnId: 'turn-stop',
+      createdAt: new Date().toISOString(),
+      method: 'item/agentMessage/delta',
+      textDelta: 'before '
+    })
+
+    await impl.abort('/test/project', 'thread-1')
+
+    expect(mockManager.interruptTurn).toHaveBeenCalledWith('thread-1', 'turn-stop')
+    expect(session.status).toBe('running')
+    expect(session.activeRun?.state).toBe('aborting')
+
+    const statusEventsBeforeProviderStop = mockWindow.webContents.send.mock.calls
+      .filter((c: any[]) => c[0] === 'agent:stream')
+      .map((c: any[]) => c[1])
+      .filter((event: any) => event.type === 'session.status')
+    expect(
+      statusEventsBeforeProviderStop.some((event: any) => event.statusPayload?.type === 'idle')
+    ).toBe(false)
+
+    emitManagerEvent({
+      id: 'delta-after-stop',
+      kind: 'notification',
+      provider: 'codex',
+      threadId: 'thread-1',
+      turnId: 'turn-stop',
+      createdAt: new Date().toISOString(),
+      method: 'item/agentMessage/delta',
+      textDelta: 'after'
+    })
+
+    emitManagerEvent({
+      id: 'provider-idle',
+      kind: 'notification',
+      provider: 'codex',
+      threadId: 'thread-1',
+      createdAt: new Date().toISOString(),
+      method: 'thread/status/changed',
+      payload: { status: { type: 'idle' } }
+    })
+
+    await promptPromise
+
+    const assistant = session.messages.find((message: any) => message.role === 'assistant') as any
+    expect(assistant?.aborted).toBe(true)
+    expect(assistant?.parts?.[0]?.text).toBe('before after')
+    expect(session.status).toBe('ready')
+    expect(session.activeRun).toBeNull()
+  })
+
   it('ignores a stale thread/read snapshot after a newer prompt has completed', async () => {
     const session = seedSession()
     let sendCount = 0
@@ -1604,5 +1676,147 @@ describe('normalizeCodexMessageTimestamps', () => {
 
     expect(Date.parse(rows[0]!.created_at)).toBeLessThan(Date.parse(rows[1]!.created_at))
     expect(Date.parse(rows[1]!.created_at)).toBeLessThan(Date.parse(rows[2]!.created_at))
+  })
+})
+
+describe('CodexImplementer.parseThreadSnapshot()', () => {
+  it('uses Codex JSONL response-item timestamps to keep tools and text in turn order', () => {
+    const impl = new CodexImplementer()
+    const dir = mkdtempSync(join(tmpdir(), 'xuanpu-codex-jsonl-'))
+    const jsonlPath = join(dir, 'rollout.jsonl')
+    const entries = [
+      {
+        timestamp: '2026-05-23T10:00:00.000Z',
+        type: 'event_msg',
+        payload: { type: 'task_started', turn_id: 'turn-1' }
+      },
+      {
+        timestamp: '2026-05-23T10:00:00.010Z',
+        type: 'event_msg',
+        payload: { type: 'user_message' }
+      },
+      {
+        timestamp: '2026-05-23T10:00:01.000Z',
+        type: 'response_item',
+        payload: { type: 'message', role: 'assistant', content: [{ type: 'text', text: 'Intro' }] }
+      },
+      {
+        timestamp: '2026-05-23T10:00:02.000Z',
+        type: 'response_item',
+        payload: { type: 'function_call', name: 'shell_command', call_id: 'call-1' }
+      },
+      {
+        timestamp: '2026-05-23T10:00:03.000Z',
+        type: 'response_item',
+        payload: { type: 'reasoning', summary: [] }
+      },
+      {
+        timestamp: '2026-05-23T10:00:04.000Z',
+        type: 'response_item',
+        payload: { type: 'message', role: 'assistant', content: [{ type: 'text', text: 'Done' }] }
+      }
+    ]
+    writeFileSync(jsonlPath, entries.map((entry) => JSON.stringify(entry)).join('\n'))
+
+    const messages = (impl as any).parseThreadSnapshot(
+      {
+        thread: {
+          path: jsonlPath,
+          turns: [
+            {
+              id: 'turn-1',
+              startedAt: 1779530400,
+              items: [
+                {
+                  type: 'userMessage',
+                  content: [{ type: 'text', text: 'Run it' }]
+                },
+                { type: 'agentMessage', id: 'item-2', text: 'Intro' },
+                { type: 'commandExecution', id: 'call-1' },
+                { type: 'reasoning', summary: [], content: [] },
+                { type: 'agentMessage', id: 'item-5', text: 'Done' }
+              ]
+            }
+          ]
+        }
+      },
+      new Map()
+    )
+
+    expect(messages.map((message: any) => [message.id, message.timestamp])).toEqual([
+      ['turn-1:user', '2026-05-23T10:00:00.010Z'],
+      ['turn-1:assistant', '2026-05-23T10:00:01.000Z'],
+      ['turn-1:assistant:item-5', '2026-05-23T10:00:04.000Z']
+    ])
+  })
+
+  it('matches JSONL assistant timestamps by text when thread/read omits tool items', () => {
+    const impl = new CodexImplementer()
+    const dir = mkdtempSync(join(tmpdir(), 'xuanpu-codex-jsonl-summary-'))
+    const jsonlPath = join(dir, 'rollout.jsonl')
+    const entries = [
+      {
+        timestamp: '2026-05-23T10:00:00.000Z',
+        type: 'event_msg',
+        payload: { type: 'task_started', turn_id: 'turn-1' }
+      },
+      {
+        timestamp: '2026-05-23T10:00:00.010Z',
+        type: 'event_msg',
+        payload: { type: 'user_message', message: 'Run it' }
+      },
+      {
+        timestamp: '2026-05-23T10:00:01.000Z',
+        type: 'response_item',
+        payload: { type: 'message', role: 'assistant', content: [{ text: 'Intro' }] }
+      },
+      {
+        timestamp: '2026-05-23T10:00:02.000Z',
+        type: 'response_item',
+        payload: { type: 'function_call', name: 'shell_command', call_id: 'call-1' }
+      },
+      {
+        timestamp: '2026-05-23T10:00:03.000Z',
+        type: 'response_item',
+        payload: { type: 'function_call_output', call_id: 'call-1', output: 'ok' }
+      },
+      {
+        timestamp: '2026-05-23T10:00:04.000Z',
+        type: 'response_item',
+        payload: { type: 'message', role: 'assistant', content: [{ text: 'Done' }] }
+      }
+    ]
+    writeFileSync(jsonlPath, entries.map((entry) => JSON.stringify(entry)).join('\n'))
+
+    const messages = (impl as any).parseThreadSnapshot(
+      {
+        thread: {
+          path: jsonlPath,
+          turns: [
+            {
+              id: 'turn-1',
+              startedAt: 1779530400,
+              // App-server can return a summarized item view here. The JSONL
+              // still has tool response_items between the assistant texts.
+              items: [
+                {
+                  type: 'userMessage',
+                  content: [{ type: 'text', text: 'Run it' }]
+                },
+                { type: 'agentMessage', id: 'item-2', text: 'Intro' },
+                { type: 'agentMessage', id: 'item-3', text: 'Done' }
+              ]
+            }
+          ]
+        }
+      },
+      new Map()
+    )
+
+    expect(messages.map((message: any) => [message.id, message.timestamp])).toEqual([
+      ['turn-1:user', '2026-05-23T10:00:00.010Z'],
+      ['turn-1:assistant', '2026-05-23T10:00:01.000Z'],
+      ['turn-1:assistant:item-3', '2026-05-23T10:00:04.000Z']
+    ])
   })
 })

--- a/test/phase-22/session-6/codex-abort-getmessages.test.ts
+++ b/test/phase-22/session-6/codex-abort-getmessages.test.ts
@@ -159,7 +159,7 @@ describe('Codex Abort & getMessages', () => {
       await interruptPromise
     })
 
-    it('updates session status to ready and clears activeTurnId', async () => {
+    it('keeps session running until provider confirms interruption', async () => {
       const { context, child } = createTestContext({
         status: 'running',
         activeTurnId: 'turn-active-1'
@@ -182,11 +182,11 @@ describe('Codex Abort & getMessages', () => {
 
       await interruptPromise
 
-      expect(context.session.status).toBe('ready')
-      expect(context.session.activeTurnId).toBeNull()
+      expect(context.session.status).toBe('running')
+      expect(context.session.activeTurnId).toBe('turn-active-1')
     })
 
-    it('emits turn/interrupted event', async () => {
+    it('does not synthesize turn/interrupted on interrupt acknowledgement', async () => {
       const { context, child } = createTestContext()
       const sessionsMap = (manager as any).sessions as Map<string, CodexSessionContext>
       sessionsMap.set('thread-abort-1', context)
@@ -210,7 +210,7 @@ describe('Codex Abort & getMessages', () => {
       await interruptPromise
 
       const interruptEvent = events.find((e) => e.method === 'turn/interrupted')
-      expect(interruptEvent).toBeDefined()
+      expect(interruptEvent).toBeUndefined()
     })
 
     it('throws when threadId is unknown', async () => {
@@ -346,7 +346,7 @@ describe('Codex Abort & getMessages', () => {
       expect(result).toBe(false)
     })
 
-    it('still succeeds even if interruptTurn throws', async () => {
+    it('returns false if interruptTurn throws', async () => {
       const { CodexImplementer } = await import('../../../src/main/services/codex-implementer')
       const impl = new CodexImplementer()
       const internalManager = impl.getManager() as any
@@ -371,10 +371,10 @@ describe('Codex Abort & getMessages', () => {
       internalManager.interruptTurn = vi.fn().mockRejectedValue(new Error('Server not responding'))
 
       const result = await impl.abort('/test', 'thread-abort-1')
-      expect(result).toBe(true) // Still succeeds
+      expect(result).toBe(false)
     })
 
-    it('materializes live assistant draft before clearing an aborted run', async () => {
+    it('keeps the live draft and active run until provider confirms abort', async () => {
       const { CodexImplementer } = await import('../../../src/main/services/codex-implementer')
       const impl = new CodexImplementer()
       const internalManager = impl.getManager() as any
@@ -429,19 +429,15 @@ describe('Codex Abort & getMessages', () => {
 
       expect(result).toBe(true)
       expect(internalManager.interruptTurn).toHaveBeenCalledWith('thread-abort-1', 'turn-live-1')
-      expect(session.liveAssistantDraft).toBeNull()
-      expect(session.activeRun).toBeNull()
-
-      const assistant = session.messages[0] as any
-      expect(assistant.role).toBe('assistant')
-      expect(assistant.aborted).toBe(true)
-      expect(assistant.parts[0].text).toBe('Partial answer')
-      expect(assistant.parts[1].state.status).toBe('cancelled')
-      expect(assistant.parts[1].state.output).toBe('running...')
+      expect(session.liveAssistantDraft).not.toBeNull()
+      expect(session.activeRun?.state).toBe('aborting')
+      expect(session.activeRun?.interruptRequestedTurnId).toBe('turn-live-1')
+      expect(session.messages).toHaveLength(0)
 
       const messages = await impl.getMessages('/test', 'thread-abort-1')
       expect(messages).toHaveLength(1)
-      expect((messages[0] as any).aborted).toBe(true)
+      expect((messages[0] as any).aborted).toBeUndefined()
+      expect((messages[0] as any).parts[0].text).toBe('Partial answer')
     })
   })
 
@@ -515,6 +511,80 @@ describe('Codex Abort & getMessages', () => {
       expect((messages[0] as any).parts[0].text).toBe('User question')
       expect((messages[1] as any).role).toBe('assistant')
       expect((messages[1] as any).parts[0].text).toBe('Assistant answer')
+    })
+
+    it('does not treat persisted user-only Codex rows as a complete transcript', async () => {
+      const { CodexImplementer } = await import('../../../src/main/services/codex-implementer')
+      const impl = new CodexImplementer()
+      const internalManager = impl.getManager() as any
+
+      impl.getSessions().set('/test::thread-msg-1', {
+        threadId: 'thread-msg-1',
+        hiveSessionId: 'hive-msg-1',
+        worktreePath: '/test',
+        status: 'ready',
+        messages: [],
+        liveAssistantDraft: null,
+        revertMessageID: null,
+        revertDiff: null,
+        titleGenerated: false
+      })
+
+      const replaceSessionMessages = vi.fn()
+      impl.setDatabaseService({
+        getSessionMessages: vi.fn().mockReturnValue([
+          {
+            id: 'db-user-1',
+            session_id: 'hive-msg-1',
+            role: 'user',
+            content: 'Persisted question',
+            opencode_message_id: 'turn-1:user',
+            opencode_message_json: JSON.stringify({
+              id: 'turn-1:user',
+              role: 'user',
+              parts: [{ type: 'text', text: 'Persisted question' }],
+              timestamp: '2026-01-01T00:00:00.000Z'
+            }),
+            opencode_parts_json: null,
+            opencode_timeline_json: null,
+            created_at: '2026-01-01T00:00:00.000Z'
+          }
+        ]),
+        replaceSessionMessages
+      } as any)
+
+      internalManager.readThread = vi.fn().mockResolvedValue({
+        thread: {
+          id: 'thread-msg-1',
+          turns: [
+            {
+              id: 'turn-1',
+              items: [
+                {
+                  type: 'userMessage',
+                  id: 'user-1',
+                  content: [{ type: 'text', text: 'Persisted question' }]
+                },
+                {
+                  type: 'agentMessage',
+                  id: 'assistant-1',
+                  text: 'Recovered assistant answer'
+                }
+              ],
+              createdAt: '2026-01-01T00:00:00.000Z',
+              updatedAt: '2026-01-01T00:00:02.000Z'
+            }
+          ]
+        }
+      })
+
+      const messages = await impl.getMessages('/test', 'thread-msg-1')
+
+      expect(internalManager.readThread).toHaveBeenCalledWith('thread-msg-1')
+      expect(messages).toHaveLength(2)
+      expect((messages[1] as any).role).toBe('assistant')
+      expect((messages[1] as any).parts[0].text).toBe('Recovered assistant answer')
+      expect(replaceSessionMessages).toHaveBeenCalled()
     })
 
     it('warms in-memory cache from readThread result', async () => {

--- a/test/phase-22/session-6/codex-question-prompts.test.ts
+++ b/test/phase-22/session-6/codex-question-prompts.test.ts
@@ -617,7 +617,7 @@ describe('Codex Question Prompts', () => {
 
       const sendCalls = mockWindow.webContents.send.mock.calls
       const streamCalls = sendCalls
-        .filter((c: any[]) => c[0] === 'opencode:stream')
+        .filter((c: any[]) => c[0] === 'agent:stream')
         .map((c: any[]) => c[1])
 
       const questionEvent = streamCalls.find((e: any) => e.type === 'question.asked')

--- a/test/phase-22/session-7/codex-model-selection.test.ts
+++ b/test/phase-22/session-7/codex-model-selection.test.ts
@@ -21,6 +21,11 @@ vi.mock('node:child_process', async (importOriginal) => {
   }
 })
 
+vi.mock('../../../src/main/services/codex-config', () => ({
+  getCodexConfiguredModel: vi.fn(() => undefined),
+  getCodexConfiguredContextWindow: vi.fn(() => undefined)
+}))
+
 import {
   normalizeCodexModelSlug,
   resolveCodexModelSlug,
@@ -219,7 +224,7 @@ describe('Codex Model Selection', () => {
       expect(info).not.toBeNull()
       expect(info!.id).toBe('gpt-5.4')
       expect(info!.name).toBe('GPT-5.4')
-      expect(info!.limit.context).toBe(200000)
+      expect(info!.limit.context).toBe(258400)
     })
 
     it('getModelInfo resolves aliases', async () => {

--- a/test/phase-22/session-8/codex-fast-toggle.test.tsx
+++ b/test/phase-22/session-8/codex-fast-toggle.test.tsx
@@ -128,7 +128,7 @@ describe('CodexFastToggle', () => {
       'utf8'
     )
 
-    const modelIndex = source.indexOf('<ModelSelector sessionId={sessionId} />')
+    const modelIndex = source.indexOf('<ModelSelector sessionId={sessionId}')
     const fastIndex = source.indexOf('<CodexFastToggle')
     const attachmentIndex = source.indexOf('<AttachmentButton onAttach={handleAttach} />')
 

--- a/test/phase-22/session-8/codex-timeline.test.ts
+++ b/test/phase-22/session-8/codex-timeline.test.ts
@@ -68,9 +68,9 @@ describe('codex timeline derivation', () => {
 
     expect(timeline).toHaveLength(3)
     expect(timeline[0]?.id).toBe('turn-1:user')
-    expect(timeline[1]?.id).toBe('turn-1:assistant')
-    expect(timeline[2]?.id).toBe('tool:tool-1')
-    expect(timeline[2]?.parts?.some((part) => part.type === 'tool_use')).toBe(true)
+    expect(timeline[1]?.id).toBe('turn-1:tool:tool-1')
+    expect(timeline[2]?.id).toBe('turn-1:assistant')
+    expect(timeline[1]?.parts?.some((part) => part.type === 'tool_use')).toBe(true)
   })
 
   it('projects persisted plan.ready activity into an ExitPlanMode tool card', () => {
@@ -228,7 +228,7 @@ describe('codex timeline derivation', () => {
     ).toBe(true)
   })
 
-  it('keeps unanchored activities as standalone assistant rows when multiple turns exist', () => {
+  it('infers the turn for unanchored tool activities from activity time', () => {
     const messages: SessionMessage[] = [
       {
         id: 'db-user-1',
@@ -301,14 +301,14 @@ describe('codex timeline derivation', () => {
     ]
 
     const timeline = deriveCodexTimelineMessages(messages, activities)
-    const synthetic = timeline.find((message) => message.id === 'tool:tool-unanchored')
+    const synthetic = timeline.find((message) => message.id === 'turn-2:tool:tool-unanchored')
 
     expect(timeline.map((message) => message.id)).toEqual([
       'turn-1:user',
       'turn-1:assistant',
       'turn-2:user',
-      'turn-2:assistant',
-      'tool:tool-unanchored'
+      'turn-2:tool:tool-unanchored',
+      'turn-2:assistant'
     ])
     expect(
       synthetic?.parts?.some(

--- a/test/phase-22/session-9/codex-regression-smoke.test.ts
+++ b/test/phase-22/session-9/codex-regression-smoke.test.ts
@@ -18,7 +18,7 @@ vi.mock('../../../src/main/services/logger', () => ({
   })
 }))
 
-import { AgentSdkManager } from '../../../src/main/services/agent-sdk-manager'
+import { AgentRuntimeManager as AgentSdkManager } from '../../../src/main/services/agent-runtime-manager'
 import {
   withSdkDispatch,
   withSdkDispatchByHiveSession,
@@ -286,9 +286,17 @@ describe('Regression: capability lookup for all providers', () => {
     })
   }
 
-  it('OpenCode has all capabilities enabled', () => {
+  it('OpenCode exposes its expected capabilities', () => {
     const caps = sdkManager.getCapabilities('opencode')
-    expect(Object.values(caps).every((v) => v === true)).toBe(true)
+    expect(caps.supportsUndo).toBe(true)
+    expect(caps.supportsRedo).toBe(true)
+    expect(caps.supportsCommands).toBe(true)
+    expect(caps.supportsPermissionRequests).toBe(true)
+    expect(caps.supportsQuestionPrompts).toBe(true)
+    expect(caps.supportsModelSelection).toBe(true)
+    expect(caps.supportsReconnect).toBe(true)
+    expect(caps.supportsPartialStreaming).toBe(true)
+    expect(caps.supportsSteer).toBe(false)
   })
 
   it('Codex lacks redo and commands', () => {
@@ -379,7 +387,7 @@ describe('Regression: graceful error on unknown SDK', () => {
     const manager = new AgentSdkManager(impls)
 
     expect(() => manager.getImplementer('nonexistent' as AgentSdkId)).toThrow(
-      'Unknown agent SDK: "nonexistent"'
+      'Unknown agent runtime: "nonexistent"'
     )
   })
 

--- a/test/phase-22/session-9/graphql-codex-routing.test.ts
+++ b/test/phase-22/session-9/graphql-codex-routing.test.ts
@@ -17,7 +17,7 @@ vi.mock('../../../src/main/services/logger', () => ({
   })
 }))
 
-import { AgentSdkManager } from '../../../src/main/services/agent-sdk-manager'
+import { AgentRuntimeManager as AgentSdkManager } from '../../../src/main/services/agent-runtime-manager'
 import { mapGraphQLSdkToInternal } from '../../../src/server/resolvers/helpers/sdk-dispatch'
 
 /**

--- a/test/phase-23/agent-timeline-user-actions.test.tsx
+++ b/test/phase-23/agent-timeline-user-actions.test.tsx
@@ -105,8 +105,64 @@ describe('AgentTimeline user message actions', () => {
     )
 
     const rail = screen.getByTestId('timeline-round-anchor-rail')
-    expect(rail.className).toContain('top-1/2')
-    expect(rail.className).toContain('-translate-y-1/2')
+    expect(rail.className).toContain('top-0')
+    expect(rail.className).toContain('-mt-6')
+    expect(rail.className).not.toContain('-translate-y-1/2')
+
+    const railItems = screen.getByTestId('timeline-round-anchor-rail-items')
+    expect(railItems.className).toContain('overflow-visible')
+    expect(railItems.className).not.toContain('overflow-y-auto')
+    expect(railItems).toHaveStyle({ height: '336px' })
+  })
+
+  it('keeps every prompt anchor in the fixed fisheye rail for long sessions', () => {
+    render(
+      <AgentTimeline
+        timelineMessages={Array.from({ length: 18 }, (_, index) =>
+          makeUserMessage(`u-anchor-many-${index + 1}`, `Prompt ${index + 1}`)
+        )}
+        streamingContent=""
+        streamingParts={[]}
+        isStreaming={false}
+        lifecycle="idle"
+      />
+    )
+
+    const railButtons = screen.getAllByTestId('timeline-round-anchor-button')
+    expect(railButtons).toHaveLength(18)
+    expect(railButtons[0]).toHaveStyle({ top: '0%' })
+    expect(railButtons[railButtons.length - 1]).toHaveStyle({ top: '100%' })
+    expect(railButtons[0].getAttribute('aria-label')).toContain('第 1 轮')
+    expect(railButtons[railButtons.length - 1].getAttribute('aria-label')).toContain('第 18 轮')
+  })
+
+  it('magnifies anchors near the pointer without using a rail scrollbar', () => {
+    render(
+      <AgentTimeline
+        timelineMessages={Array.from({ length: 50 }, (_, index) =>
+          makeUserMessage(`u-fisheye-${index + 1}`, `Prompt ${index + 1}`)
+        )}
+        streamingContent=""
+        streamingParts={[]}
+        isStreaming={false}
+        lifecycle="idle"
+      />
+    )
+
+    const railItems = screen.getByTestId('timeline-round-anchor-rail-items')
+    Object.defineProperty(railItems, 'getBoundingClientRect', {
+      value: () => ({ top: 0, left: 0, width: 32, height: 420, right: 32, bottom: 420 }),
+      configurable: true
+    })
+
+    fireEvent.mouseMove(railItems, { clientY: 210 })
+
+    const railButtons = screen.getAllByTestId('timeline-round-anchor-button')
+    expect(railButtons).toHaveLength(50)
+    expect(railItems.className).not.toContain('overflow-y-auto')
+    expect(Number.parseFloat(railButtons[25].style.height)).toBeGreaterThan(
+      Number.parseFloat(railButtons[0].style.height)
+    )
   })
 
   it('shows edit button only when the message is editable', () => {

--- a/test/phase-23/agent-timeline-user-actions.test.tsx
+++ b/test/phase-23/agent-timeline-user-actions.test.tsx
@@ -57,6 +57,22 @@ describe('AgentTimeline user message actions', () => {
     expect(screen.getByTestId('fork-message-button')).toBeInTheDocument()
   })
 
+  it('uses the distinct user bubble tint instead of the neutral tool-card style', () => {
+    render(
+      <AgentTimeline
+        timelineMessages={[makeUserMessage('u-style', 'Keep this as a user bubble')]}
+        streamingContent=""
+        streamingParts={[]}
+        isStreaming={false}
+        lifecycle="idle"
+      />
+    )
+
+    const bubble = screen.getByTestId('timeline-user-bubble-u-style')
+    expect(bubble.className).toContain('bg-primary/10')
+    expect(bubble.className).not.toContain('bg-agent-card')
+  })
+
   it('shows edit button only when the message is editable', () => {
     render(
       <AgentTimeline

--- a/test/phase-23/agent-timeline-user-actions.test.tsx
+++ b/test/phase-23/agent-timeline-user-actions.test.tsx
@@ -73,6 +73,42 @@ describe('AgentTimeline user message actions', () => {
     expect(bubble.className).not.toContain('bg-agent-card')
   })
 
+  it('renders a clear-screen spacer when the active turn reserves top-scroll room', () => {
+    render(
+      <AgentTimeline
+        timelineMessages={[makeUserMessage('u-spacer', 'Start a fresh turn')]}
+        streamingContent=""
+        streamingParts={[]}
+        isStreaming={false}
+        lifecycle="idle"
+        clearScreenBottomInset={320}
+      />
+    )
+
+    expect(screen.getByTestId('timeline-clear-screen-spacer')).toHaveStyle({
+      height: '320px'
+    })
+  })
+
+  it('keeps the prompt anchor rail vertically centered', () => {
+    render(
+      <AgentTimeline
+        timelineMessages={[
+          makeUserMessage('u-anchor-1', 'First prompt'),
+          makeUserMessage('u-anchor-2', 'Second prompt')
+        ]}
+        streamingContent=""
+        streamingParts={[]}
+        isStreaming={false}
+        lifecycle="idle"
+      />
+    )
+
+    const rail = screen.getByTestId('timeline-round-anchor-rail')
+    expect(rail.className).toContain('top-1/2')
+    expect(rail.className).toContain('-translate-y-1/2')
+  })
+
   it('shows edit button only when the message is editable', () => {
     render(
       <AgentTimeline

--- a/test/phase-23/session-shell-composer-layout.test.ts
+++ b/test/phase-23/session-shell-composer-layout.test.ts
@@ -14,8 +14,22 @@ describe('SessionShell composer layout source guard', () => {
     )
 
     expect(shellSource).toContain('data-testid="session-composer-dock"')
+    expect(shellSource).toContain('grid-rows-[minmax(0,1fr)_auto_auto]')
+    expect(shellSource).toContain('flex h-full min-h-0 flex-col overflow-hidden')
     expect(shellSource).not.toContain('data-testid="session-composer-boundary"')
     expect(composerSource).toContain("'relative z-20'")
     expect(composerSource).not.toContain("'absolute bottom-6 z-20'")
+  })
+
+  test('constrains the timeline to a single scroll row above the composer', async () => {
+    const fs = await import('fs')
+    const path = await import('path')
+    const timelineSource = fs.readFileSync(
+      path.resolve(__dirname, '../../src/renderer/src/components/session-hq/AgentTimeline.tsx'),
+      'utf-8'
+    )
+
+    expect(timelineSource).toContain('data-testid="hq-agent-timeline-scroll"')
+    expect(timelineSource).toContain('className="min-h-0 overflow-y-auto"')
   })
 })

--- a/test/phase-23/session-shell-composer-layout.test.ts
+++ b/test/phase-23/session-shell-composer-layout.test.ts
@@ -12,13 +12,31 @@ describe('SessionShell composer layout source guard', () => {
       path.resolve(__dirname, '../../src/renderer/src/components/session-hq/ComposerBar.tsx'),
       'utf-8'
     )
+    const scrollFabSource = fs.readFileSync(
+      path.resolve(__dirname, '../../src/renderer/src/components/sessions/ScrollToBottomFab.tsx'),
+      'utf-8'
+    )
+    const planFabSource = fs.readFileSync(
+      path.resolve(
+        __dirname,
+        '../../src/renderer/src/components/sessions/PlanReadyImplementFab.tsx'
+      ),
+      'utf-8'
+    )
 
     expect(shellSource).toContain('data-testid="session-composer-dock"')
-    expect(shellSource).toContain('grid-rows-[minmax(0,1fr)_auto_auto]')
+    expect(shellSource).toContain('data-testid="session-transcript-region"')
+    expect(shellSource).toContain('data-testid="session-bottom-stack"')
+    expect(shellSource).toContain('grid-rows-[minmax(0,1fr)_auto]')
     expect(shellSource).toContain('flex h-full min-h-0 flex-col overflow-hidden')
+    expect(shellSource).toContain('row-start-1 row-end-2 min-h-0 overflow-hidden')
+    expect(shellSource).toContain('row-start-2 row-end-3 min-h-0 overflow-visible')
     expect(shellSource).not.toContain('data-testid="session-composer-boundary"')
+    expect(shellSource).not.toContain('absolute bottom-0 left-0 right-0 z-30')
     expect(composerSource).toContain("'relative z-20'")
     expect(composerSource).not.toContain("'absolute bottom-6 z-20'")
+    expect(scrollFabSource).toContain('absolute right-4 z-10')
+    expect(planFabSource).toContain('absolute bottom-36 right-4 z-30')
   })
 
   test('constrains the timeline to a single scroll row above the composer', async () => {
@@ -30,6 +48,7 @@ describe('SessionShell composer layout source guard', () => {
     )
 
     expect(timelineSource).toContain('data-testid="hq-agent-timeline-scroll"')
-    expect(timelineSource).toContain('className="min-h-0 overflow-y-auto"')
+    expect(timelineSource).toContain('className="h-full min-h-0 overflow-y-auto"')
   })
+
 })

--- a/test/phase-23/session-shell-composer-layout.test.ts
+++ b/test/phase-23/session-shell-composer-layout.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from 'vitest'
+
+describe('SessionShell composer layout source guard', () => {
+  test('docks the composer in normal layout instead of overlapping the timeline', async () => {
+    const fs = await import('fs')
+    const path = await import('path')
+    const shellSource = fs.readFileSync(
+      path.resolve(__dirname, '../../src/renderer/src/components/session-hq/SessionShell.tsx'),
+      'utf-8'
+    )
+    const composerSource = fs.readFileSync(
+      path.resolve(__dirname, '../../src/renderer/src/components/session-hq/ComposerBar.tsx'),
+      'utf-8'
+    )
+
+    expect(shellSource).toContain('data-testid="session-composer-dock"')
+    expect(shellSource).not.toContain('data-testid="session-composer-boundary"')
+    expect(composerSource).toContain("'relative z-20'")
+    expect(composerSource).not.toContain("'absolute bottom-6 z-20'")
+  })
+})

--- a/test/phase-23/session-timeline-service.test.ts
+++ b/test/phase-23/session-timeline-service.test.ts
@@ -346,7 +346,10 @@ describe('getSessionTimeline', () => {
       const planPart = result.messages[0].parts?.find(
         (p) => p.type === 'tool_use' && p.toolUse?.name === 'ExitPlanMode'
       )
-      expect(planPart?.toolUse?.status).toBe('success')
+      // Bug 3 fix: plan.resolved payload with resolution='rejected' must
+      // surface a 'rejected' verdict on reload so PlanCard renders the
+      // rejected state (greyed out) instead of mis-rendering as approved.
+      expect(planPart?.toolUse?.status).toBe('rejected')
     })
 
     it('strips text part whose content matches the plan to avoid double-rendering', () => {

--- a/test/phase-23/use-session-smart-scroll.test.tsx
+++ b/test/phase-23/use-session-smart-scroll.test.tsx
@@ -58,6 +58,7 @@ interface HarnessProps {
   contentVersion: number
   ready: boolean
   isStreaming?: boolean
+  clearScreenActive?: boolean
 }
 
 function SmartScrollHarness({
@@ -65,7 +66,8 @@ function SmartScrollHarness({
   mirrorVersion,
   contentVersion,
   ready,
-  isStreaming = true
+  isStreaming = true,
+  clearScreenActive = false
 }: HarnessProps): React.JSX.Element {
   const bottomAreaRef = useRef<HTMLDivElement>(null)
   const composerRef = useRef<HTMLDivElement>(null)
@@ -76,7 +78,8 @@ function SmartScrollHarness({
     mirrorVersion,
     isStreaming,
     bottomAreaRef,
-    composerRef
+    composerRef,
+    clearScreenActive
   })
 
   return (
@@ -97,20 +100,28 @@ function SmartScrollHarness({
       <button onClick={smartScroll.handleScrollToBottomClick} data-testid="smart-scroll-fab-button">
         Jump
       </button>
-      <div data-testid="smart-scroll-fab-visible">
-        {smartScroll.showScrollFab ? 'yes' : 'no'}
-      </div>
+      <button
+        onClick={() => smartScroll.scrollToOffset(320, 'instant')}
+        data-testid="smart-scroll-offset-button"
+      >
+        Offset
+      </button>
+      <div data-testid="smart-scroll-fab-visible">{smartScroll.showScrollFab ? 'yes' : 'no'}</div>
       <div data-testid="smart-scroll-fab-count">{smartScroll.scrollFabCount}</div>
       <div data-testid="smart-scroll-fab-offset">{smartScroll.scrollFabBottomOffset}</div>
+      <div data-testid="smart-scroll-clear-inset">{smartScroll.clearScreenBottomInset}</div>
     </div>
   )
 }
 
-function attachScrollMetrics(element: HTMLElement, values: {
-  scrollTop: { current: number }
-  scrollHeight: { current: number }
-  clientHeight: number
-}) {
+function attachScrollMetrics(
+  element: HTMLElement,
+  values: {
+    scrollTop: { current: number }
+    scrollHeight: { current: number }
+    clientHeight: number
+  }
+) {
   Object.defineProperty(element, 'scrollTop', {
     configurable: true,
     get: () => values.scrollTop.current,
@@ -193,12 +204,7 @@ describe('useSessionSmartScroll', () => {
     attachScrollMetrics(scroller, { scrollTop, scrollHeight, clientHeight: 400 })
 
     rerender(
-      <SmartScrollHarness
-        sessionId="session-a"
-        mirrorVersion={2}
-        contentVersion={1}
-        ready={true}
-      />
+      <SmartScrollHarness sessionId="session-a" mirrorVersion={2} contentVersion={1} ready={true} />
     )
 
     expect(scrollTop.current).toBe(240)
@@ -232,15 +238,10 @@ describe('useSessionSmartScroll', () => {
     attachScrollMetrics(scroller, { scrollTop, scrollHeight, clientHeight: 400 })
 
     rerender(
-      <SmartScrollHarness
-        sessionId="session-a"
-        mirrorVersion={4}
-        contentVersion={1}
-        ready={true}
-      />
+      <SmartScrollHarness sessionId="session-a" mirrorVersion={4} contentVersion={1} ready={true} />
     )
 
-    expect(scrollTop.current).toBe(1200)
+    expect(scrollTop.current).toBe(800)
     expect(getSessionViewState('session-a')).toMatchObject({
       stickyBottom: true,
       manualScrollLocked: false,
@@ -265,12 +266,7 @@ describe('useSessionSmartScroll', () => {
     attachScrollMetrics(scroller, { scrollTop, scrollHeight, clientHeight: 400 })
 
     rerender(
-      <SmartScrollHarness
-        sessionId="session-a"
-        mirrorVersion={1}
-        contentVersion={1}
-        ready={true}
-      />
+      <SmartScrollHarness sessionId="session-a" mirrorVersion={1} contentVersion={1} ready={true} />
     )
 
     scrollTop.current = 200
@@ -278,12 +274,7 @@ describe('useSessionSmartScroll', () => {
     fireEvent.scroll(scroller)
 
     rerender(
-      <SmartScrollHarness
-        sessionId="session-a"
-        mirrorVersion={4}
-        contentVersion={2}
-        ready={true}
-      />
+      <SmartScrollHarness sessionId="session-a" mirrorVersion={4} contentVersion={2} ready={true} />
     )
 
     expect(screen.getByTestId('smart-scroll-fab-visible')).toHaveTextContent('yes')
@@ -296,7 +287,7 @@ describe('useSessionSmartScroll', () => {
 
     fireEvent.click(screen.getByTestId('smart-scroll-fab-button'))
 
-    expect(scrollTop.current).toBe(1200)
+    expect(scrollTop.current).toBe(800)
     expect(screen.getByTestId('smart-scroll-fab-visible')).toHaveTextContent('no')
     expect(getSessionViewState('session-a')).toMatchObject({
       stickyBottom: true,
@@ -325,11 +316,52 @@ describe('useSessionSmartScroll', () => {
     attachHeight(composer, 80)
 
     rerender(
+      <SmartScrollHarness sessionId="session-a" mirrorVersion={2} contentVersion={1} ready={true} />
+    )
+
+    scrollHeight.current = 1440
+    act(() => {
+      getObserverFor(composer).trigger(120)
+    })
+
+    expect(scrollTop.current).toBe(1040)
+    expect(
+      Number(screen.getByTestId('smart-scroll-fab-offset').textContent)
+    ).toBeGreaterThanOrEqual(152)
+  })
+
+  it('does not auto-scroll bottom-area resize while clear-screen top lock is active', () => {
+    setSessionViewState('session-a', {
+      scrollTop: 320,
+      stickyBottom: false,
+      manualScrollLocked: false,
+      lastSeenVersion: 2
+    })
+
+    const { rerender } = render(
+      <SmartScrollHarness
+        sessionId="session-a"
+        mirrorVersion={2}
+        contentVersion={1}
+        ready={false}
+        clearScreenActive
+      />
+    )
+
+    const scroller = screen.getByTestId('smart-scroll-scroller')
+    const composer = screen.getByTestId('smart-scroll-composer')
+    const scrollTop = { current: 320 }
+    const scrollHeight = { current: 1200 }
+    attachScrollMetrics(scroller, { scrollTop, scrollHeight, clientHeight: 400 })
+    attachHeight(composer, 80)
+
+    rerender(
       <SmartScrollHarness
         sessionId="session-a"
         mirrorVersion={2}
         contentVersion={1}
         ready={true}
+        clearScreenActive
       />
     )
 
@@ -338,18 +370,89 @@ describe('useSessionSmartScroll', () => {
       getObserverFor(composer).trigger(120)
     })
 
-    expect(scrollTop.current).toBe(1440)
-    expect(Number(screen.getByTestId('smart-scroll-fab-offset').textContent)).toBeGreaterThanOrEqual(152)
+    expect(scrollTop.current).toBe(320)
+  })
+
+  it('scrolls to a programmatic turn-top offset without re-enabling sticky bottom', () => {
+    const { rerender } = render(
+      <SmartScrollHarness
+        sessionId="session-a"
+        mirrorVersion={5}
+        contentVersion={1}
+        ready={false}
+        clearScreenActive
+      />
+    )
+
+    const scroller = screen.getByTestId('smart-scroll-scroller')
+    const scrollTop = { current: 0 }
+    const scrollHeight = { current: 1600 }
+    attachScrollMetrics(scroller, { scrollTop, scrollHeight, clientHeight: 500 })
+
+    rerender(
+      <SmartScrollHarness
+        sessionId="session-a"
+        mirrorVersion={5}
+        contentVersion={1}
+        ready={true}
+        clearScreenActive
+      />
+    )
+
+    fireEvent.click(screen.getByTestId('smart-scroll-offset-button'))
+
+    expect(scrollTop.current).toBe(320)
+    expect(getSessionViewState('session-a')).toMatchObject({
+      scrollTop: 320,
+      stickyBottom: false,
+      manualScrollLocked: false,
+      lastSeenVersion: 5
+    })
+  })
+
+  it('ignores the clear-screen spacer when jumping to the real content bottom', () => {
+    const { rerender } = render(
+      <SmartScrollHarness
+        sessionId="session-a"
+        mirrorVersion={5}
+        contentVersion={1}
+        ready={false}
+        clearScreenActive
+      />
+    )
+
+    const scroller = screen.getByTestId('smart-scroll-scroller')
+    const scrollTop = { current: 0 }
+    const scrollHeight = { current: 1600 }
+    attachScrollMetrics(scroller, { scrollTop, scrollHeight, clientHeight: 500 })
+
+    rerender(
+      <SmartScrollHarness
+        sessionId="session-a"
+        mirrorVersion={5}
+        contentVersion={1}
+        ready={true}
+        clearScreenActive
+      />
+    )
+
+    const clearInset = Number(screen.getByTestId('smart-scroll-clear-inset').textContent)
+    fireEvent.click(screen.getByTestId('smart-scroll-fab-button'))
+
+    expect(clearInset).toBeGreaterThan(0)
+    expect(scrollTop.current).toBe(1600 - 500 - clearInset)
+    expect(getSessionViewState('session-a')).toMatchObject({
+      stickyBottom: true,
+      manualScrollLocked: false,
+      lastSeenVersion: 5
+    })
   })
 
   it('keeps the v1 smart-scroll guard structure in the shared hook source', async () => {
     const fs = await import('fs')
     const path = await import('path')
     const source = fs.readFileSync(
-      path.resolve(
-        __dirname,
-        '../../src/renderer/src/hooks/useSessionSmartScroll.ts'
-      ),
+      path.resolve(__dirname, '../../src/renderer/src/hooks/useSessionSmartScroll.ts'),
       'utf-8'
     )
 
@@ -358,5 +461,6 @@ describe('useSessionSmartScroll', () => {
     expect(source).toContain('pointerDownInScrollerRef')
     expect(source).toContain("scrollToBottom('instant')")
     expect(source).toContain('BOTTOM_AREA_COMPENSATE_THRESHOLD')
+    expect(source).toContain('clearScreenBottomInset')
   })
 })

--- a/test/session-2/layout.test.tsx
+++ b/test/session-2/layout.test.tsx
@@ -9,10 +9,12 @@ describe('Session 2: Application Layout', () => {
     // Reset stores before each test
     useLayoutStore.setState({
       leftSidebarWidth: LAYOUT_CONSTRAINTS.leftSidebar.default,
+      leftSidebarCollapsed: false,
       rightSidebarWidth: LAYOUT_CONSTRAINTS.rightSidebar.default,
       rightSidebarCollapsed: false,
+      rightContextTab: 'overview'
     })
-    useThemeStore.setState({ theme: 'dark' })
+    useThemeStore.setState({ themeId: 'mocha', followSystem: false, isLoading: false })
     localStorage.clear()
   })
 
@@ -74,11 +76,33 @@ describe('Session 2: Application Layout', () => {
     })
   })
 
-  test('Right sidebar shows file tree component', () => {
+  test('Left sidebar collapses and expands from the header toggle', async () => {
     render(<AppLayout />)
 
-    // File tree component should be rendered (with "Files" header and "Select a worktree" message)
-    expect(screen.getByText('Files')).toBeInTheDocument()
+    expect(screen.getByTestId('left-sidebar')).toBeInTheDocument()
+
+    const toggleButton = screen.getByTestId('left-sidebar-toggle')
+    fireEvent.click(toggleButton)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('left-sidebar-collapsed')).toBeInTheDocument()
+      expect(screen.queryByTestId('left-sidebar')).not.toBeInTheDocument()
+    })
+
+    fireEvent.click(toggleButton)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('left-sidebar')).toBeInTheDocument()
+      expect(screen.queryByTestId('left-sidebar-collapsed')).not.toBeInTheDocument()
+    })
+  })
+
+  test('Right sidebar shows file tree component', () => {
+    useLayoutStore.getState().setRightContextTab('files')
+    render(<AppLayout />)
+
+    // File tree panel should be rendered (with no selected worktree message)
+    expect(screen.getByTestId('context-panel-tab-files')).toHaveAttribute('data-active', 'true')
     expect(screen.getByText('Select a worktree')).toBeInTheDocument()
   })
 
@@ -94,34 +118,21 @@ describe('Session 2: Application Layout', () => {
     expect(parsed.state.leftSidebarWidth).toBe(300)
   })
 
-  test('Theme toggle switches modes', async () => {
-    render(<AppLayout />)
-
-    // Theme toggle button exists in header
-    const themeToggle = screen.getByTestId('theme-toggle')
-    expect(themeToggle).toBeInTheDocument()
-
-    // Initially dark
-    expect(useThemeStore.getState().theme).toBe('dark')
-
-    // Theme toggle is a dropdown menu trigger (has aria-haspopup)
-    expect(themeToggle).toHaveAttribute('aria-haspopup', 'menu')
-
-    // Test theme changes via store (dropdown UI testing is in session-6)
+  test('Theme store switches theme presets', async () => {
     const { setTheme } = useThemeStore.getState()
 
     // Switch to light
-    setTheme('light')
-    expect(useThemeStore.getState().theme).toBe('light')
+    setTheme('latte')
+    expect(useThemeStore.getState().themeId).toBe('latte')
     expect(document.documentElement.classList.contains('light')).toBe(true)
 
     // Switch to system
-    setTheme('system')
-    expect(useThemeStore.getState().theme).toBe('system')
+    useThemeStore.getState().setFollowSystem(true)
+    expect(useThemeStore.getState().followSystem).toBe(true)
 
     // Switch back to dark
-    setTheme('dark')
-    expect(useThemeStore.getState().theme).toBe('dark')
+    setTheme('mocha')
+    expect(useThemeStore.getState().themeId).toBe('mocha')
     expect(document.documentElement.classList.contains('dark')).toBe(true)
   })
 
@@ -155,11 +166,10 @@ describe('Session 2: Application Layout', () => {
     expect(layoutContent).toHaveClass('flex')
   })
 
-  test('Right sidebar can be closed via X button', async () => {
+  test('Right sidebar can be closed via header toggle button', async () => {
     render(<AppLayout />)
 
-    // Find the X button inside the right sidebar header
-    const closeButton = screen.getByTitle('Close sidebar')
+    const closeButton = screen.getByTestId('right-sidebar-toggle')
     fireEvent.click(closeButton)
 
     await waitFor(() => {
@@ -169,12 +179,12 @@ describe('Session 2: Application Layout', () => {
 
   test('Theme persists to localStorage', () => {
     const { setTheme } = useThemeStore.getState()
-    setTheme('light')
+    setTheme('latte')
 
     const stored = localStorage.getItem('hive-theme')
     expect(stored).not.toBeNull()
 
     const parsed = JSON.parse(stored!)
-    expect(parsed.state.theme).toBe('light')
+    expect(parsed.state.themeId).toBe('latte')
   })
 })

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -36,38 +36,36 @@ if (typeof window !== 'undefined') {
     })
   }
 
-  if (!HTMLCanvasElement.prototype.getContext) {
-    Object.defineProperty(HTMLCanvasElement.prototype, 'getContext', {
-      writable: true,
-      configurable: true,
-      value: vi.fn(() => ({
-        fillRect: vi.fn(),
-        clearRect: vi.fn(),
-        getImageData: vi.fn(),
-        putImageData: vi.fn(),
-        createImageData: vi.fn(),
-        setTransform: vi.fn(),
-        drawImage: vi.fn(),
-        save: vi.fn(),
-        fillText: vi.fn(),
-        restore: vi.fn(),
-        beginPath: vi.fn(),
-        moveTo: vi.fn(),
-        lineTo: vi.fn(),
-        closePath: vi.fn(),
-        stroke: vi.fn(),
-        translate: vi.fn(),
-        scale: vi.fn(),
-        rotate: vi.fn(),
-        arc: vi.fn(),
-        fill: vi.fn(),
-        measureText: vi.fn(() => ({ width: 0 })),
-        transform: vi.fn(),
-        rect: vi.fn(),
-        clip: vi.fn()
-      }))
-    })
-  }
+  Object.defineProperty(HTMLCanvasElement.prototype, 'getContext', {
+    writable: true,
+    configurable: true,
+    value: vi.fn(() => ({
+      fillRect: vi.fn(),
+      clearRect: vi.fn(),
+      getImageData: vi.fn(),
+      putImageData: vi.fn(),
+      createImageData: vi.fn(),
+      setTransform: vi.fn(),
+      drawImage: vi.fn(),
+      save: vi.fn(),
+      fillText: vi.fn(),
+      restore: vi.fn(),
+      beginPath: vi.fn(),
+      moveTo: vi.fn(),
+      lineTo: vi.fn(),
+      closePath: vi.fn(),
+      stroke: vi.fn(),
+      translate: vi.fn(),
+      scale: vi.fn(),
+      rotate: vi.fn(),
+      arc: vi.fn(),
+      fill: vi.fn(),
+      measureText: vi.fn(() => ({ width: 0 })),
+      transform: vi.fn(),
+      rect: vi.fn(),
+      clip: vi.fn()
+    }))
+  })
 
   if (typeof window.localStorage?.getItem !== 'function') {
     const storage = new Map<string, string>()
@@ -193,6 +191,17 @@ if (typeof window !== 'undefined') {
         track: vi.fn().mockResolvedValue(undefined),
         setEnabled: vi.fn().mockResolvedValue(undefined),
         isEnabled: vi.fn().mockResolvedValue(true)
+      }
+    })
+  }
+
+  if (!window.usageOps) {
+    Object.defineProperty(window, 'usageOps', {
+      writable: true,
+      configurable: true,
+      value: {
+        fetch: vi.fn().mockResolvedValue({ success: true, data: null }),
+        fetchOpenai: vi.fn().mockResolvedValue({ success: true, data: null })
       }
     })
   }

--- a/test/xfp/field-context-envelope.test.ts
+++ b/test/xfp/field-context-envelope.test.ts
@@ -26,6 +26,17 @@ Observed context
     expect(stripFieldContextEnvelope(input)).toBe('继续')
   })
 
+  it('extracts the real user message from an XFP fallback envelope', () => {
+    const input = `[Xuanpu Field Fallback]
+## Current Focus
+- File: src/main.ts
+
+[User Message]
+这里为什么挂？`
+
+    expect(stripFieldContextEnvelope(input)).toBe('这里为什么挂？')
+  })
+
   it('returns non-envelope input unchanged', () => {
     const input = '普通消息\n[User Message]\n也只是用户自己输入的文本'
 


### PR DESCRIPTION
## Summary
- Polish Session HQ layout, sidebar collapse, composer spacing, prompt anchors, and task tracker behavior
- Improve Codex runtime recovery, timeline ordering, context-window config handling, and usage/cost reporting
- Rework Codex durable timeline merging so assistant text and tool cards are restored in chronological order from JSONL/thread data
- Add regression coverage for task extraction, Codex config, lifecycle, timeline recovery, and UI behavior

## Verification
- pnpm vitest run test/phase-22/session-5/codex-prompt-streaming.test.ts test/phase-22/session-4/session-timeline-handler-codex.test.ts
- pnpm vitest run test/phase-22/session-5/codex-durable-read.test.ts test/phase-22/session-8/codex-timeline.test.ts test/phase-22/session-6/codex-abort-getmessages.test.ts
- pnpm exec tsc --noEmit --pretty false
- pnpm lint
- git diff --check
- pnpm build